### PR TITLE
- GetSectorFloorZ/GetSectorCeilingZ tag=0 handling

### DIFF
--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -7874,14 +7874,19 @@ scriptwait:
 		case PCD_GETSECTORCEILINGZ:
 			// Arguments are (tag, x, y). If you don't use slopes, then (x, y) don't
 			// really matter and can be left as (0, 0) if you like.
+			// [Dusk] If tag = 0, then this returns the z height at whatever sector
+			// is in x, y.
 			{
 				int secnum = P_FindSectorFromTag (STACK(3), -1);
+				fixed_t x = STACK(2) << FRACBITS;
+				fixed_t y = STACK(1) << FRACBITS;
 				fixed_t z = 0;
+
+				if (secnum == 0)
+					secnum = P_PointInSector (x, y) - sectors;
 
 				if (secnum >= 0)
 				{
-					fixed_t x = STACK(2) << FRACBITS;
-					fixed_t y = STACK(1) << FRACBITS;
 					if (pcd == PCD_GETSECTORFLOORZ)
 					{
 						z = sectors[secnum].floorplane.ZatPoint (x, y);


### PR DESCRIPTION
Okay I reconsidered what to do and here's a pretty generic solution. With this patch GetSectorFloorZ and GetSectorCeilingZ consider tag=0 to mean 'any sector' and look up the sector at the coordinates given.

tag=0 is useless as it is because the function first gets the sector by tag first and then gets the coordinates, so it only works for single tagged sectors. This adds a generalized way of getting z by x and y at whatever point in the map.
