### PR TITLE
Add AProp_MeleeRange to SetActorProperty.

### DIFF
--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -3843,6 +3843,10 @@ void DLevelScript::DoSetActorProperty (AActor *actor, int property, int value)
 		actor->reactiontime = value;
 		break;
 
+	case APROP_MeleeRange:
+		actor->meleerange = value;
+		break;
+
 	case APROP_ViewHeight:
 		if (actor->IsKindOf (RUNTIME_CLASS (APlayerPawn)))
 			static_cast<APlayerPawn *>(actor)->ViewHeight = value;


### PR DESCRIPTION
AProp_MeleeRange already exists for GetActorProperty and CheckActorProperty, but it does nothing when used with SetActorProperty. This should fix it. Use a float value when setting the new value for MeleeRange.
