### PR TITLE
Missing break in case NAME_FillColor

### DIFF
--- a/src/p_udmf.cpp
+++ b/src/p_udmf.cpp
@@ -690,6 +690,7 @@ public:
 
 			case NAME_FillColor:
 				th->fillcolor = CheckInt(key);
+				break;
 
 			case NAME_Health:
 				th->health = CheckInt(key);


### PR DESCRIPTION
This caused weirdness with invulnerable monsters when their fillcolor was changed.
