### PR TITLE
Prediction was rebuilding too much thinglist data

### DIFF
--- a/src/p_local.h
+++ b/src/p_local.h
@@ -500,6 +500,7 @@ void	P_RadiusAttack (AActor *spot, AActor *source, int damage, int distance,
 
 void	P_DelSector_List();
 void	P_DelSeclist(msecnode_t *);							// phares 3/16/98
+msecnode_t*	P_DelSecnode(msecnode_t *);
 void	P_CreateSecNodeList(AActor*,fixed_t,fixed_t);		// phares 3/14/98
 int		P_GetMoveFactor(const AActor *mo, int *frictionp);	// phares  3/6/98
 int		P_GetFriction(const AActor *mo, int *frictionfactor);


### PR DESCRIPTION
- Stopped player prediction from rebuilding more sector list data then the player originally had.
  "Fixes" this strange undefined behaviour with Polyobjects (a static player will go unnoticed by a sector attached to a polyobject) causing things to desync: http://youtu.be/CbbQXonORxY
