### PR TITLE
Made onground a player property

### DIFF
--- a/src/d_player.h
+++ b/src/d_player.h
@@ -434,6 +434,7 @@ public:
 	TObjPtr<AWeapon>	PremorphWeapon;		// ready weapon before morphing
 	int			chickenPeck;			// chicken peck countdown
 	int			jumpTics;				// delay the next jump for a moment
+	bool		onground;				// Identifies if this player is on the ground or other object
 
 	int			respawn_time;			// [RH] delay respawning until this tic
 	TObjPtr<AActor>		camera;			// [RH] Whose eyes this player sees through

--- a/src/version.h
+++ b/src/version.h
@@ -76,7 +76,7 @@ const char *GetVersionString();
 
 // Use 4500 as the base git save version, since it's higher than the
 // SVN revision ever got.
-#define SAVEVER 4504
+#define SAVEVER 4505
 
 #define SAVEVERSTRINGIFY2(x) #x
 #define SAVEVERSTRINGIFY(x) SAVEVERSTRINGIFY2(x)


### PR DESCRIPTION
"onground" was a global, despite being treated as a player property and crossed with instances from other players or prediction.

This also fixes a critical sync issue involving player prediction and landing on other mobj's. As onground would promptly change due to prediction, the next time onground was looked at would be based on the predicted player, rather then the actual player's value, which resulted in jumptics changing inconsistently.
