### PR TITLE
- Use a more conformant C++ preprocessor macro identifier for Unix systems.

### DIFF
--- a/src/b_game.cpp
+++ b/src/b_game.cpp
@@ -505,7 +505,7 @@ bool FCajunMaster::LoadBots ()
 	bool gotteam = false;
 
 	bglobal.ForgetBots ();
-#ifndef unix
+#ifndef __unix__
 	tmp = progdir;
 	tmp += "zcajun/" BOTFILENAME;
 	if (!FileExists (tmp))

--- a/src/c_console.cpp
+++ b/src/c_console.cpp
@@ -1742,7 +1742,7 @@ static bool C_HandleKey (event_t *ev, BYTE *buffer, int len)
 		}
 		break;
 
-#ifdef unix
+#ifdef __unix__
 	case EV_GUI_MButtonDown:
 		C_PasteText(I_GetFromClipboard(true), buffer, len);
 		break;

--- a/src/c_dispatch.cpp
+++ b/src/c_dispatch.cpp
@@ -1506,7 +1506,7 @@ CCMD (pullin)
 	{
 		const char *lastSlash;
 
-#ifdef unix
+#ifdef __unix__
 		lastSlash = strrchr (PullinFile, '/');
 #else
 		const char *lastSlash1, *lastSlash2;

--- a/src/ct_chat.cpp
+++ b/src/ct_chat.cpp
@@ -169,7 +169,7 @@ bool CT_Responder (event_t *ev)
 			}
 			return true;
 		}
-#ifdef unix
+#ifdef __unix__
 		else if (ev->subtype == EV_GUI_MButtonDown)
 		{
 			CT_PasteChat(I_GetFromClipboard(true));

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -38,7 +38,7 @@
 #endif
 #include <float.h>
 
-#if defined(unix) || defined(__APPLE__)
+#if defined(__unix__) || defined(__APPLE__)
 #include <unistd.h>
 #endif
 
@@ -2009,7 +2009,7 @@ static void AddAutoloadFiles(const char *gamesection)
 			D_AddFile (allwads, wad);
 	
 		// [RH] Add any .wad files in the skins directory
-#ifdef unix
+#ifdef __unix__
 		file = SHARE_DIR;
 #else
 		file = progdir;
@@ -2017,7 +2017,7 @@ static void AddAutoloadFiles(const char *gamesection)
 		file += "skins";
 		D_AddDirectory (allwads, file);
 
-#ifdef unix
+#ifdef __unix__
 		file = NicePath("~/" GAME_DIR "/skins");
 		D_AddDirectory (allwads, file);
 #endif	
@@ -2137,7 +2137,7 @@ static void CheckCmdLine()
 		Printf ("%s", GStrings("D_DEVSTR"));
 	}
 
-#if !defined(unix) && !defined(__APPLE__)
+#if !defined(__unix__) && !defined(__APPLE__)
 	// We do not need to support -cdrom under Unix, because all the files
 	// that would go to c:\\zdoomdat are already stored in .zdoom inside
 	// the user's home directory.

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -1919,7 +1919,7 @@ FString G_BuildSaveName (const char *prefix, int slot)
 	leader = Args->CheckValue ("-savedir");
 	if (leader.IsEmpty())
 	{
-#if !defined(unix) && !defined(__APPLE__)
+#if !defined(__unix__) && !defined(__APPLE__)
 		if (Args->CheckParm ("-cdrom"))
 		{
 			leader = CDROM_DIR "/";
@@ -1931,7 +1931,7 @@ FString G_BuildSaveName (const char *prefix, int slot)
 		}
 		if (leader.IsEmpty())
 		{
-#ifdef unix
+#ifdef __unix__
 			leader = "~/" GAME_DIR;
 #elif defined(__APPLE__)
 			char cpath[PATH_MAX];

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -135,7 +135,7 @@ FGameConfigFile::FGameConfigFile ()
 			local_app_support << cpath << "/" GAME_DIR;
 			SetValueForKey("Path", local_app_support, true);
 		}
-#elif !defined(unix)
+#elif !defined(__unix__)
 		SetValueForKey ("Path", "$HOME", true);
 		SetValueForKey ("Path", "$PROGDIR", true);
 #else
@@ -153,7 +153,7 @@ FGameConfigFile::FGameConfigFile ()
 		SetValueForKey ("Path", user_app_support, true);
 		SetValueForKey ("Path", "$PROGDIR", true);
 		SetValueForKey ("Path", local_app_support, true);
-#elif !defined(unix)
+#elif !defined(__unix__)
 		SetValueForKey ("Path", "$PROGDIR", true);
 #else
 		SetValueForKey ("Path", "~/" GAME_DIR, true);
@@ -683,7 +683,7 @@ void FGameConfigFile::CreateStandardAutoExec(const char *section, bool start)
 		{
 			path << cpath << "/" GAME_DIR "/autoexec.cfg";
 		}
-#elif !defined(unix)
+#elif !defined(__unix__)
 		path = "$PROGDIR/autoexec.cfg";
 #else
 		path = GetUserFile ("autoexec.cfg");

--- a/src/m_misc.cpp
+++ b/src/m_misc.cpp
@@ -333,7 +333,7 @@ static long ParseCommandLine (const char *args, int *argc, char **argv)
 }
 
 
-#if defined(unix)
+#if defined(__unix__)
 FString GetUserFile (const char *file)
 {
 	FString path;
@@ -698,7 +698,7 @@ void M_ScreenShot (const char *filename)
 	// find a file name to save it to
 	if (filename == NULL || filename[0] == '\0')
 	{
-#if !defined(unix) && !defined(__APPLE__)
+#if !defined(__unix__) && !defined(__APPLE__)
 		if (Args->CheckParm ("-cdrom"))
 		{
 			autoname = CDROM_DIR "\\";
@@ -715,7 +715,7 @@ void M_ScreenShot (const char *filename)
 			dirlen = autoname.Len();
 			if (dirlen == 0)
 			{
-#ifdef unix
+#ifdef __unix__
 				autoname = "~/" GAME_DIR "/screenshots/";
 #elif defined(__APPLE__)
 				char cpath[PATH_MAX];

--- a/src/menu/loadsavemenu.cpp
+++ b/src/menu/loadsavemenu.cpp
@@ -345,7 +345,7 @@ void DLoadSaveMenu::NotifyNewSave (const char *file, const char *title, bool okF
 	for (unsigned i=0; i<SaveGames.Size(); i++)
 	{
 		FSaveGameNode *node = SaveGames[i];
-#ifdef unix
+#ifdef __unix__
 		if (node->Filename.Compare (file) == 0)
 #else
 		if (node->Filename.CompareNoCase (file) == 0)

--- a/src/menu/menudef.cpp
+++ b/src/menu/menudef.cpp
@@ -158,7 +158,7 @@ static bool CheckSkipOptionBlock(FScanner &sc)
 		}
 		else if (sc.Compare("unix"))
 		{
-			#ifdef unix
+			#ifdef __unix__
 				filter = true;
 			#endif
 		}

--- a/src/sound/fmodsound.cpp
+++ b/src/sound/fmodsound.cpp
@@ -816,7 +816,7 @@ bool FMODSoundRenderer::Init()
 	}
 	
 	result = Sys->getNumDrivers(&driver);
-#ifdef unix
+#ifdef __unix__
 	if (result == FMOD_OK)
 	{
 		// On Linux, FMOD defaults to OSS. If OSS is not present, it doesn't

--- a/src/sound/music_fluidsynth_mididevice.cpp
+++ b/src/sound/music_fluidsynth_mididevice.cpp
@@ -295,7 +295,7 @@ FluidSynthMIDIDevice::FluidSynthMIDIDevice()
 		fluid_chorus_speed, fluid_chorus_depth, fluid_chorus_type);
 	if (0 == LoadPatchSets(fluid_patchset))
 	{
-#ifdef unix
+#ifdef __unix__
 		// This is the standard location on Ubuntu.
 		if (0 == LoadPatchSets("/usr/share/sounds/sf2/FluidR3_GS.sf2:/usr/share/sounds/sf2/FluidR3_GM.sf2"))
 		{
@@ -322,7 +322,7 @@ FluidSynthMIDIDevice::FluidSynthMIDIDevice()
 			}
 		}
 #endif
-#ifdef unix
+#ifdef __unix__
 		}
 #endif
 	}

--- a/src/timidity/instrum.cpp
+++ b/src/timidity/instrum.cpp
@@ -166,7 +166,7 @@ static Instrument *load_instrument(Renderer *song, const char *name, int percuss
 		tmp += ".pat";
 		if ((fp = open_filereader(tmp, openmode, NULL)) == NULL)
 		{
-#ifdef unix			// Windows isn't case-sensitive.
+#ifdef __unix__			// Windows isn't case-sensitive.
 			tmp.ToUpper();
 			if ((fp = open_filereader(tmp, openmode, NULL)) == NULL)
 #endif

--- a/src/version.h
+++ b/src/version.h
@@ -91,7 +91,7 @@ const char *GetVersionString();
 #define FORUM_URL "http://forum.zdoom.org"
 #define BUGS_FORUM_URL	"http://forum.zdoom.org/index.php?c=3"
 
-#ifdef unix
+#ifdef __unix__
 #define GAME_DIR ".config/zdoom"
 #elif defined(__APPLE__)
 #define GAME_DIR GAMENAME


### PR DESCRIPTION
The 'unix' identifier isn't defined when '-std' is passed to the compiler (tested with gcc and clang), so use '**unix**' which is well enough documented.
