### PR TITLE
Fixed signed overflow issue with P_FindUniqueTID

### DIFF
--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -4933,7 +4933,7 @@ int DLevelScript::CallFunction(int argCount, int funcIndex, SDWORD *args, const 
 			break;
 
 		case ACSF_UniqueTID:
-			return P_FindUniqueTID(argCount > 0 ? args[0] : 0, argCount > 1 ? args[1] : 0);
+			return P_FindUniqueTID(argCount > 0 ? args[0] : 0, (argCount > 1 && args[1] >= 0) ? args[1] : 0);
 
 		case ACSF_IsTIDUsed:
 			return P_IsTIDUsed(args[0]);

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -2722,12 +2722,16 @@ int P_FindUniqueTID(int start_tid, int limit)
 
 	if (start_tid != 0)
 	{ // Do a linear search.
-		limit = start_tid + limit - 1;
-		if (limit < start_tid)
-		{ // If it overflowed, clamp to INT_MAX
-			limit = INT_MAX;
+		int end_tid = start_tid;
+		if (start_tid > 0 && limit > INT_MAX - start_tid + 1)
+		{ // If 'limit+start_tid-1' overflows, clamp 'end_tid' to INT_MAX
+			end_tid = INT_MAX;
 		}
-		for (tid = start_tid; tid <= limit; ++tid)
+		else
+		{
+			end_tid += limit-1;
+		}
+		for (tid = start_tid; tid <= end_tid; ++tid)
 		{
 			if (tid != 0 && !P_IsTIDUsed(tid))
 			{
@@ -2765,7 +2769,7 @@ CCMD(utid)
 {
 	Printf("%d\n",
 		P_FindUniqueTID(argv.argc() > 1 ? atoi(argv[1]) : 0,
-		argv.argc() > 2 ? atoi(argv[2]) : 0));
+		(argv.argc() > 2 && atoi(argv[2]) >= 0) ? atoi(argv[2]) : 0));
 }
 
 //==========================================================================


### PR DESCRIPTION
This caused a non-intended aggressive optimization by GCC 4.8. Also, negative values of the 'limit' parameter in both ACS UniqueTID() and in 'utid' CCMD are ignored and replaced by 0.
