### PR TITLE
Fixed P_LookForPlayers scanning redundancies and oversights

### DIFF
--- a/src/p_enemy.cpp
+++ b/src/p_enemy.cpp
@@ -1693,11 +1693,11 @@ bool P_LookForPlayers (AActor *actor, INTBOOL allaround, FLookExParams *params)
 					&& P_AproxDistance (player->mo->velx, player->mo->vely)
 					< 5*FRACUNIT)
 				{ // Player is sneaking - can't detect
-					return false;
+					continue;
 				}
 				if (pr_lookforplayers() < 225)
 				{ // Player isn't sneaking, but still didn't detect
-					return false;
+					continue;
 				}
 			}
 		}


### PR DESCRIPTION
- Players could be scanned multiple times, repeating expensive tests
- Players could be skipped completely and become invisible to monsters as a result
- Partial invisibility would cause P_LookForPlayers to end early, causing later players to be checked later

---

Fixes this: http://forum.zdoom.org/viewtopic.php?f=2&t=40308
