### PR TITLE
- linedefs can now use subtractive translucency as well

### DIFF
--- a/specs/udmf_zdoom.txt
+++ b/specs/udmf_zdoom.txt
@@ -93,7 +93,7 @@ Note: All <bool> fields default to false unless mentioned otherwise.
    linedef
    {
       alpha = <float>;          // Translucency of this line, default is 1.0
-      renderstyle = <string>;   // Render style, can be "translucent" or "add",
+      renderstyle = <string>;   // Render style, can be "translucent", "add" or "subtract",
                                 // default is "translucent".
       playeruseback = <bool>;   // New SPAC flag, true = player can use from back side.
       anycross = <bool>;        // New SPAC flag, true = any non-projectile 
@@ -334,6 +334,9 @@ Added arg0str thing property.
 
 1.21 09.08.2013
 Added waterzone sector property.
+
+1.22 17.12.2013
+Added subtractive renderstyle.
 
 ===============================================================================
 EOF

--- a/src/doomdata.h
+++ b/src/doomdata.h
@@ -154,6 +154,7 @@ enum ELineFlags
 	ML_BLOCKUSE					= 0x02000000,	// blocks all use actions through this line
 	ML_BLOCKSIGHT				= 0x04000000,	// blocks monster line of sight
 	ML_BLOCKHITSCAN				= 0x08000000,	// blocks hitscan attacks
+	ML_SUBTRANS					= 0x10000000,	// [Dusk] subtractive translucency for linedefs
 };
 
 

--- a/src/p_lnspec.cpp
+++ b/src/p_lnspec.cpp
@@ -2867,18 +2867,11 @@ FUNC(LS_TranslucentLine)
 	while ((linenum = P_FindLineFromID (arg0, linenum)) >= 0)
 	{
 		lines[linenum].Alpha = Scale(clamp(arg1, 0, 255), FRACUNIT, 255);
-		if (arg2 == 0)
-		{
-			lines[linenum].flags &= ~ML_ADDTRANS;
-		}
-		else if (arg2 == 1)
-		{
-			lines[linenum].flags |= ML_ADDTRANS;
-		}
+
+		if (arg2 >= 0 && arg2 < NumLineRenderStyles)
+			P_SetLineRenderStyle (&lines[linenum], arg2);
 		else
-		{
-			Printf ("Unknown translucency type used with TranslucentLine\n");
-		}
+			Printf ("Unknown translucency type used with TranslucentLine\n"); break;
 	}
 
 	return true;

--- a/src/p_local.h
+++ b/src/p_local.h
@@ -508,6 +508,10 @@ bool	Check_Sides(AActor *, int, int);					// phares
 // [RH] 
 const secplane_t * P_CheckSlopeWalk (AActor *actor, fixed_t &xmove, fixed_t &ymove);
 
+// [Dusk]
+static const int NumLineRenderStyles = 3; // @style is to be within [0, NumLineRenderStyles[
+void P_SetLineRenderStyle (line_t* ld, int style);
+
 //----------------------------------------------------------------------------------
 //
 // Added so that in the source there's a clear distinction between

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -5748,3 +5748,22 @@ bool P_ActivateThingSpecial(AActor * thing, AActor * trigger, bool death)
 	// Returns the result
 	return res;
 }
+
+//=============================================================================
+//
+// P_ActivateThingSpecial
+//
+// [Dusk] Sets renderstyle flags for a line
+//
+//=============================================================================
+
+void P_SetLineRenderStyle (line_t* ld, int style)
+{
+	switch (style)
+	{
+		case 0: ld->flags &= ~(ML_ADDTRANS | ML_SUBTRANS); break;
+		case 1: ld->flags = (ld->flags & ~ML_SUBTRANS) | ML_ADDTRANS; break;
+		case 2: ld->flags = (ld->flags & ~ML_ADDTRANS) | ML_SUBTRANS; break;
+		default: break;
+	}
+}

--- a/src/p_setup.cpp
+++ b/src/p_setup.cpp
@@ -1986,7 +1986,7 @@ void P_SaveLineSpecial (line_t *ld)
 
 void P_FinishLoadingLineDef(line_t *ld, int alpha)
 {
-	bool additive = false;
+	int renderstyle = 0;
 
 	ld->frontsector = ld->sidedef[0] != NULL ? ld->sidedef[0]->sector : NULL;
 	ld->backsector  = ld->sidedef[1] != NULL ? ld->sidedef[1]->sector : NULL;
@@ -2023,22 +2023,25 @@ void P_FinishLoadingLineDef(line_t *ld, int alpha)
 		if (alpha == SHRT_MIN)
 		{
 			alpha = ld->args[1];
-			additive = !!ld->args[2];
+			renderstyle = ld->args[2];
+
+			if (renderstyle >= NumLineRenderStyles)
+			{
+				Printf ("TranslucentLine: Line #%d has an unknown renderstyle %d\n", linenum, renderstyle);
+				renderstyle = 0;
+			}
 		}
 		else if (alpha < 0)
 		{
 			alpha = -alpha;
-			additive = true;
+			renderstyle = 1;
 		}
 
 		alpha = Scale(alpha, FRACUNIT, 255); 
 		if (!ld->args[0])
 		{
 			ld->Alpha = alpha;
-			if (additive)
-			{
-				ld->flags |= ML_ADDTRANS;
-			}
+			P_SetLineRenderStyle (ld, renderstyle);
 		}
 		else
 		{
@@ -2047,10 +2050,7 @@ void P_FinishLoadingLineDef(line_t *ld, int alpha)
 				if (lines[j].id == ld->args[0])
 				{
 					lines[j].Alpha = alpha;
-					if (additive)
-					{
-						lines[j].flags |= ML_ADDTRANS;
-					}
+					P_SetLineRenderStyle (&lines[j], renderstyle);
 				}
 			}
 		}

--- a/src/p_udmf.cpp
+++ b/src/p_udmf.cpp
@@ -46,6 +46,7 @@
 #include "r_state.h"
 #include "r_data/colormaps.h"
 #include "w_wad.h"
+#include "p_local.h"
 
 //===========================================================================
 //
@@ -869,8 +870,9 @@ public:
 			case NAME_Renderstyle:
 			{
 				const char *str = CheckString(key);
-				if (!stricmp(str, "translucent")) ld->flags &= ~ML_ADDTRANS;
-				else if (!stricmp(str, "add")) ld->flags |= ML_ADDTRANS;
+				if (!stricmp(str, "translucent")) P_SetLineRenderStyle (ld, 0);
+				else if (!stricmp(str, "add")) P_SetLineRenderStyle (ld, 1);
+				else if (!stricmp(str, "subtract")) P_SetLineRenderStyle (ld, 2);
 				else sc.ScriptMessage("Unknown value \"%s\" for 'renderstyle'\n", str);
 				continue;
 			}

--- a/src/r_segs.cpp
+++ b/src/r_segs.cpp
@@ -252,8 +252,11 @@ void R_RenderMaskedSegRange (drawseg_t *ds, int x1, int x2)
 	// [RH] modified because we don't use user-definable translucency maps
 	ESPSResult drawmode;
 
-	drawmode = R_SetPatchStyle (LegacyRenderStyles[curline->linedef->flags & ML_ADDTRANS ? STYLE_Add : STYLE_Translucent],
-		MIN(curline->linedef->Alpha, FRACUNIT),	0, 0);
+	const int rstyle = curline->linedef->flags & ML_ADDTRANS ? STYLE_Add :
+		curline->linedef->flags & ML_SUBTRANS ? STYLE_Subtract :
+		STYLE_Translucent;
+
+	drawmode = R_SetPatchStyle (LegacyRenderStyles[rstyle], MIN(curline->linedef->Alpha, FRACUNIT),	0, 0);
 
 	if ((drawmode == DontDraw && !ds->bFogBoundary && !ds->bFakeBoundary))
 	{


### PR DESCRIPTION
- renderstyle "subtract" for udmf
- translucentline args[2]=2 for subtractive renderstyle
- updated udmf spec appropriately
