### PR TITLE
- Fixed useless 'array != NULL' check.

### DIFF
--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -387,7 +387,7 @@ void G_InitNew (const char *mapname, bool bTitleLevel)
 	StatusBar->NewGame ();
 	setsizeneeded = true;
 
-	if (gameinfo.gametype == GAME_Strife || (SBarInfoScript != NULL && SBarInfoScript[SCRIPT_CUSTOM]->GetGameType() == GAME_Strife))
+	if (gameinfo.gametype == GAME_Strife || (SBarInfoScript[SCRIPT_CUSTOM] != NULL && SBarInfoScript[SCRIPT_CUSTOM]->GetGameType() == GAME_Strife))
 	{
 		// Set the initial quest log text for Strife.
 		for (i = 0; i < MAXPLAYERS; ++i)

--- a/src/v_font.cpp
+++ b/src/v_font.cpp
@@ -2009,26 +2009,20 @@ void FSpecialFont::LoadTranslations()
 	}
 
 	// exclude the non-translated colors from the translation calculation
-	if (notranslate != NULL)
-	{
-		for (i = 0; i < 256; i++)
-			if (notranslate[i])
-				usedcolors[i] = false;
-	}
+	for (i = 0; i < 256; i++)
+		if (notranslate[i])
+			usedcolors[i] = false;
 
 	TotalColors = ActiveColors = SimpleTranslation (usedcolors, PatchRemap, identity, &luminosity);
 
 	// Map all untranslated colors into the table of used colors
-	if (notranslate != NULL)
+	for (i = 0; i < 256; i++) 
 	{
-		for (i = 0; i < 256; i++) 
+		if (notranslate[i])
 		{
-			if (notranslate[i]) 
-			{
-				PatchRemap[i] = TotalColors;
-				identity[TotalColors] = i;
-				TotalColors++;
-			}
+			PatchRemap[i] = TotalColors;
+			identity[TotalColors] = i;
+			TotalColors++;
 		}
 	}
 


### PR DESCRIPTION
- 'notranslate != NULL' is completely useless, because 'notranslate' is an array, hence removed.
- I interpreted 'SbarInfoScript != NULL' as a typo, since 1)in the next expression inside the condition there's a dereference to 'SBarInfoScript[SCRIPT_CUSTOM]' and 2)'SBarInfoScript[SCRIPT_CUSTOM]' is checked against 'NULL', in line 352, and then dereferenced when introducing 'cstype'.
