### PR TITLE
- Fixed compiler errors in latest TEXTURES code.

### DIFF
--- a/src/r_data/sprites.cpp
+++ b/src/r_data/sprites.cpp
@@ -63,7 +63,7 @@ static bool R_InstallSpriteLump (FTextureID lump, unsigned frame, char rot, bool
 
 	if (frame >= MAX_SPRITE_FRAMES || rotation > 16)
 	{
-		Printf (TEXTCOLOR_RED"R_InstallSpriteLump: Bad frame characters in lump %s\n", TexMan[lump]->Name);
+		Printf (TEXTCOLOR_RED"R_InstallSpriteLump: Bad frame characters in lump %s\n", TexMan[lump]->Name.GetChars());
 		return false;
 	}
 

--- a/src/r_utility.cpp
+++ b/src/r_utility.cpp
@@ -972,7 +972,7 @@ void FCanvasTextureInfo::Add (AActor *viewpoint, FTextureID picnum, int fov)
 	texture = static_cast<FCanvasTexture *>(TexMan[picnum]);
 	if (!texture->bHasCanvas)
 	{
-		Printf ("%s is not a valid target for a camera\n", texture->Name);
+		Printf ("%s is not a valid target for a camera\n", texture->Name.GetChars());
 		return;
 	}
 

--- a/src/textures/animations.cpp
+++ b/src/textures/animations.cpp
@@ -231,8 +231,8 @@ void FTextureManager::InitAnimated (void)
 				if (debuganimated)
 				{
 					Printf("Defining animation '%s' (texture %d, lump %d, file %d) to '%s' (texture %d, lump %d, file %d)\n",
-						tex1->Name, pic1.GetIndex(), tex1->GetSourceLump(), Wads.GetLumpFile(tex1->GetSourceLump()),
-						tex2->Name, pic2.GetIndex(), tex2->GetSourceLump(), Wads.GetLumpFile(tex2->GetSourceLump()));
+						tex1->Name.GetChars(), pic1.GetIndex(), tex1->GetSourceLump(), Wads.GetLumpFile(tex1->GetSourceLump()),
+						tex2->Name.GetChars(), pic2.GetIndex(), tex2->GetSourceLump(), Wads.GetLumpFile(tex2->GetSourceLump()));
 				}
 
 				if (pic1 == pic2)

--- a/src/textures/jpegtexture.cpp
+++ b/src/textures/jpegtexture.cpp
@@ -448,7 +448,7 @@ void FJPEGTexture::MakeTexture ()
 	}
 	catch (int)
 	{
-		Printf (TEXTCOLOR_ORANGE "   in texture %s\n", Name);
+		Printf (TEXTCOLOR_ORANGE "   in texture %s\n", Name.GetChars());
 		jpeg_destroy_decompress(&cinfo);
 	}
 	if (buff != NULL)
@@ -532,7 +532,7 @@ int FJPEGTexture::CopyTrueColorPixels(FBitmap *bmp, int x, int y, int rotate, FC
 	}
 	catch(int)
 	{
-		Printf (TEXTCOLOR_ORANGE "   in JPEG texture %s\n", Name);
+		Printf (TEXTCOLOR_ORANGE "   in JPEG texture %s\n", Name.GetChars());
 	}
 	jpeg_destroy_decompress(&cinfo);
 	if (buff != NULL) delete [] buff;

--- a/src/textures/multipatchtexture.cpp
+++ b/src/textures/multipatchtexture.cpp
@@ -268,14 +268,14 @@ FMultiPatchTexture::FMultiPatchTexture (const void *texdef, FPatchLookup *patchl
 		if (unsigned(LittleShort(mpatch.d->patch)) >= unsigned(maxpatchnum))
 		{
 			I_FatalError ("Bad PNAMES and/or texture directory:\n\nPNAMES has %d entries, but\n%s wants to use entry %d.",
-				maxpatchnum, Name, LittleShort(mpatch.d->patch)+1);
+				maxpatchnum, Name.GetChars(), LittleShort(mpatch.d->patch)+1);
 		}
 		Parts[i].OriginX = LittleShort(mpatch.d->originx);
 		Parts[i].OriginY = LittleShort(mpatch.d->originy);
 		Parts[i].Texture = patchlookup[LittleShort(mpatch.d->patch)].Texture;
 		if (Parts[i].Texture == NULL)
 		{
-			Printf(TEXTCOLOR_RED "Unknown patch %s in texture %s\n", patchlookup[LittleShort(mpatch.d->patch)].Name, Name);
+			Printf(TEXTCOLOR_RED "Unknown patch %s in texture %s\n", patchlookup[LittleShort(mpatch.d->patch)].Name.GetChars(), Name.GetChars());
 			NumParts--;
 			i--;
 		}
@@ -290,7 +290,7 @@ FMultiPatchTexture::FMultiPatchTexture (const void *texdef, FPatchLookup *patchl
 	}
 	if (NumParts == 0)
 	{
-		Printf ("Texture %s is left without any patches\n", Name);
+		Printf ("Texture %s is left without any patches\n", Name.GetChars());
 	}
 
 	CheckForHacks ();
@@ -1023,7 +1023,7 @@ void FMultiPatchTexture::ParsePatch(FScanner &sc, TexPart & part, bool silent, i
 	}
 	if (part.Texture == NULL)
 	{
-		if (!silent) Printf(TEXTCOLOR_RED "Unknown patch '%s' in texture '%s'\n", sc.String, Name);
+		if (!silent) Printf(TEXTCOLOR_RED "Unknown patch '%s' in texture '%s'\n", sc.String, Name.GetChars());
 	}
 	sc.MustGetStringName(",");
 	sc.MustGetNumber();
@@ -1244,13 +1244,13 @@ FMultiPatchTexture::FMultiPatchTexture (FScanner &sc, int usetype)
 			{
 				sc.MustGetFloat();
 				xScale = FLOAT2FIXED(sc.Float);
-				if (xScale == 0) sc.ScriptError("Texture %s is defined with null x-scale\n", Name);
+				if (xScale == 0) sc.ScriptError("Texture %s is defined with null x-scale\n", Name.GetChars());
 			}
 			else if (sc.Compare("YScale"))
 			{
 				sc.MustGetFloat();
 				yScale = FLOAT2FIXED(sc.Float);
-				if (yScale == 0) sc.ScriptError("Texture %s is defined with null y-scale\n", Name);
+				if (yScale == 0) sc.ScriptError("Texture %s is defined with null y-scale\n", Name.GetChars());
 			}
 			else if (sc.Compare("WorldPanning"))
 			{
@@ -1318,7 +1318,7 @@ FMultiPatchTexture::FMultiPatchTexture (FScanner &sc, int usetype)
 	if (Width <= 0 || Height <= 0)
 	{
 		UseType = FTexture::TEX_Null;
-		Printf("Texture %s has invalid dimensions (%d, %d)\n", Name, Width, Height);
+		Printf("Texture %s has invalid dimensions (%d, %d)\n", Name.GetChars(), Width, Height);
 		Width = Height = 1;
 	}
 	CalcBitSize ();

--- a/src/textures/texturemanager.cpp
+++ b/src/textures/texturemanager.cpp
@@ -949,7 +949,7 @@ void FTextureManager::SortTexturesByType(int start, int end)
 	{
 		if (newtextures[j] != NULL)
 		{
-			Printf("Texture %s has unknown type!\n", newtextures[j]->Name);
+			Printf("Texture %s has unknown type!\n", newtextures[j]->Name.GetChars());
 			AddTexture(newtextures[j]);
 		}
 	}

--- a/src/w_wad.h
+++ b/src/w_wad.h
@@ -196,8 +196,8 @@ public:
 	int GetLumpOffset (int lump);					// [RH] Returns offset of lump in the wadfile
 	int GetLumpFlags (int lump);					// Return the flags for this lump
 	void GetLumpName (char *to, int lump) const;	// [RH] Copies the lump name to to using uppercopy
-	void FWadCollection::GetLumpName(FString &to, int lump) const;
-	const char *GetLumpFullName(int lump) const;	// [RH] Returns the lump's full name
+	void GetLumpName (FString &to, int lump) const;
+	const char *GetLumpFullName (int lump) const;	// [RH] Returns the lump's full name
 	FString GetLumpFullPath (int lump) const;		// [RH] Returns wad's name + lump's full name
 	int GetLumpFile (int lump) const;				// [RH] Returns wadnum for a specified lump
 	int GetLumpNamespace (int lump) const;			// [RH] Returns the namespace a lump belongs to


### PR DESCRIPTION
GCC and Clang reported errors after pull request #61 was merged in master.

1)

```
/home/edward-san/zdoom/trunk/src/w_wad.h:199:23: error: extra qualification on
      member 'GetLumpName'
        void FWadCollection::GetLumpName(FString &to, int lump) const;
             ~~~~~~~~~~~~~~~~^
```

2)

```
/home/edward-san/zdoom/trunk/src/(other files): error: cannot pass
      non-trivial object of type 'FString' to variadic function; expected type
      from format string was 'char *' [-Wnon-pod-varargs]
```
