### PR TITLE
Ignore dehacked.exe from *.zip files to enable loading of *.deh files

### DIFF
--- a/src/resourcefiles/file_zip.cpp
+++ b/src/resourcefiles/file_zip.cpp
@@ -259,6 +259,13 @@ bool FZipFile::Open(bool quiet)
 		lump_p->CompressedSize = LittleLong(zip_fh->CompressedSize);
 		lump_p->Position = LittleLong(zip_fh->LocalHeaderOffset);
 		lump_p->CheckEmbedded();
+
+		// Ignore some very specific names
+		if (0 == stricmp("dehacked.exe", name))
+		{
+			memset(lump_p->Name, 0, sizeof(lump_p->Name));
+		}
+
 		lump_p++;
 	}
 	// Resize the lump record array to its actual size


### PR DESCRIPTION
Even with .DEH auto-loading set to all presence of dehacked.exe will prevent to load existing *.deh files from *.zip archive.
Clearing of short name seems to be the easiest way to ignore dehacked.exe lump.
