### PR TITLE
Results for console tab-completion are now color-coded. 

### DIFF
--- a/src/c_console.cpp
+++ b/src/c_console.cpp
@@ -2121,7 +2121,20 @@ static bool C_TabCompleteList ()
 		Printf (TEXTCOLOR_BLUE "Completions for %s:\n", CmdLine+2);
 		for (i = TabPos; nummatches > 0; ++i, --nummatches)
 		{
-			Printf ("%-*s", int(maxwidth), TabCommands[i].TabName.GetChars());
+			// [Dusk] Print console commands blue, CVars green, aliases red.
+			const char* colorcode = "";
+			FConsoleCommand* ccmd;
+			if (FindCVar (TabCommands[i].TabName, NULL))
+				colorcode = "\\c[Green]";
+			else if ((ccmd = FConsoleCommand::FindByName (TabCommands[i].TabName)) != NULL)
+			{
+				if (ccmd->IsAlias())
+					colorcode = "\\c[Red]";
+				else
+					colorcode = "\\c[Light Blue]";
+			}
+
+			Printf ("%s%-*s", strbin1 (colorcode).GetChars(), int(maxwidth), TabCommands[i].TabName.GetChars());
 			x += maxwidth;
 			if (x > ConCols - maxwidth)
 			{

--- a/src/c_dispatch.cpp
+++ b/src/c_dispatch.cpp
@@ -955,6 +955,11 @@ bool FConsoleCommand::AddToHash (FConsoleCommand **table)
 	return true;
 }
 
+FConsoleCommand* FConsoleCommand::FindByName (const char* name)
+{
+	return FindNameInHashTable (Commands, name, strlen (name));
+}
+
 FConsoleCommand::FConsoleCommand (const char *name, CCmdRun runFunc)
 	: m_RunFunc (runFunc)
 {

--- a/src/c_dispatch.h
+++ b/src/c_dispatch.h
@@ -93,6 +93,7 @@ public:
 	void PrintCommand () { Printf ("%s\n", m_Name); }
 
 	virtual void Run (FCommandLine &args, APlayerPawn *instigator, int key);
+	static FConsoleCommand* FindByName (const char* name);
 
 	FConsoleCommand *m_Next, **m_Prev;
 	char *m_Name;


### PR DESCRIPTION
CCMDs appear blue, CVars green and aliases red.
