### PR TITLE
- Added flags for A_Fade functions:

### DIFF
--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -2354,18 +2354,33 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetTranslucent)
 // Fades the actor in
 //
 //===========================================================================
+
+enum FadeFlags
+{
+	FTF_REMOVE =	1 << 0,
+	FTF_CLAMP =		1 << 1,
+};
+
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FadeIn)
 {
 	ACTION_PARAM_START(1);
 	ACTION_PARAM_FIXED(reduce, 0);
+	ACTION_PARAM_INT(flags, 1);
 
 	if (reduce == 0)
 	{
-		reduce = FRACUNIT/10;
+		reduce = FRACUNIT / 10;
 	}
 	self->RenderStyle.Flags &= ~STYLEF_Alpha1;
 	self->alpha += reduce;
-	// Should this clamp alpha to 1.0?
+
+	if (self->alpha >= (FRACUNIT * 1))
+	{
+		if (flags & FTF_CLAMP)
+			self->alpha = (FRACUNIT * 1);
+		if (flags & FTF_REMOVE)
+			self->Destroy();
+	}
 }
 
 //===========================================================================
@@ -2379,7 +2394,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FadeOut)
 {
 	ACTION_PARAM_START(2);
 	ACTION_PARAM_FIXED(reduce, 0);
-	ACTION_PARAM_BOOL(remove, 1);
+	ACTION_PARAM_INT(flags, 1);
 
 	if (reduce == 0)
 	{
@@ -2387,9 +2402,12 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FadeOut)
 	}
 	self->RenderStyle.Flags &= ~STYLEF_Alpha1;
 	self->alpha -= reduce;
-	if (self->alpha <= 0 && remove)
+	if (self->alpha <= 0)
 	{
-		self->Destroy();
+		if (flags & FTF_CLAMP)
+			self->alpha = 0;
+		if (flags & FTF_REMOVE)
+			self->Destroy();
 	}
 }
 
@@ -2406,7 +2424,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FadeTo)
 	ACTION_PARAM_START(3);
 	ACTION_PARAM_FIXED(target, 0);
 	ACTION_PARAM_FIXED(amount, 1);
-	ACTION_PARAM_BOOL(remove, 2);
+	ACTION_PARAM_INT(flags, 2);
 
 	self->RenderStyle.Flags &= ~STYLEF_Alpha1;
 
@@ -2428,7 +2446,14 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FadeTo)
 			self->alpha = target;
 		}
 	}
-	if (self->alpha == target && remove)
+	if (flags & FTF_CLAMP)
+	{
+		if (self->alpha > (FRACUNIT * 1))
+			self->alpha = (FRACUNIT * 1);
+		else if (self->alpha < 0)
+			self->alpha = 0;
+	}
+	if (self->alpha == target && (flags & FTF_REMOVE))
 	{
 		self->Destroy();
 	}

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -222,9 +222,9 @@ ACTOR Actor native //: Thinker
 	action native A_Log(string whattoprint);
 	action native A_LogInt(int whattoprint);
 	action native A_SetTranslucent(float alpha, int style = 0);
-	action native A_FadeIn(float reduce = 0.1);
-	action native A_FadeOut(float reduce = 0.1, bool remove = true);
-	action native A_FadeTo(float target, float amount = 0.1, bool remove = false);
+	action native A_FadeIn(float reduce = 0.1, int flags = 0);
+	action native A_FadeOut(float reduce = 0.1, int flags = 1); //bool remove == true
+	action native A_FadeTo(float target, float amount = 0.1, int flags = 0);
 	action native A_SetScale(float scalex, float scaley = 0);
 	action native A_SetMass(int mass);
 	action native A_SpawnDebris(class<Actor> spawntype, bool transfer_translation = false, float mult_h = 1, float mult_v = 1);

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -405,6 +405,13 @@ enum
 	RMVF_EVERYTHING =		1 << 3,
 };
 
+// Flags for A_Fade*
+enum
+{
+	FTF_REMOVE =	1 << 0,
+	FTF_CLAMP =		1 << 1,
+};
+
 
 // This is only here to provide one global variable for testing.
 native int testglobalvar;


### PR DESCRIPTION
- FTF_REMOVE: Removes the actor when the alpha hits a certain level.
- \- A_FadeIn - 1.0
- \- A_FadeOut - 0.0
- \- A_FadeTo - Alpha target level reached
- FTF_CLAMP: Locks the alpha to the range [0.0, 1.0]. This can be used to fix the alpha in case it goes over the threshold as well.
