### PR TITLE
General cleanup

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -937,9 +937,6 @@ public:
 	TObjPtr<AInventory>	Inventory;		// [RH] This actor's inventory
 	DWORD			InventoryID;	// A unique ID to keep track of inventory items
 
-	//Added by MC:
-	SDWORD id;						// Player ID (for items, # in list.)
-
 	BYTE smokecounter;
 	BYTE FloatBobPhase;
 	BYTE FriendPlayer;				// [RH] Player # + 1 this friendly monster works for (so 0 is no player, 1 is player 0, etc)

--- a/src/b_func.cpp
+++ b/src/b_func.cpp
@@ -249,7 +249,7 @@ shootmissile:
 
 		if (m)
 		{
-			if (inc[actor->id])
+			if (inc[actor->player - players])
 				actor->player->angle += m;
 			else
 				actor->player->angle -= m;
@@ -257,7 +257,7 @@ shootmissile:
 
 		if (abs (actor->player->angle - actor->angle) < 4*ANGLE_1)
 		{
-			inc[actor->id] = !inc[actor->id];
+			inc[actor->player - players] = !inc[actor->player - players];
 		}
 
 		if (Check_LOS (actor, enemy, (SHOOTFOV/2)))

--- a/src/b_move.cpp
+++ b/src/b_move.cpp
@@ -17,20 +17,7 @@
 #include "gi.h"
 #include "a_keys.h"
 #include "d_event.h"
-
-enum dirtype_t
-{
-    DI_EAST,
-    DI_NORTHEAST,
-    DI_NORTH,
-    DI_NORTHWEST,
-    DI_WEST,
-    DI_SOUTHWEST,
-    DI_SOUTH,
-    DI_SOUTHEAST,
-    DI_NODIR,
-    NUMDIRS
-};
+#include "p_enemy.h"
 
 static FRandom pr_botopendoor ("BotOpenDoor");
 static FRandom pr_bottrywalk ("BotTryWalk");
@@ -39,10 +26,6 @@ static FRandom pr_botnewchasedir ("BotNewChaseDir");
 // borrow some tables from p_enemy.cpp
 extern dirtype_t opposite[9];
 extern dirtype_t diags[4];
-extern fixed_t xspeed[8];
-extern fixed_t yspeed[8];
-
-extern TArray<line_t *> spechit;
 
 //Called while the bot moves after its player->dest mobj
 //which can be a weapon/enemy/item whatever.

--- a/src/d_netinfo.cpp
+++ b/src/d_netinfo.cpp
@@ -60,9 +60,6 @@
 
 static FRandom pr_pickteam ("PickRandomTeam");
 
-extern bool st_firsttime;
-EXTERN_CVAR (Bool, teamplay)
-
 CVAR (Float,	autoaim,				5000.f,		CVAR_USERINFO | CVAR_ARCHIVE);
 CVAR (String,	name,					"Player",	CVAR_USERINFO | CVAR_ARCHIVE);
 CVAR (Color,	color,					0x40cf00,	CVAR_USERINFO | CVAR_ARCHIVE);

--- a/src/d_player.h
+++ b/src/d_player.h
@@ -76,8 +76,6 @@ FPlayerColorSet *P_GetPlayerColorSet(FName classname, int setnum);
 void P_EnumPlayerColorSets(FName classname, TArray<int> *out);
 const char *GetPrintableDisplayName(const PClass *cls);
 
-class player_t;
-
 class APlayerPawn : public AActor
 {
 	DECLARE_CLASS (APlayerPawn, AActor)
@@ -398,8 +396,7 @@ public:
 
 	int			inventorytics;
 	BYTE		CurrentPlayerClass;		// class # for this player instance
-	bool		backpack;
-	
+
 	int			frags[MAXPLAYERS];		// kills of other players
 	int			fragcount;				// [RH] Cumulative frags for this player
 	int			lastkilltime;			// [RH] For multikills

--- a/src/g_shared/a_pickups.cpp
+++ b/src/g_shared/a_pickups.cpp
@@ -1025,7 +1025,7 @@ void AInventory::Touch (AActor *toucher)
 	for (int i = 0; i < MAXPLAYERS; i++)
 	{
 		if (playeringame[i] && this == players[i].dest)
-    		players[i].dest = NULL;
+			players[i].dest = NULL;
 	}
 }
 

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -252,9 +252,13 @@ void AActor::Serialize (FArchive &arc)
 		<< MinMissileChance
 		<< SpawnFlags
 		<< Inventory
-		<< InventoryID
-		<< id
-		<< FloatBobPhase
+		<< InventoryID;
+	if (SaveVersion < 4513)
+	{
+		SDWORD id;
+		arc << id;
+	}
+	arc << FloatBobPhase
 		<< Translation
 		<< SeeSound
 		<< AttackSound
@@ -4357,9 +4361,6 @@ APlayerPawn *P_SpawnPlayer (FPlayerStart *mthing, int playernum, int flags)
 	mobj->angle = spawn_angle;
 	mobj->pitch = mobj->roll = 0;
 	mobj->health = p->health;
-
-	//Added by MC: Identification (number in the players[MAXPLAYERS] array)
-    mobj->id = playernum;
 
 	// [RH] Set player sprite based on skin
 	if (!(mobj->flags4 & MF4_NOSKIN))

--- a/src/p_user.cpp
+++ b/src/p_user.cpp
@@ -240,7 +240,6 @@ player_t::player_t()
   health(0),
   inventorytics(0),
   CurrentPlayerClass(0),
-  backpack(0),
   fragcount(0),
   lastkilltime(0),
   multicount(0),
@@ -341,7 +340,6 @@ player_t &player_t::operator=(const player_t &p)
 	health = p.health;
 	inventorytics = p.inventorytics;
 	CurrentPlayerClass = p.CurrentPlayerClass;
-	backpack = p.backpack;
 	memcpy(frags, &p.frags, sizeof(frags));
 	fragcount = p.fragcount;
 	lastkilltime = p.lastkilltime;
@@ -2889,9 +2887,13 @@ void player_t::Serialize (FArchive &arc)
 		<< vely
 		<< centering
 		<< health
-		<< inventorytics
-		<< backpack
-		<< fragcount
+		<< inventorytics;
+	if (SaveVersion < 4513)
+	{
+		bool backpack;
+		arc << backpack;
+	}
+	arc << fragcount
 		<< spreecount
 		<< multicount
 		<< lastkilltime

--- a/src/version.h
+++ b/src/version.h
@@ -76,7 +76,7 @@ const char *GetVersionString();
 
 // Use 4500 as the base git save version, since it's higher than the
 // SVN revision ever got.
-#define SAVEVER 4512
+#define SAVEVER 4513
 
 #define SAVEVERSTRINGIFY2(x) #x
 #define SAVEVERSTRINGIFY(x) SAVEVERSTRINGIFY2(x)


### PR DESCRIPTION
- Removed unnecessary 'id' variable from AActor.
- Removed unused 'backpack' variable from player_t.
- Removed duplicate code from b_move.cpp.
- General cleanup.
