### PR TITLE
- Fixed a possible uninitialized condition.

### DIFF
--- a/src/r_utility.cpp
+++ b/src/r_utility.cpp
@@ -737,24 +737,20 @@ void R_ClearPastViewer (AActor *actor)
 
 void R_RebuildViewInterpolation(player_t *player)
 {
-	InterpolationViewer *iview;
-	if (NoInterpolateView)
-	{
-		if (player != NULL && player->camera != NULL)
-		{
-			iview = FindPastViewer(player->camera);
-		}
+	if (player == NULL || player->camera == NULL)
+		return;
 
-		if (iview == NULL)
-			return;
+	if (!NoInterpolateView)
+		return;
+	NoInterpolateView = false;
 
-		NoInterpolateView = false;
-		iview->oviewx = iview->nviewx;
-		iview->oviewy = iview->nviewy;
-		iview->oviewz = iview->nviewz;
-		iview->oviewpitch = iview->nviewpitch;
-		iview->oviewangle = iview->nviewangle;
-	}
+	InterpolationViewer *iview = FindPastViewer(player->camera);
+
+	iview->oviewx = iview->nviewx;
+	iview->oviewy = iview->nviewy;
+	iview->oviewz = iview->nviewz;
+	iview->oviewpitch = iview->nviewpitch;
+	iview->oviewangle = iview->nviewangle;
 }
 
 //==========================================================================


### PR DESCRIPTION
In the function R_RebuildViewInterpolation, the pointer 'iview' was not initialized when the player or its camera were NULL, hence 'iview == NULL' was garbage. Also, the function FindPastViewer does not return NULL, hence the mentioned check is not needed at all. Just return early if the player camera does not exist.
