### PR TITLE
Add PickActor ACS function.

### DIFF
--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -4368,6 +4368,7 @@ enum EACSFunctions
 	ACSF_ChangeActorPitch,		// 80
 	ACSF_GetArmorInfo,
 	ACSF_DropInventory,
+	ACSF_PickActor,
 
 	/* Zandronum's - these must be skipped when we reach 99!
 	-100:ResetMap(0),
@@ -5590,6 +5591,38 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 			if (argCount >= 2)
 			{
 				SetActorPitch(activator, args[0], args[1], argCount > 2 ? !!args[2] : false);
+			}
+			break;
+
+		case ACSF_PickActor:
+			if (argCount >= 5)
+			{
+				actor = SingleActorFromTID(args[0], activator);
+				if (actor == NULL)
+				{
+					return 0;
+				}
+
+				DWORD actorMask = MF_SHOOTABLE;
+				if (argCount >= 6) {
+					actorMask = args[5];
+				}
+
+				DWORD wallMask = ML_BLOCKEVERYTHING | ML_BLOCKHITSCAN;
+				if (argCount >= 7) {
+					wallMask = args[6];
+				}
+
+				AActor* pickedActor = P_LinePickActor(actor, args[1] << 16, args[3], args[2] << 16, actorMask, wallMask);
+				if (pickedActor == NULL) {
+					return 0;
+				}
+
+				pickedActor->RemoveFromHash();
+				pickedActor->tid = args[4];
+				pickedActor->AddToHash();
+				
+				return 1;
 			}
 			break;
 

--- a/src/p_local.h
+++ b/src/p_local.h
@@ -462,6 +462,7 @@ enum	// P_LineAttack flags
 
 AActor *P_LineAttack (AActor *t1, angle_t angle, fixed_t distance, int pitch, int damage, FName damageType, const PClass *pufftype, int flags = 0, AActor **victim = NULL, int *actualdamage = NULL);
 AActor *P_LineAttack (AActor *t1, angle_t angle, fixed_t distance, int pitch, int damage, FName damageType, FName pufftype, int flags = 0, AActor **victim = NULL, int *actualdamage = NULL);
+AActor *P_LinePickActor (AActor *t1, angle_t angle, fixed_t distance, int pitch, DWORD actorMask, DWORD wallMask);
 void	P_TraceBleed (int damage, fixed_t x, fixed_t y, fixed_t z, AActor *target, angle_t angle, int pitch);
 void	P_TraceBleed (int damage, AActor *target, angle_t angle, int pitch);
 void	P_TraceBleed (int damage, AActor *target, AActor *missile);		// missile version

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -3785,6 +3785,52 @@ AActor *P_LineAttack(AActor *t1, angle_t angle, fixed_t distance,
 
 //==========================================================================
 //
+// P_LinePickActor
+//
+//==========================================================================
+
+AActor *P_LinePickActor(AActor *t1, angle_t angle, fixed_t distance, int pitch,
+						DWORD actorMask, DWORD wallMask)
+{
+	fixed_t vx, vy, vz, shootz;
+	
+	angle >>= ANGLETOFINESHIFT;
+	pitch = (angle_t)(pitch) >> ANGLETOFINESHIFT;
+
+	vx = FixedMul(finecosine[pitch], finecosine[angle]);
+	vy = FixedMul(finecosine[pitch], finesine[angle]);
+	vz = -finesine[pitch];
+
+	shootz = t1->z - t1->floorclip + (t1->height >> 1);
+	if (t1->player != NULL)
+	{
+		shootz += FixedMul(t1->player->mo->AttackZOffset, t1->player->crouchfactor);
+	}
+	else
+	{
+		shootz += 8 * FRACUNIT;
+	}
+
+	FTraceResults trace;
+	Origin TData;
+	
+	TData.Caller = t1;
+	TData.hitGhosts = true;
+	
+	if (Trace(t1->x, t1->y, shootz, t1->Sector, vx, vy, vz, distance,
+		actorMask, wallMask, t1, trace, TRACE_NoSky, CheckForActor, &TData))
+	{
+		if (trace.HitType == TRACE_HitActor)
+		{
+			return trace.Actor;
+		}
+	}
+
+	return NULL;
+}
+
+//==========================================================================
+//
 //
 //
 //==========================================================================


### PR DESCRIPTION
PickActor can be used to set a TID on an actor under the player's crosshair (or using any TID as the source really). Filtering can be done on the actor flags level.

PickActor(tid, angle, pitch, max_distance, set_tid, [actormask], [wallmask])

A corresponding pull request exists for the function definition and wallmask constants in ACC.
