### PR TITLE
New Freedoom names

### DIFF
--- a/wadsrc/static/iwadinfo.txt
+++ b/wadsrc/static/iwadinfo.txt
@@ -189,7 +189,7 @@ IWad
 
 IWad
 {
-	Name = "Freedoom"
+	Name = "Freedoom: Phase 2"
 	Autoname = "Freedoom"
 	Game = "Doom"
 	Config = "Doom"
@@ -200,7 +200,7 @@ IWad
 
 IWad
 {
-	Name = "Ultimate Freedoom"
+	Name = "Freedoom: Phase 1"
 	Autoname = "Freedoom1"
 	Game = "Doom"
 	Config = "Doom"
@@ -348,9 +348,10 @@ Names
 	"strife1.wad"
 	"strife0.wad"
 	"strife.wad"
-	"freedoom.wad"
 	"freedoom1.wad"
+	"freedoom2.wad"
 	"freedoomu.wad"
+	"freedoom.wad"
 	"freedm.wad"
 	"blasphem.wad"
 	"blasphemer.wad"


### PR DESCRIPTION
- Added freedoom2.wad as valid alias name (freedoom1.wad already
  existed).
- Renamed titles to Freedoom: Phase 1 and Freedoom: Phase 2.
- Reordered to put Phase 1 above Phase 2 in the IWAD picker.
