### PR TITLE
Added cl_waitforsave

### DIFF
--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -116,6 +116,7 @@ CVAR (Bool, chasedemo, false, 0);
 CVAR (Bool, storesavepic, true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 CVAR (Bool, longsavemessages, true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 CVAR (String, save_dir, "", CVAR_ARCHIVE|CVAR_GLOBALCONFIG);
+CVAR (Bool, cl_waitforsave, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG);
 EXTERN_CVAR (Float, con_midtime);
 
 //==========================================================================
@@ -2147,6 +2148,9 @@ void G_DoSaveGame (bool okForQuicksave, FString filename, const char *descriptio
 		filename = G_BuildSaveName ("demosave.zds", -1);
 	}
 
+	if (cl_waitforsave)
+		I_FreezeTime(true);
+
 	insave = true;
 	G_SnapshotLevel ();
 
@@ -2156,6 +2160,7 @@ void G_DoSaveGame (bool okForQuicksave, FString filename, const char *descriptio
 	{
 		Printf ("Could not create savegame '%s'\n", filename.GetChars());
 		insave = false;
+		I_FreezeTime(false);
 		return;
 	}
 
@@ -2232,6 +2237,7 @@ void G_DoSaveGame (bool okForQuicksave, FString filename, const char *descriptio
 	}
 		
 	insave = false;
+	I_FreezeTime(false);
 }
 
 


### PR DESCRIPTION
- cl_waitforsave (default true) pauses the game timer when a save starts, preventing the network buffer from trying to compensate for slow saves. Notably resolves frame skipping in single player games with badly timed autosaves, or even autosaves at the start of the level.
