### PR TITLE
Added compat profile for TNT MAP31

### DIFF
--- a/src/compatibility.cpp
+++ b/src/compatibility.cpp
@@ -82,6 +82,7 @@ enum
 	CP_SETWALLYSCALE,
 	CP_SETTHINGZ,
 	CP_SETTAG,
+	CP_SETTHINGFLAGS,
 };
 
 // EXTERNAL FUNCTION PROTOTYPES --------------------------------------------
@@ -318,6 +319,15 @@ void ParseCompatibility()
 				sc.MustGetNumber();
 				CompatParams.Push(sc.Number);
 			}
+			else if (sc.Compare("setthingflags"))
+			{
+				if (flags.ExtCommandIndex == ~0u) flags.ExtCommandIndex = CompatParams.Size();
+				CompatParams.Push(CP_SETTHINGFLAGS);
+				sc.MustGetNumber();
+				CompatParams.Push(sc.Number);
+				sc.MustGetNumber();
+				CompatParams.Push(sc.Number);
+			}
 			else 
 			{
 				sc.UnGet();
@@ -536,6 +546,15 @@ void SetCompatibilityParams()
 					if ((unsigned)CompatParams[i + 1] < (unsigned)numsectors)
 					{
 						sectors[CompatParams[i + 1]].tag = CompatParams[i + 2];
+					}
+					i += 3;
+					break;
+				}
+				case CP_SETTHINGFLAGS:
+				{
+					if ((unsigned)CompatParams[i + 1] < MapThingsConverted.Size())
+					{
+						MapThingsConverted[CompatParams[i + 1]].flags = CompatParams[i + 2];
 					}
 					i += 3;
 					break;

--- a/wadsrc/static/compatibility.txt
+++ b/wadsrc/static/compatibility.txt
@@ -389,3 +389,8 @@ B9DFF13207EACAC675C71D82624D0007 // XtheaterIII map01
 {
 	DisablePushWindowCheck
 }
+
+A53AE580A4AF2B5D0B0893F86914781E // TNT: Evilution map31
+{
+	setthingflags 470 2016
+}


### PR DESCRIPTION
TNT MAP31 has a missing yellow key in singleplayer with non-anthology versions. However, there is no comparable version difference, and the anthology version is actually incredibly rare.
