### PR TITLE
Fix loading of lumps from directory on OS X

### DIFF
--- a/src/resourcefiles/file_directory.cpp
+++ b/src/resourcefiles/file_directory.cpp
@@ -198,7 +198,7 @@ int FDirectory::AddDirectory(const char *dirpath)
 	return count;
 }
 
-#elif defined(__sun)
+#elif defined(__sun) || defined(__APPLE__)
 
 int FDirectory::AddDirectory(const char *dirpath)
 {


### PR DESCRIPTION
Use POSIX-compliant opendir() / readdir() functions instead fts_open() / fts_read()
Unlike Linux version, on OS X fts_read() inserts extra slash character between source directory and traversed entry paths
