### PR TITLE
- Fixed scanf in IWAD picker without GTK

### DIFF
--- a/src/sdl/i_system.cpp
+++ b/src/sdl/i_system.cpp
@@ -684,8 +684,7 @@ int I_PickIWad (WadStuff *wads, int numwads, bool showwin, int defaultiwad)
 		printf ("%d. %s (%s)\n", i+1, wads[i].Name.GetChars(), filepart);
 	}
 	printf ("Which one? ");
-	scanf ("%d", &i);
-	if (i > numwads)
+	if (scanf ("%d", &i) != 1 || i > numwads)
 		return -1;
 	return i-1;
 }


### PR DESCRIPTION
If you try to kill the program with Ctrl-C, it would run the first IWAD available in the list instead of closing it.
