### PR TITLE
Ignore 0 length chat messages

### DIFF
--- a/src/ct_chat.cpp
+++ b/src/ct_chat.cpp
@@ -343,6 +343,9 @@ static void CT_ClearChatMessage ()
 
 static void ShoveChatStr (const char *str, BYTE who)
 {
+	if (strlen(str) < 1) // Don't send empty messages
+		return;
+
 	FString substBuff;
 
 	if (str[0] == '/' &&


### PR DESCRIPTION
- There is no reason to send empty messages, and they just produced strange output anyway.
  Fixes http://forum.zdoom.org/viewtopic.php?f=2&t=47360
