### PR TITLE
- Added three missile impact pointer changing flags.

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -347,6 +347,9 @@ enum
 	MF7_DONTTHRUST		= 0x00000100,	// Thrusting functions do not take, and do not give thrust (damage) to actors with this flag.
 	MF7_ALLOWPAIN		= 0x00000200,	// Invulnerable or immune (via damagefactors) actors can still react to taking damage even if they don't.
 	MF7_CAUSEPAIN		= 0x00000400,	// Damage sources with this flag can cause similar effects like ALLOWPAIN.
+	MF7_HITTARGET		= 0x00004000,	// The actor the projectile dies on is set to target, provided it's targetable anyway.
+	MF7_HITMASTER		= 0x00008000,	// Same as HITTARGET, except it's master instead of target.
+	MF7_HITTRACER		= 0x00010000,	// Same as HITTARGET, but for tracer.
 
 // --- mobj.renderflags ---
 

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -1202,6 +1202,9 @@ void P_ExplodeMissile (AActor *mo, line_t *line, AActor *target)
 	
 	if (target != NULL && ((target->flags & (MF_SHOOTABLE|MF_CORPSE)) || (target->flags6 & MF6_KILLED)) )
 	{
+		if (target->flags7 & MF7_HITTARGET)	mo->target = target;
+		if (target->flags7 & MF7_HITMASTER)	mo->master = target;
+		if (target->flags7 & MF7_HITTRACER)	mo->tracer = target;
 		if (target->flags & MF_NOBLOOD) nextstate = mo->FindState(NAME_Crash);
 		if (nextstate == NULL) nextstate = mo->FindState(NAME_Death, NAME_Extreme);
 	}

--- a/src/thingdef/thingdef_data.cpp
+++ b/src/thingdef/thingdef_data.cpp
@@ -247,7 +247,10 @@ static FFlagDef ActorFlags[]=
 	DEFINE_FLAG(MF7, DONTTHRUST, AActor, flags7),
 	DEFINE_FLAG(MF7, ALLOWPAIN, AActor, flags7),
 	DEFINE_FLAG(MF7, CAUSEPAIN, AActor, flags7),
-
+	DEFINE_FLAG(MF7, HITTARGET, AActor, flags7),
+	DEFINE_FLAG(MF7, HITMASTER, AActor, flags7),
+	DEFINE_FLAG(MF7, HITTRACER, AActor, flags7),
+	
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),
 	DEFINE_FLAG2(FX_ROCKET, ROCKETTRAIL, AActor, effects),


### PR DESCRIPTION
- HITTARGET, HITMASTER, and HITTRACER.
- A missile that dies hitting an actor will set this impacted actor as the new target/master/tracer, depending on specifications.
