### PR TITLE
- Shut up GCC aggressive optimizer warnings.

### DIFF
--- a/src/g_heretic/a_hereticmisc.cpp
+++ b/src/g_heretic/a_hereticmisc.cpp
@@ -187,7 +187,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_VolcanoBlast)
 
 DEFINE_ACTION_FUNCTION(AActor, A_VolcBallImpact)
 {
-	int i;
+	unsigned int i;
 	AActor *tiny;
 	angle_t angle;
 

--- a/src/g_heretic/a_hereticweaps.cpp
+++ b/src/g_heretic/a_hereticweaps.cpp
@@ -797,7 +797,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FireBlasterPL1)
 
 DEFINE_ACTION_FUNCTION(AActor, A_SpawnRippers)
 {
-	int i;
+	unsigned int i;
 	angle_t angle;
 	AActor *ripper;
 

--- a/src/g_heretic/a_ironlich.cpp
+++ b/src/g_heretic/a_ironlich.cpp
@@ -171,7 +171,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_WhirlwindSeek)
 
 DEFINE_ACTION_FUNCTION(AActor, A_LichIceImpact)
 {
-	int i;
+	unsigned int i;
 	angle_t angle;
 	AActor *shard;
 

--- a/src/g_hexen/a_iceguy.cpp
+++ b/src/g_hexen/a_iceguy.cpp
@@ -125,7 +125,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_IceGuyDie)
 DEFINE_ACTION_FUNCTION(AActor, A_IceGuyMissileExplode)
 {
 	AActor *mo;
-	int i;
+	unsigned int i;
 
 	for (i = 0; i < 8; i++)
 	{


### PR DESCRIPTION
From what I can see, GCC would miscompile the involved loops, because the index variable is 'signed int' and the multiplication with an unsigned would cause signed overflow (undefined behavior). Change the index variable type to 'unsigned int' to expect unsigned overflow (conformant to standard).
