### PR TITLE
Don't reset the inventory of dead players

### DIFF
--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -1307,7 +1307,7 @@ void G_PlayerFinishLevel (int player, EFinishLevelType mode, int flags)
 	}
 
 	// Clears the entire inventory and gives back the defaults for starting a game
-	if (flags & CHANGELEVEL_RESETINVENTORY)
+	if ((flags & CHANGELEVEL_RESETINVENTORY) && p->playerstate != PST_DEAD)
 	{
 		p->mo->ClearInventory();
 		p->mo->GiveDefaultInventory();


### PR DESCRIPTION
Dead players would enter a zombie state if changelevel attempted to reset their inventory. As dead players have their inventory reset anyway, it was also redundant to do.
