### PR TITLE
Stall testing for interpolation

### DIFF
--- a/src/d_net.h
+++ b/src/d_net.h
@@ -115,6 +115,9 @@ void D_QuitNetGame (void);
 //? how many ticks to run?
 void TryRunTics (void);
 
+//Use for checking to see if the netgame has stalled
+void Net_CheckLastRecieved(int);
+
 // [RH] Functions for making and using special "ticcmds"
 void Net_NewMakeTic ();
 void Net_WriteByte (BYTE);


### PR DESCRIPTION
Uncapped framerate never triggered the stall detection code, as it never tried to process a frame to start with.
