### PR TITLE
Dup frames shouldn't adapt.

### DIFF
--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -1276,7 +1276,7 @@ void NetUpdate (void)
 	// listen for other packets
 	GetPackets ();
 
-	if (!demoplayback)
+	if (!resendOnly)
 	{
 		// ideally nettics[0] should be 1 - 3 tics above lowtic
 		// if we are consistantly slower, speed up time
@@ -1323,7 +1323,7 @@ void NetUpdate (void)
 			}
 			oldnettics = nettics[0];
 		}
-	}// !demoplayback
+	}
 }
 
 


### PR DESCRIPTION
Adapting during a dup frame caused jittery network performance (especially when using high dup values).
The demoplayback check also didn't need to be there anyway.
