### PR TITLE
Fixed build on compilers other than MSVC

### DIFF
--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -1677,7 +1677,7 @@ void FBehavior::SerializeVarSet (FArchive &arc, SDWORD *vars, int max)
 
 static int ParseLocalArrayChunk(void *chunk, ACSLocalArrays *arrays, int offset)
 {
-	unsigned count = (LittleShort(((unsigned *)chunk)[1]) - 2) / 4;
+	unsigned count = (LittleShort(static_cast<unsigned short>(((unsigned *)chunk)[1]) - 2)) / 4;
 	int *sizes = (int *)((BYTE *)chunk + 10);
 	arrays->Count = count;
 	if (count > 0)


### PR DESCRIPTION
No more "Call to 'LittleShort' is ambiguous" error

This should fix Mac builds on DRD.
