### PR TITLE
- Enable 'language' feature on unix targets.

### DIFF
--- a/src/sdl/i_system.cpp
+++ b/src/sdl/i_system.cpp
@@ -97,13 +97,7 @@ SDL_Cursor *X11Cursor;
 SDL_Cursor *FirstCursor;
 #endif
 
-DWORD LanguageIDs[4] =
-{
-	MAKE_ID ('e','n','u',0),
-	MAKE_ID ('e','n','u',0),
-	MAKE_ID ('e','n','u',0),
-	MAKE_ID ('e','n','u',0)
-};
+DWORD LanguageIDs[4];
 	
 int (*I_GetTime) (bool saveMS);
 int (*I_WaitForTic) (int);
@@ -326,6 +320,13 @@ void I_WaitVBL (int count)
 //
 void SetLanguageIDs ()
 {
+	size_t langlen = strlen(language);
+
+	DWORD lang = (langlen < 2 || langlen > 3) ?
+		MAKE_ID('e','n','u','0') :
+		MAKE_ID(language[0],language[1],language[2],'0');
+
+	LanguageIDs[3] = LanguageIDs[2] = LanguageIDs[1] = LanguageIDs[0] = lang;
 }
 
 //


### PR DESCRIPTION
The sdl version of the function 'SetLanguageIDs' is very limited, comparing to the win32 counterpart, as it will try to accept only the language codes (ie 'enu', 'fr', 'ptb', etc). If a different string is provided, zdoom will default its language to English.
