### PR TITLE
Enable fighting between different types of gargoyles and golems

### DIFF
--- a/wadsrc/static/actors/heretic/hereticimp.txt
+++ b/wadsrc/static/actors/heretic/hereticimp.txt
@@ -82,6 +82,7 @@ ACTOR HereticImpLeader : HereticImp 5
 {
 	Game Heretic
 	SpawnID 7
+	Species "HereticImpLeader"
 	Health 80
 	-MISSILEMORE
 	AttackSound "himp/leaderattack"

--- a/wadsrc/static/actors/heretic/mummy.txt
+++ b/wadsrc/static/actors/heretic/mummy.txt
@@ -55,6 +55,7 @@ ACTOR MummyLeader : Mummy 45
 {
 	Game Heretic
 	SpawnID 2
+	Species "MummyLeader"
 	Health 100
 	Painchance 64
 	Obituary "$OB_MUMMYLEADER"
@@ -89,6 +90,7 @@ ACTOR MummyLeaderGhost : MummyLeader 46
 {
 	Game Heretic
 	SpawnID 9
+	Species "MummyLeaderGhost"
 	+SHADOW
 	+GHOST
 	RenderStyle Translucent


### PR DESCRIPTION
In vanilla Heretic:
- Gargoyles are able to fight with Fire Gargoyles
- Golems are able to fight with Nitro Golems, both regular and ghosted versions
