### PR TITLE
Some DOSBox Raw OPL v2 indices were off by one.

### DIFF
--- a/src/oplsynth/opl_mus_player.cpp
+++ b/src/oplsynth/opl_mus_player.cpp
@@ -267,7 +267,7 @@ bool OPLmusicBlock::ServiceStream (void *buff, int numbytes)
 					{
 						for (i = 0; i < io->NumChips; ++i)
 						{
-							io->chips[i]->Update(samples1, samplesleft);
+							io->chips[i]->Update(samples1, numsamples);
 						}
 						OffsetSamples(samples1, numsamples << stereoshift);
 					}


### PR DESCRIPTION
This caused access violation errors on perfectly fine DRO files. For
reference, scoredata[20] is the hardware type (OPL2, dual OPL2, or
OPL3).
