### PR TITLE
- Various CMake fixes for two problems.

### DIFF
--- a/dumb/CMakeLists.txt
+++ b/dumb/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required( VERSION 2.4 )
 make_release_only()
 
 include( CheckFunctionExists )
+include( CheckCXXCompilerFlag )
 
 # DUMB is much slower in a Debug build than a Release build, so we force a Release
 # build here, since we're not maintaining DUMB, only using it.
@@ -104,5 +105,9 @@ add_library( dumb
 target_link_libraries( dumb )
 
 if( ZD_CMAKE_COMPILER_IS_GNUCXX_COMPATIBLE )
-	set_source_files_properties( src/it/filter.cpp PROPERTIES COMPILE_FLAGS -msse )
+	CHECK_CXX_COMPILER_FLAG( -msse DUMB_CAN_USE_SSE )
+
+	if( DUMB_CAN_USE_SSE )
+		set_source_files_properties( src/it/filter.cpp PROPERTIES COMPILE_FLAGS -msse )
+	endif( DUMB_CAN_USE_SSE )
 endif( ZD_CMAKE_COMPILER_IS_GNUCXX_COMPATIBLE )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,9 @@ endif( ZD_CMAKE_COMPILER_IS_GNUCXX_COMPATIBLE )
 
 option( DYN_FLUIDSYNTH "Dynamically load fluidsynth" ON )
 
-option( OSX_COCOA_BACKEND "Use native Cocoa backend instead of SDL" ON )
+if( APPLE )
+    option( OSX_COCOA_BACKEND "Use native Cocoa backend instead of SDL" ON )
+endif( APPLE )
 
 if( CMAKE_SIZEOF_VOID_P MATCHES "8" )
 	set( X64 64 )


### PR DESCRIPTION
1) Don't show OSX_COCOA_BACKEND option if the host is not OSX;
2) Don't use the '-msse' compiler flag in dumb/ if the architecture does not support it.
