### PR TITLE
Possibly missing brackets in A_EntityDeath

### DIFF
--- a/src/g_strife/a_entityboss.cpp
+++ b/src/g_strife/a_entityboss.cpp
@@ -91,7 +91,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_EntityDeath)
 
 	fixed_t SpawnX = spot->x;
 	fixed_t SpawnY = spot->y;
-	fixed_t SpawnZ = spot->z + self->tracer? 70*FRACUNIT : 0;
+	fixed_t SpawnZ = spot->z + (self->tracer? 70*FRACUNIT : 0);
 	
 	an = self->angle >> ANGLETOFINESHIFT;
 	second = Spawn("EntitySecond", SpawnX + FixedMul (secondRadius, finecosine[an]),


### PR DESCRIPTION
There's a big possibility that the brackets in A_EntityDeath are missing.
The + operator has a higher priority than the ?: operator.
