### PR TITLE
Fix compilation with Visual Studio 2013

### DIFF
--- a/src/win32/i_crash.cpp
+++ b/src/win32/i_crash.cpp
@@ -845,7 +845,13 @@ HANDLE WriteTextReport ()
 			" Cr0NpxState=%08x\r\n\r\n",
 			(WORD)ctxt->FloatSave.ControlWord, (WORD)ctxt->FloatSave.StatusWord, (WORD)ctxt->FloatSave.TagWord,
 			ctxt->FloatSave.ErrorOffset, ctxt->FloatSave.ErrorSelector, ctxt->FloatSave.DataOffset,
-			ctxt->FloatSave.DataSelector, ctxt->FloatSave.Cr0NpxState);
+			ctxt->FloatSave.DataSelector, ctxt->FloatSave.
+#if (_MSC_VER >= 1800)
+				Spare0
+#else
+				Cr0NpxState
+#endif
+				);
 
 		for (i = 0; i < 8; ++i)
 		{


### PR DESCRIPTION
It looks like in latest VS, a member of _ FLOATING_ SAVE_ AREA, Cr0NpxState, was renamed to Spare0. This should fix the issue for VS2013 and newer versions, leaving compilation in older ones unharmed.
