### PR TITLE
Fixed Unknown CMake command "CHECK_LIBRARY_EXISTS" error on Unix targets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ endif( COMMAND cmake_policy )
 include( CheckCXXSourceCompiles )
 include( CheckFunctionExists )
 include( CheckCXXCompilerFlag )
+include( CheckLibraryExists )
 include( FindPkgConfig )
 
 if( NOT APPLE )


### PR DESCRIPTION
Previously it worked somehow but not with CMake 3.0.2
