### PR TITLE
Destroy mod-created CVars when 'restart' is invoked

### DIFF
--- a/src/c_cvars.cpp
+++ b/src/c_cvars.cpp
@@ -1515,6 +1515,22 @@ void UnlatchCVars (void)
 	}
 }
 
+void DestroyCVarsFlagged (DWORD flags)
+{
+	FBaseCVar *cvar = CVars;
+	FBaseCVar *next = cvar;
+
+	while(cvar)
+	{
+		next = cvar->m_Next;
+
+		if(cvar->Flags & flags)
+			delete cvar;
+
+		cvar = next;
+	}
+}
+
 void C_SetCVarsToDefaults (void)
 {
 	FBaseCVar *cvar = CVars;

--- a/src/c_cvars.h
+++ b/src/c_cvars.h
@@ -159,6 +159,7 @@ private:
 	friend FBaseCVar *FindCVar (const char *var_name, FBaseCVar **prev);
 	friend FBaseCVar *FindCVarSub (const char *var_name, int namelen);
 	friend void UnlatchCVars (void);
+	friend void DestroyCVarsFlagged (DWORD flags);
 	friend void C_ArchiveCVars (FConfigFile *f, uint32 filter);
 	friend void C_SetCVarsToDefaults (void);
 	friend void FilterCompactCVars (TArray<FBaseCVar *> &cvars, uint32 filter);
@@ -189,6 +190,9 @@ FBaseCVar *C_CreateCVar(const char *var_name, ECVarType var_type, DWORD flags);
 
 // Called from G_InitNew()
 void UnlatchCVars (void);
+
+// Destroy CVars with the matching flags; called from CCMD(restart)
+void DestroyCVarsFlagged (DWORD flags);
 
 // archive cvars to FILE f
 void C_ArchiveCVars (FConfigFile *f, uint32 filter);

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -2578,6 +2578,7 @@ void D_DoomMain (void)
 			new (&gameinfo) gameinfo_t;		// Reset gameinfo
 			S_Shutdown();					// free all channels and delete playlist
 			C_ClearAliases();				// CCMDs won't be reinitialized so these need to be deleted here
+			DestroyCVarsFlagged(CVAR_MOD);	// Delete any cvar left by mods
 
 			GC::FullGC();					// perform one final garbage collection before deleting the class data
 			PClass::ClearRuntimeData();		// clear all runtime generated class data


### PR DESCRIPTION
Getting my feet wet with working on ZDoom-- apologies if I'm way off base here.

Addresses [this seemingly minor issue](http://forum.zdoom.org/viewtopic.php?f=2&t=45603), where CVars are not destroyed when `restart` is invoked from the console. My solution was to delete CVars flagged with CVAR_MOD, which seems to be the intended behavior.
