### PR TITLE
Fix handshakes between GCC and MSVC

### DIFF
--- a/src/i_net.cpp
+++ b/src/i_net.cpp
@@ -136,7 +136,7 @@ struct PreGamePacket
 	struct
 	{
 		DWORD	address;
-		u_short	port;
+		WORD	port;
 		BYTE	player;
 		BYTE	pad;
 	} machines[MAXNETNODES];


### PR DESCRIPTION
u_long has two different sizes between Linux GCC and MSVC
Stopped netgames from starting up if player count wont fit
