### PR TITLE
- increased updaterevision's buffer sizes to prevent GIT_BRANCH from cut short

### DIFF
--- a/tools/updaterevision/updaterevision.c
+++ b/tools/updaterevision/updaterevision.c
@@ -34,7 +34,7 @@ void stripnl(char *str)
 
 int main(int argc, char **argv)
 {
-	char vertag[64], lastlog[64], lasthash[64], *hash = NULL;
+	char vertag[128], lastlog[128], lasthash[128], *hash = NULL;
 	FILE *stream = NULL;
 	int gotrev = 0, needupdate = 1;
 


### PR DESCRIPTION
A little something I stumbled on my own project: a 64 byte array isn't enough to contain the entire git log output, leaving `GIT_HASH` truncated. I ran `git log -1 --format=%ai*%H` and it yielded this:
`2014-03-27 16:34:32 +0200*d7a2435703f56ce36c00892f31c3a582bb947b7d`

compare this in gitinfo.h:
`#define GIT_HASH "d7a2435703f56ce36c00892f31c3a582bb947"`

notice it's three bytes short. This patch corrects the issue by making the buffers large enough that fgets doesn't have to truncate data. While just a couple more bytes would've done the trick I doubled the sizes of the buffers for extra futureproofing.
