### PR TITLE
Allow SXF_SETMASTER to work on non-monsters.

### DIFF
--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -1843,6 +1843,10 @@ static bool InitSpawnedItem(AActor *self, AActor *mo, int flags)
 		// If this is a missile or something else set the target to the originator
 		mo->target = originator ? originator : self;
 	}
+	if (flags & SIXF_SETMASTER)
+	{
+		mo->master = originator;
+	}
 	if (flags & SIXF_TRANSFERSCALE)
 	{
 		mo->scaleX = self->scaleX;


### PR DESCRIPTION
Because spawning projectiles with +ISMONSTER and then disabling said flag after spawning is just a terrible idea. Not to mention, -nomonsters will stop it from working anyway.
http://forum.zdoom.org/viewtopic.php?f=15&t=46707
