### PR TITLE
- Fixed new[]/delete mismatch in FNodeBuilder

### DIFF
--- a/src/nodebuild.cpp
+++ b/src/nodebuild.cpp
@@ -90,7 +90,7 @@ FNodeBuilder::~FNodeBuilder()
 	}
 	if (OldVertexTable != NULL)
 	{
-		delete OldVertexTable;
+		delete[] OldVertexTable;
 	}
 }
 


### PR DESCRIPTION
Found with address sanitizer, when running doom2.wad map30.
