### PR TITLE
cl_bloodtype broke playsim sync

### DIFF
--- a/src/g_hexen/a_fighteraxe.cpp
+++ b/src/g_hexen/a_fighteraxe.cpp
@@ -26,8 +26,6 @@ void A_FAxeAttack (AActor *actor);
 
 extern void AdjustPlayerAngle (AActor *pmo, AActor *linetarget);
 
-EXTERN_CVAR (Int, cl_bloodtype)
-
 // The Fighter's Axe --------------------------------------------------------
 
 class AFWeapAxe : public AFighterWeapon

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -4879,7 +4879,8 @@ void P_DoCrunch (AActor *thing, FChangePosition *cpos)
 				const PClass *bloodcls = thing->GetBloodType();
 				
 				P_TraceBleed (newdam > 0 ? newdam : cpos->crushchange, thing);
-				if (cl_bloodtype <= 1 && bloodcls != NULL)
+
+				if (bloodcls != NULL)
 				{
 					AActor *mo;
 
@@ -4892,14 +4893,15 @@ void P_DoCrunch (AActor *thing, FChangePosition *cpos)
 					{
 						mo->Translation = TRANSLATION(TRANSLATION_Blood, bloodcolor.a);
 					}
+
+					if (!(cl_bloodtype <= 1)) mo->renderflags |= RF_INVISIBLE;
 				}
+
+				angle_t an;
+				an = (M_Random () - 128) << 24;
 				if (cl_bloodtype >= 1)
 				{
-					angle_t an;
-
-					an = (M_Random () - 128) << 24;
-					P_DrawSplash2 (32, thing->x, thing->y,
-								   thing->z + thing->height/2, an, 2, bloodcolor);
+					P_DrawSplash2(32, thing->x, thing->y, thing->z + thing->height / 2, an, 2, bloodcolor);
 				}
 			}
 			if (thing->CrushPainSound != 0 && !S_GetSoundPlayingInfo(thing, thing->CrushPainSound))

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -4874,7 +4874,7 @@ void P_SpawnBlood (fixed_t x, fixed_t y, fixed_t z, angle_t dir, int damage, AAc
 	if (bloodcls != NULL && !(GetDefaultByType(bloodcls)->flags4 & MF4_ALLOWPARTICLES))
 		bloodtype = 0;
 
-	if (bloodcls!=NULL && bloodtype <= 1)
+	if (bloodcls != NULL)
 	{
 		z += pr_spawnblood.Random2 () << 10;
 		th = Spawn (bloodcls, x, y, z, NO_REPLACE); // GetBloodType already performed the replacement
@@ -4945,7 +4945,7 @@ void P_SpawnBlood (fixed_t x, fixed_t y, fixed_t z, angle_t dir, int damage, AAc
 	}
 
 statedone:
-
+	if (!(bloodtype <= 1)) th->renderflags |= RF_INVISIBLE;
 	if (bloodtype >= 1)
 		P_DrawSplash2 (40, x, y, z, dir, 2, bloodcolor);
 }
@@ -4966,7 +4966,7 @@ void P_BloodSplatter (fixed_t x, fixed_t y, fixed_t z, AActor *originator)
 	if (bloodcls != NULL && !(GetDefaultByType(bloodcls)->flags4 & MF4_ALLOWPARTICLES))
 		bloodtype = 0;
 
-	if (bloodcls!=NULL && bloodtype <= 1)
+	if (bloodcls != NULL)
 	{
 		AActor *mo;
 
@@ -4981,6 +4981,8 @@ void P_BloodSplatter (fixed_t x, fixed_t y, fixed_t z, AActor *originator)
 		{
 			mo->Translation = TRANSLATION(TRANSLATION_Blood, bloodcolor.a);
 		}
+
+		if (!(bloodtype <= 1)) mo->renderflags |= RF_INVISIBLE;
 	}
 	if (bloodtype >= 1)
 	{
@@ -5004,7 +5006,7 @@ void P_BloodSplatter2 (fixed_t x, fixed_t y, fixed_t z, AActor *originator)
 	if (bloodcls != NULL && !(GetDefaultByType(bloodcls)->flags4 & MF4_ALLOWPARTICLES))
 		bloodtype = 0;
 
-	if (bloodcls!=NULL && bloodtype <= 1)
+	if (bloodcls != NULL)
 	{
 		AActor *mo;
 		
@@ -5019,6 +5021,8 @@ void P_BloodSplatter2 (fixed_t x, fixed_t y, fixed_t z, AActor *originator)
 		{
 			mo->Translation = TRANSLATION(TRANSLATION_Blood, bloodcolor.a);
 		}
+
+		if (!(bloodtype <= 1)) mo->renderflags |= RF_INVISIBLE;
 	}
 	if (bloodtype >= 1)
 	{
@@ -5047,7 +5051,7 @@ void P_RipperBlood (AActor *mo, AActor *bleeder)
 	if (bloodcls != NULL && !(GetDefaultByType(bloodcls)->flags4 & MF4_ALLOWPARTICLES))
 		bloodtype = 0;
 
-	if (bloodcls!=NULL && bloodtype <= 1)
+	if (bloodcls != NULL)
 	{
 		AActor *th;
 		th = Spawn (bloodcls, x, y, z, NO_REPLACE); // GetBloodType already performed the replacement
@@ -5064,6 +5068,8 @@ void P_RipperBlood (AActor *mo, AActor *bleeder)
 		{
 			th->Translation = TRANSLATION(TRANSLATION_Blood, bloodcolor.a);
 		}
+
+		if (!(bloodtype <= 1)) th->renderflags |= RF_INVISIBLE;
 	}
 	if (bloodtype >= 1)
 	{


### PR DESCRIPTION
Corrected entries were blood would spawn inconsistently because of cl_bloodtype.
Blood now always spawns but is marked invisible according to cl_bloodtype.
