### PR TITLE
- added GetActorSectorFloorZ and GetActorSectorCeilingZ ACS functions (take 2)

### DIFF
--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -4253,6 +4253,8 @@ enum EACSFunctions
 	ACSF_CheckFlag,
 	ACSF_SetLineActivation,
 	ACSF_GetLineActivation,
+	ACSF_GetActorSectorFloorZ, // [Dusk]
+	ACSF_GetActorSectorCeilingZ, // [Dusk]
 
 	// ZDaemon
 	ACSF_GetTeamScore = 19620,	// (int team)
@@ -5317,6 +5319,22 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 				return line >= 0 ? lines[line].activation : 0;
 			}
 			break;
+
+		// [Dusk]
+		case ACSF_GetActorSectorFloorZ:
+		case ACSF_GetActorSectorCeilingZ:
+		{
+			AActor* mo = SingleActorFromTID (args[0], activator);
+
+			if (mo != NULL && mo->Sector != NULL)
+			{
+				secplane_t *const plane = &(funcIndex == ACSF_GetActorSectorFloorZ ?
+					mo->Sector->floorplane : mo->Sector->ceilingplane);
+				return plane->ZatPoint (mo->x, mo->y);
+			}
+
+			break;
+		}
 
 		default:
 			break;


### PR DESCRIPTION
from here: http://forum.zdoom.org/viewtopic.php?f=3&t=45543

These functions return floor and ceiling z by actor's sector, in contrast with GetActorFloorZ and GetActorCeilingZ which returns the actor's floorz and ceilingz fields. These versions are compatible with GetActorLightLevel, CheckActorFloorTexture, CheckActorCeilingTexture, maybe some others that I don't know yet of either..

It's 2014, let's make ZDoom ACS able to check whether the player is in lava or not. :cactus: 
