### PR TITLE
Added "The Adventures of Square" I-PK3 detection and blank MAPINFO base file.

### DIFF
--- a/wadsrc/static/iwadinfo.txt
+++ b/wadsrc/static/iwadinfo.txt
@@ -2,6 +2,26 @@
 
 IWad
 {
+	Name = "The Adventures of Square"
+	Game = "Doom"
+	Config = "Square"
+	Mapinfo = "mapinfo/blank.txt"
+	MustContain = "SQU-IWAD", "E1A1"
+	BannerColors = "ff ff ff", "80 00 80"
+}
+
+IWad
+{
+	Name = "The Adventures of Square (Square-ware)"
+	Game = "Doom"
+	Config = "Square"
+	Mapinfo = "mapinfo/blank.txt"
+	MustContain = "SQU-SWE1", "E1A1"
+	BannerColors = "ff ff ff", "80 00 80"
+}
+
+IWad
+{
 	Name = "Harmony"
 	Game = "Doom"
 	Config = "Harmony"
@@ -361,4 +381,6 @@ Names
 	"harm1.wad"
 	"hacx.wad"
 	"hacx2.wad"
+	"square.pk3"
+	"square1.pk3"
 }

--- a/wadsrc/static/mapinfo/blank.txt
+++ b/wadsrc/static/mapinfo/blank.txt
@@ -1,0 +1,2 @@
+// Blank MAPINFO. Defines nothing.
+// For Generic IWADs/PK3s that declare their own info.


### PR DESCRIPTION
This will enable ZDoom to run with Square support, outside of our hack-y distro.  It requires no existing definitions in MAPINFO because it uses its own, so I have provided a blank one. This will also help future projects that are also building an IWAD/PK3 from complete scratch.
