### PR TITLE
- Fixed mismatched alloc/dealloc in FTextureManager.

### DIFF
--- a/src/textures/texturemanager.cpp
+++ b/src/textures/texturemanager.cpp
@@ -127,7 +127,7 @@ void FTextureManager::DeleteAll()
 	{
 		if (mAnimatedDoors[i].TextureFrames != NULL)
 		{
-			delete mAnimatedDoors[i].TextureFrames;
+			delete[] mAnimatedDoors[i].TextureFrames;
 			mAnimatedDoors[i].TextureFrames = NULL;
 		}
 	}


### PR DESCRIPTION
The 'TextureFrames', which is attached to all the 'mAnimatedDoors', were deleted with one-pointer 'delete' and they were allocated with 'new[]'. Pointed out by Valgrind when running some games.
