### PR TITLE
- added udmf key midtex3dimpassible

### DIFF
--- a/specs/udmf_zdoom.txt
+++ b/specs/udmf_zdoom.txt
@@ -92,30 +92,33 @@ Note: All <bool> fields default to false unless mentioned otherwise.
 
    linedef
    {
-      alpha = <float>;          // Translucency of this line, default is 1.0
-      renderstyle = <string>;   // Render style, can be "translucent" or "add",
-                                // default is "translucent".
-      playeruseback = <bool>;   // New SPAC flag, true = player can use from back side.
-      anycross = <bool>;        // New SPAC flag, true = any non-projectile 
-                                // crossing will trigger this line
-      monsteractivate = <bool>; // Monsters can trigger this line.
-                                // For compatibility only because this flag's 
-                                // semantics can not be fully reproduced with
-                                // explicit trigger flags.
-      blockplayers = <bool>;    // Line blocks players' movement.
-      blockeverything = <bool>; // Line blocks everything.
-      firstsideonly = <bool>;   // Line can only be triggered from the front side.
-      zoneboundary = <bool>;    // Line is a boundary for sound reverb zones.
-      clipmidtex = <bool>;      // Line's mid textures are clipped to floor and ceiling.
-      wrapmidtex = <bool>;      // Line's mid textures are wrapped.
-      midtex3d = <bool>;        // Actors can walk on mid texture.
-      checkswitchrange = <bool>;// Switches can only be activated when vertically reachable.
-      blockprojectiles = <bool>;// Line blocks all projectiles
-      blockuse = <bool>;        // Line blocks all use actions
-      blocksight = <bool>;      // Line blocks monster line of sight
-      blockhitscan = <bool>;    // Line blocks hitscan attacks
-      locknumber = <int>;       // Line special is locked
-      arg0str = <string>;       // Alternate string-based version of arg0
+      alpha = <float>;            // Translucency of this line, default is 1.0
+      renderstyle = <string>;     // Render style, can be "translucent" or "add",
+                                  // default is "translucent".
+      playeruseback = <bool> ;    // New SPAC flag, true = player can use from back side.
+      anycross = <bool>;          // New SPAC flag, true = any non-projectile 
+                                  // crossing will trigger this line
+      monsteractivate = <bool>;   // Monsters can trigger this line.
+                                  // For compatibility only because this flag's 
+                                  // semantics can not be fully reproduced with
+                                  // explicit trigger flags.
+      blockplayers = <bool>;      // Line blocks players' movement.
+      blockeverything = <bool>;   // Line blocks everything.
+      firstsideonly = <bool>;     // Line can only be triggered from the front side.
+      zoneboundary = <bool>;      // Line is a boundary for sound reverb zones.
+      clipmidtex = <bool>;        // Line's mid textures are clipped to floor and ceiling.
+      wrapmidtex = <bool>;        // Line's mid textures are wrapped.
+      midtex3d = <bool>;          // Actors can walk on mid texture.
+      midtex3dimpassible = <bool>;// Used in conjuction with midtex3d - causes the mid
+                                  // texture to behave like an impassible line (projectiles
+                                  // pass through it).
+      checkswitchrange = <bool>;  // Switches can only be activated when vertically reachable.
+      blockprojectiles = <bool>;  // Line blocks all projectiles
+      blockuse = <bool>;          // Line blocks all use actions
+      blocksight = <bool>;        // Line blocks monster line of sight
+      blockhitscan = <bool>;      // Line blocks hitscan attacks
+      locknumber = <int>;         // Line special is locked
+      arg0str = <string>;         // Alternate string-based version of arg0
 
       transparent   = <bool>; // true = line is a Strife transparent line (alpha 0.25)
 

--- a/src/doomdata.h
+++ b/src/doomdata.h
@@ -162,6 +162,7 @@ enum ELineFlags
 	ML_BLOCKUSE					= 0x02000000,	// blocks all use actions through this line
 	ML_BLOCKSIGHT				= 0x04000000,	// blocks monster line of sight
 	ML_BLOCKHITSCAN				= 0x08000000,	// blocks hitscan attacks
+	ML_3DMIDTEX_IMPASS			= 0x10000000,	// [TP] if 3D midtex, behaves like a height-restricted ML_BLOCKING
 };
 
 

--- a/src/namedef.h
+++ b/src/namedef.h
@@ -419,6 +419,7 @@ xx(Passuse)
 xx(Repeatspecial)
 xx(Conversation)
 xx(Locknumber)
+xx(Midtex3dimpassible)
 
 xx(Playercross)
 xx(Playeruse)

--- a/src/p_3dmidtex.cpp
+++ b/src/p_3dmidtex.cpp
@@ -258,6 +258,13 @@ bool P_GetMidTexturePosition(const line_t *line, int sideno, fixed_t *ptextop, f
 
 bool P_LineOpening_3dMidtex(AActor *thing, const line_t *linedef, FLineOpening &open, bool restrict)
 {
+	// [TP] Impassible-like 3dmidtextures do not block missiles
+	if ((linedef->flags & ML_3DMIDTEX_IMPASS)
+		&& (thing->flags & MF_MISSILE || thing->BounceFlags & BOUNCE_MBF))
+	{
+		return false;
+	}
+
 	fixed_t tt, tb;
 
 	open.abovemidtex = false;

--- a/src/p_udmf.cpp
+++ b/src/p_udmf.cpp
@@ -1030,9 +1030,14 @@ public:
 				Flag(ld->flags, ML_BLOCKHITSCAN, key); 
 				continue;
 			
-			// [Dusk] lock number
+			// [TP] Locks the special with a key
 			case NAME_Locknumber:
 				ld->locknumber = CheckInt(key);
+				continue;
+
+			// [TP] Causes a 3d midtex to behave like an impassible line
+			case NAME_Midtex3dimpassible:
+				Flag(ld->flags, ML_3DMIDTEX_IMPASS, key);
 				continue;
 
 			default:
@@ -1080,6 +1085,10 @@ public:
 		if (arg1str.IsNotEmpty() && (P_IsThingSpecial(ld->special) || ld->special == 0))
 		{
 			ld->args[1] = -FName(arg1str);
+		}
+		if ((ld->flags & ML_3DMIDTEX_IMPASS) && !(ld->flags & ML_3DMIDTEX)) // [TP]
+		{
+			Printf ("Line %d has midtex3dimpassible without midtex3d.\n", index);
 		}
 	}
 


### PR DESCRIPTION
Adds a linedef flag so that 3d midtextures can be shot through like with impassible lines.
