### PR TITLE
update lzma to v9.22 beta

### DIFF
--- a/lzma/C/7zCrcOpt.c
+++ b/lzma/C/7zCrcOpt.c
@@ -1,11 +1,11 @@
-/* 7zCrcOpt.c -- CRC32 calculation : optimized version
-2009-11-23 : Igor Pavlov : Public domain */
+/* 7zCrcOpt.c -- CRC32 calculation
+2010-12-01 : Igor Pavlov : Public domain */
 
 #include "CpuArch.h"
 
-#ifdef MY_CPU_LE
-
 #define CRC_UPDATE_BYTE_2(crc, b) (table[((crc) ^ (b)) & 0xFF] ^ ((crc) >> 8))
+
+#ifndef MY_CPU_BE
 
 UInt32 MY_FAST_CALL CrcUpdateT4(UInt32 v, const void *data, size_t size, const UInt32 *table)
 {
@@ -29,6 +29,36 @@ UInt32 MY_FAST_CALL CrcUpdateT4(UInt32 v, const void *data, size_t size, const U
 UInt32 MY_FAST_CALL CrcUpdateT8(UInt32 v, const void *data, size_t size, const UInt32 *table)
 {
   return CrcUpdateT4(v, data, size, table);
+}
+
+#endif
+
+
+#ifndef MY_CPU_LE
+
+#define CRC_UINT32_SWAP(v) ((v >> 24) | ((v >> 8) & 0xFF00) | ((v << 8) & 0xFF0000) | (v << 24))
+
+UInt32 MY_FAST_CALL CrcUpdateT1_BeT4(UInt32 v, const void *data, size_t size, const UInt32 *table)
+{
+  const Byte *p = (const Byte *)data;
+  for (; size > 0 && ((unsigned)(ptrdiff_t)p & 3) != 0; size--, p++)
+    v = CRC_UPDATE_BYTE_2(v, *p);
+  v = CRC_UINT32_SWAP(v);
+  table += 0x100;
+  for (; size >= 4; size -= 4, p += 4)
+  {
+    v ^= *(const UInt32 *)p;
+    v =
+      table[0x000 + (v & 0xFF)] ^
+      table[0x100 + ((v >> 8) & 0xFF)] ^
+      table[0x200 + ((v >> 16) & 0xFF)] ^
+      table[0x300 + ((v >> 24))];
+  }
+  table -= 0x100;
+  v = CRC_UINT32_SWAP(v);
+  for (; size > 0; size--, p++)
+    v = CRC_UPDATE_BYTE_2(v, *p);
+  return v;
 }
 
 #endif

--- a/lzma/C/7zVersion.h
+++ b/lzma/C/7zVersion.h
@@ -1,7 +1,8 @@
 #define MY_VER_MAJOR 9
-#define MY_VER_MINOR 20
-#define MY_VER_BUILD 0
-#define MY_VERSION "9.20"
-#define MY_DATE "2010-11-18"
+#define MY_VER_MINOR 22
+#define MY_VER_BUILD 00
+#define MY_VERSION "9.22 beta"
+#define MY_7ZIP_VERSION "9.22 beta"
+#define MY_DATE "2011-04-18"
 #define MY_COPYRIGHT ": Igor Pavlov : Public domain"
 #define MY_VERSION_COPYRIGHT_DATE MY_VERSION " " MY_COPYRIGHT " : " MY_DATE

--- a/lzma/C/CpuArch.c
+++ b/lzma/C/CpuArch.c
@@ -3,10 +3,6 @@
 
 #include "CpuArch.h"
 
-#ifdef _WIN32
-#include <windows.h>
-#endif
-
 #ifdef MY_CPU_X86_OR_AMD64
 
 #if (defined(_MSC_VER) && !defined(MY_CPU_AMD64)) || defined(__GNUC__)
@@ -74,23 +70,7 @@ static void MyCPUID(UInt32 function, UInt32 *a, UInt32 *b, UInt32 *c, UInt32 *d)
   *c = c2;
   *d = d2;
 
-  #elif __PIC__
-
-  /* GCC or Clang WITH position-independent code generation */
-
-  __asm__ __volatile__ (
-    "xchgl %%ebx, %1\n"
-    "cpuid\n"
-    "xchgl %%ebx, %1\n"
-    : "=a" (*a) ,
-      "=r" (*b) ,
-      "=c" (*c) ,
-      "=d" (*d)
-    : "0" (function)) ;
-	
   #else
-
-  /* GCC or Clang WITHOUT position-independent code generation */
 
   __asm__ __volatile__ (
     "cpuid"

--- a/lzma/C/CpuArch.h
+++ b/lzma/C/CpuArch.h
@@ -1,5 +1,5 @@
 /* CpuArch.h -- CPU specific code
-2010-10-26: Igor Pavlov : Public domain */
+2010-12-01: Igor Pavlov : Public domain */
 
 #ifndef __CPU_ARCH_H
 #define __CPU_ARCH_H
@@ -52,7 +52,7 @@ If MY_CPU_LE_UNALIGN is not defined, we don't know about these properties of pla
 #define MY_CPU_LE
 #endif
 
-#if defined(__BIG_ENDIAN__)
+#if defined(__BIG_ENDIAN__) || defined(__m68k__) ||  defined(__ARMEB__) || defined(__MIPSEB__)
 #define MY_CPU_BE
 #endif
 

--- a/lzma/C/Lzma2Dec.c
+++ b/lzma/C/Lzma2Dec.c
@@ -1,5 +1,5 @@
 /* Lzma2Dec.c -- LZMA2 Decoder
-2009-05-03 : Igor Pavlov : Public domain */
+2010-12-15 : Igor Pavlov : Public domain */
 
 /* #define SHOW_DEBUG_INFO */
 
@@ -330,27 +330,21 @@ SRes Lzma2Dec_DecodeToBuf(CLzma2Dec *p, Byte *dest, SizeT *destLen, const Byte *
 SRes Lzma2Decode(Byte *dest, SizeT *destLen, const Byte *src, SizeT *srcLen,
     Byte prop, ELzmaFinishMode finishMode, ELzmaStatus *status, ISzAlloc *alloc)
 {
-  CLzma2Dec decoder;
+  CLzma2Dec p;
   SRes res;
   SizeT outSize = *destLen, inSize = *srcLen;
-  Byte props[LZMA_PROPS_SIZE];
-
-  Lzma2Dec_Construct(&decoder);
-
   *destLen = *srcLen = 0;
   *status = LZMA_STATUS_NOT_SPECIFIED;
-  decoder.decoder.dic = dest;
-  decoder.decoder.dicBufSize = outSize;
-
-  RINOK(Lzma2Dec_GetOldProps(prop, props));
-  RINOK(LzmaDec_AllocateProbs(&decoder.decoder, props, LZMA_PROPS_SIZE, alloc));
-  
+  Lzma2Dec_Construct(&p);
+  RINOK(Lzma2Dec_AllocateProbs(&p, prop, alloc));
+  p.decoder.dic = dest;
+  p.decoder.dicBufSize = outSize;
+  Lzma2Dec_Init(&p);
   *srcLen = inSize;
-  res = Lzma2Dec_DecodeToDic(&decoder, outSize, src, srcLen, finishMode, status);
-  *destLen = decoder.decoder.dicPos;
+  res = Lzma2Dec_DecodeToDic(&p, outSize, src, srcLen, finishMode, status);
+  *destLen = p.decoder.dicPos;
   if (res == SZ_OK && *status == LZMA_STATUS_NEEDS_MORE_INPUT)
     res = SZ_ERROR_INPUT_EOF;
-
-  LzmaDec_FreeProbs(&decoder.decoder, alloc);
+  Lzma2Dec_FreeProbs(&p, alloc);
   return res;
 }

--- a/lzma/C/LzmaEnc.h
+++ b/lzma/C/LzmaEnc.h
@@ -1,14 +1,12 @@
 /*  LzmaEnc.h -- LZMA Encoder
-2009-02-07 : Igor Pavlov : Public domain */
+2011-01-27 : Igor Pavlov : Public domain */
 
 #ifndef __LZMA_ENC_H
 #define __LZMA_ENC_H
 
 #include "Types.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+EXTERN_C_BEGIN
 
 #define LZMA_PROPS_SIZE 5
 
@@ -18,6 +16,8 @@ typedef struct _CLzmaEncProps
   UInt32 dictSize; /* (1 << 12) <= dictSize <= (1 << 27) for 32-bit version
                       (1 << 12) <= dictSize <= (1 << 30) for 64-bit version
                        default = (1 << 24) */
+  UInt32 reduceSize; /* estimated size of data that will be compressed. default = 0xFFFFFFFF.
+                        Encoder uses this value to reduce dictionary size */
   int lc;          /* 0 <= lc <= 8, default = 3 */
   int lp;          /* 0 <= lp <= 4, default = 0 */
   int pb;          /* 0 <= pb <= 4, default = 2 */
@@ -73,8 +73,6 @@ SRes LzmaEncode(Byte *dest, SizeT *destLen, const Byte *src, SizeT srcLen,
     const CLzmaEncProps *props, Byte *propsEncoded, SizeT *propsSize, int writeEndMark,
     ICompressProgress *progress, ISzAlloc *alloc, ISzAlloc *allocBig);
 
-#ifdef __cplusplus
-}
-#endif
+EXTERN_C_END
 
 #endif

--- a/lzma/C/Threads.h
+++ b/lzma/C/Threads.h
@@ -6,13 +6,6 @@
 
 #include "Types.h"
 
-#ifdef _WIN32
-#include <windows.h>
-typedef DWORD WRes;
-#else
-typedef int WRes;
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/lzma/C/Types.h
+++ b/lzma/C/Types.h
@@ -6,6 +6,10 @@
 
 #include <stddef.h>
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 #ifndef EXTERN_C_BEGIN
 #ifdef __cplusplus
 #define EXTERN_C_BEGIN extern "C" {
@@ -38,12 +42,14 @@ EXTERN_C_BEGIN
 
 typedef int SRes;
 
-#ifndef RINOK
-#define RINOK(x) { int __result__ = (x); if (__result__ != 0) return __result__; }
+#ifdef _WIN32
+typedef DWORD WRes;
+#else
+typedef int WRes;
 #endif
 
-#if defined(__APPLE__) && !__LP64__
-#define _LZMA_UINT32_IS_ULONG
+#ifndef RINOK
+#define RINOK(x) { int __result__ = (x); if (__result__ != 0) return __result__; }
 #endif
 
 typedef unsigned char Byte;

--- a/lzma/history.txt
+++ b/lzma/history.txt
@@ -1,6 +1,14 @@
 HISTORY of the LZMA SDK
 -----------------------
 
+9.21 beta      2011-04-11
+-------------------------	
+- New class FString for file names at file systems.
+- Speed optimization in CRC code for big-endian CPUs.
+- The BUG in Lzma2Dec.c was fixed:
+    Lzma2Decode function didn't work.
+
+
 9.18 beta      2010-11-02
 -------------------------	
 - New small SFX module for installers (SfxSetup).

--- a/lzma/lzma.txt
+++ b/lzma/lzma.txt
@@ -1,4 +1,4 @@
-LZMA SDK 9.20
+LZMA SDK 9.22
 -------------
 
 LZMA SDK provides the documentation, samples, header files, libraries, 
@@ -23,6 +23,12 @@ LZMA SDK is written and placed in the public domain by Igor Pavlov.
 Some code in LZMA SDK is based on public domain code from another developers:
   1) PPMd var.H (2001): Dmitry Shkarin
   2) SHA-256: Wei Dai (Crypto++ library)
+
+You can copy, modify, distribute and perform LZMA SDK code, even for commercial purposes,
+all without asking permission.
+
+LZMA SDK code is compatible with open source licenses, for example, you can 
+include it to GNU GPL or GNU LGPL code.
 
 
 LZMA SDK Contents

--- a/lzma/lzmalib.vcproj
+++ b/lzma/lzmalib.vcproj
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="Windows-1252"?>
 <VisualStudioProject
 	ProjectType="Visual C++"
-	Version="8.00"
+	Version="9,00"
 	Name="lzmalib"
 	ProjectGUID="{6EB27E78-7C7A-4F08-8E19-957E8EB3A20F}"
 	RootNamespace="lzmalib"
 	Keyword="Win32Proj"
+	TargetFrameworkVersion="131072"
 	>
 	<Platforms>
 		<Platform


### PR DESCRIPTION
The internal libraries are all a little outdated, except for gme. Fortunately we can use system libs on Linux, except for lzma, which is why I've updated that one.
