### PR TITLE
Bot fixes

### DIFF
--- a/src/b_bot.h
+++ b/src/b_bot.h
@@ -130,7 +130,6 @@ private:
 
 protected:
 	bool	 ctf;
-	int		 loaded_bots;
 	int		 t_join;
 	bool	 observer; //Consoleplayer is observer.
 };
@@ -188,12 +187,12 @@ public:
 	fixed_t		oldy;
 
 private:
-	//(B_think.cpp)
+	//(b_think.cpp)
 	void Think ();
 	void ThinkForMove (ticcmd_t *cmd);
 	void Set_enemy ();
 
-	//(B_func.cpp)
+	//(b_func.cpp)
 	bool Reachable (AActor *target);
 	void Dofire (ticcmd_t *cmd);
 	AActor *Choose_Mate ();

--- a/src/b_game.cpp
+++ b/src/b_game.cpp
@@ -216,19 +216,16 @@ bool FCajunMaster::SpawnBot (const char *name, int color)
 		"\\color\\cf df 90"		//10 = Bleached Bone
 	};
 
-	botinfo_t *thebot;
-	int botshift;
+	botinfo_t *thebot = botinfo;
+	int botshift = 0;
 
 	if (name)
 	{
-		thebot = botinfo;
-
 		// Check if exist or already in the game.
-		botshift = 0;
 		while (thebot && stricmp (name, thebot->name))
 		{
-			thebot = thebot->next;
 			botshift++;
+			thebot = thebot->next;
 		}
 
 		if (thebot == NULL)
@@ -246,27 +243,36 @@ bool FCajunMaster::SpawnBot (const char *name, int color)
 			return false;
 		}
 	}
-	else if (botnum < loaded_bots)
-	{
-		bool vacant = false;  //Spawn a random bot from bots.cfg if no name given.
-		while (!vacant)
-		{
-			int rnum = (pr_botspawn() % loaded_bots);
-			thebot = botinfo;
-			botshift = 0;
-			while (rnum)
-			{
-				--rnum, thebot = thebot->next;
-				botshift++;
-			}
-			if (thebot->inuse == BOTINUSE_No)
-				vacant = true;
-		}
-	}
 	else
 	{
-		Printf ("Couldn't spawn bot; no bot left in %s\n", BOTFILENAME);
-		return false;
+		//Spawn a random bot from bots.cfg if no name given.
+		TArray<botinfo_t *> BotInfoAvailable;
+
+		while (thebot)
+		{
+			if (thebot->inuse == BOTINUSE_No)
+				BotInfoAvailable.Push (thebot);
+
+			thebot = thebot->next;
+		}
+
+		if (BotInfoAvailable.Size () == 0)
+		{
+			Printf ("Couldn't spawn bot; no bot left in %s\n", BOTFILENAME);
+			return false;
+		}
+
+		thebot = BotInfoAvailable[pr_botspawn() % BotInfoAvailable.Size ()];
+
+		botinfo_t *thebot2 = botinfo;
+		while (thebot2)
+		{
+			if (thebot == thebot2)
+				break;
+
+			botshift++;
+			thebot2 = thebot2->next;
+		}
 	}
 
 	thebot->inuse = BOTINUSE_Waiting;
@@ -478,7 +484,6 @@ void FCajunMaster::ForgetBots ()
 	}
 
 	botinfo = NULL;
-	loaded_bots = 0;
 }
 
 bool FCajunMaster::LoadBots ()
@@ -486,6 +491,7 @@ bool FCajunMaster::LoadBots ()
 	FScanner sc;
 	FString tmp;
 	bool gotteam = false;
+	int loaded_bots = 0;
 
 	bglobal.ForgetBots ();
 	tmp = M_GetCajunPath(BOTFILENAME);
@@ -602,9 +608,9 @@ bool FCajunMaster::LoadBots ()
 		newinfo->next = bglobal.botinfo;
 		newinfo->lastteam = TEAM_NONE;
 		bglobal.botinfo = newinfo;
-		bglobal.loaded_bots++;
+		loaded_bots++;
 	}
-	Printf ("%d bots read from %s\n", bglobal.loaded_bots, BOTFILENAME);
+	Printf ("%d bots read from %s\n", loaded_bots, BOTFILENAME);
 	return true;
 }
 


### PR DESCRIPTION
- Fixed: Adding multiple bots at the same time could cause the game to crash if there were too few bots defined.
- The 'loaded_bots' variable no longer needs to be stored.
