### PR TITLE
PickActor forceTID parameter

### DIFF
--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -5619,15 +5619,27 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 					wallMask = args[6];
 				}
 
+				bool forceTID = 0;
+				if (argCount >= 8)
+				{
+					if (args[7] != 0)
+						forceTID = 1;
+				}
+
 				AActor* pickedActor = P_LinePickActor(actor, args[1] << 16, args[3], args[2] << 16, actorMask, wallMask);
 				if (pickedActor == NULL) {
 					return 0;
 				}
 
-				pickedActor->RemoveFromHash();
-				pickedActor->tid = args[4];
-				pickedActor->AddToHash();
-				
+				if (!(forceTID) && (args[4] == 0) && (pickedActor->tid == 0))
+					return 0;
+
+				if ((pickedActor->tid == 0) || (forceTID))
+				{
+					pickedActor->RemoveFromHash();
+					pickedActor->tid = args[4];
+					pickedActor->AddToHash();
+				}
 				return 1;
 			}
 			break;


### PR DESCRIPTION
This changes the default behavior of PickActor to only set the TID if the picked actor has a TID of 0. In the case that the actor has no TID, you didn't force the TID to be changed, and you used 0 for the 5th argument, the function will return false. The 8th parameter (bool forceTID) will revert to the original behavior, potentially breaking scripts that rely on the TID.
