### PR TITLE
P_HitWater ignore extra floors below real floor

### DIFF
--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -5169,7 +5169,7 @@ bool P_HitWater (AActor * thing, sector_t * sec, fixed_t x, fixed_t y, fixed_t z
 			}
 		}
 		planez = rover->bottom.plane->ZatPoint(x, y);
-		if (planez < z) return false;
+		if (planez < z && !(planez < thing->floorz)) return false;
 	}
 #endif
 	hsec = sec->GetHeightSec();


### PR DESCRIPTION
P_HitWater incorrectly assumed extra floors were always above the real floor. This caused terrain splashes not to occur for any sector where a 3dfloor, brightness transfer or otherwise had a floor height below the floor of the real sector.
