### PR TITLE
Fix visual studio linking for x64 builds

### DIFF
--- a/src/win32/zdoom.exe.manifest
+++ b/src/win32/zdoom.exe.manifest
@@ -2,7 +2,7 @@
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <dependency>
     <dependentAssembly>
-      <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="x86" publicKeyToken="6595b64144ccf1df" language="*"></assemblyIdentity>
+      <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*"></assemblyIdentity>
     </dependentAssembly>
   </dependency>
 </assembly>


### PR DESCRIPTION
Currently, if you build a 64-bit zdoom executable using the supplied solution, the resulting .exe will fail to launch   with an error message such as:

The application was unable to start correctly (0xc000007b)

After a few hours of digging, and discovering Dependency Walker, I discovered this was because the zdoom.exe.manifest tells the linker to load the x86 version of the Windows Common Controls even for 64-bit builds!  This clearly isn't going to work.

According to:

http://msdn.microsoft.com/en-us/library/windows/desktop/bb773175(v=vs.85).aspx#using_manifests

> You can also specify "*", which ensures that all platforms are targeted, as shown in the following examples.

So I would like to propose making this change so that 64-bit and 32-bit builds work "out of the box".

After the proposed change I was able to successfully build and execute 64-bit zdoom.
