### PR TITLE
Stop NetUpdate from corrupting demo playback

### DIFF
--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -1052,6 +1052,12 @@ void NetUpdate (void)
 	if (singletics)
 		return; 		// singletic update is synchronous
 
+	if (demoplayback)
+	{
+		nettics[0] = (maketic / ticdup);
+		return;			// Don't touch netcmd data while playing a demo, as it'll already exist.
+	}
+
 	// If maketic didn't cross a ticdup boundary, only send packets
 	// to players waiting for resends.
 	resendOnly = (maketic / ticdup) == (maketic - i) / ticdup;


### PR DESCRIPTION
Fixes a long standing issue where multiplayer demos would desync during normal playback due to buffer corruption. Whether this also affected singleplayer demos is probably anybody's guess, but nobody reported any issues.

(Fixes: http://forum.zdoom.org/viewtopic.php?f=2&t=35149 )
