### PR TITLE
- Fixed miscompilation with Clang 3.5.0.

### DIFF
--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -2306,6 +2306,12 @@ void FBehavior::LoadScriptsDirectory ()
 	default:
 		break;
 	}
+
+// [EP] Clang 3.5.0 optimizer miscompiles this function and causes random
+// crashes in the program. I hope that Clang 3.5.x will fix this.
+#if defined(__clang__) && __clang_major__ == 3 && __clang_minor__ >= 5
+	asm("" : "+g" (NumScripts));
+#endif
 	for (i = 0; i < NumScripts; ++i)
 	{
 		Scripts[i].Flags = 0;


### PR DESCRIPTION
The optimizer miscompiles the function FBehavior::LoadScriptsDirectory and causes random crashes when zdoom is run with wads containing scripts.
As said in the comment, I just hope that the Clang devs fix it for the next patching release, ie 3.5.1.
