### PR TITLE
CANRAISE state definition

### DIFF
--- a/src/info.h
+++ b/src/info.h
@@ -76,6 +76,7 @@ struct FState
 	BYTE		SameFrame:1;	// Ignore Frame (except when spawning actor)
 	BYTE		Fast:1;
 	BYTE		NoDelay:1;		// Spawn states executes its action normally
+	BYTE		CanRaise:1;		// Allows a monster to be resurrected without waiting for an infinate frame
 	int			ParameterIndex;
 
 	inline int GetFrame() const
@@ -113,6 +114,10 @@ struct FState
 	inline bool GetNoDelay() const
 	{
 		return NoDelay;
+	}
+	inline bool GetCanRaise() const
+	{
+		return CanRaise;
 	}
 	inline void SetFrame(BYTE frame)
 	{

--- a/src/p_enemy.cpp
+++ b/src/p_enemy.cpp
@@ -2527,8 +2527,9 @@ static bool P_CheckForResurrection(AActor *self, bool usevilestates)
 			if (!(corpsehit->flags & MF_CORPSE) )
 				continue;	// not a monster
 			
-			if (corpsehit->tics != -1)
-				continue;	// not lying still yet
+			if (corpsehit->tics != -1 && // not lying still yet
+				!corpsehit->state->GetCanRaise()) // or not ready to be raised yet
+				continue;
 			
 			raisestate = corpsehit->FindState(NAME_Raise);
 			if (raisestate == NULL)

--- a/src/thingdef/thingdef_states.cpp
+++ b/src/thingdef/thingdef_states.cpp
@@ -313,6 +313,11 @@ do_stop:
 					sc.MustGetStringName(")");
 					continue;
 				}
+				if (sc.Compare("CANRAISE"))
+				{
+					state.CanRaise = true;
+					continue;
+				}
 
 				// Make the action name lowercase
 				strlwr (sc.String);


### PR DESCRIPTION
CANRAISE state for allowing a monster to be resurrected without an infinite frame.
Fulfills this suggestion: http://forum.zdoom.org/viewtopic.php?f=15&t=45517
