### PR TITLE
Fixed incorrect volume levels of Timidity instruments

### DIFF
--- a/src/timidity/instrum.cpp
+++ b/src/timidity/instrum.cpp
@@ -485,7 +485,7 @@ fail:
 			sample_t *tmp;
 			for (i = sp->data_length, tmp = sp->data; i; --i)
 			{
-				a = abs(*tmp++);
+				a = fabsf(*tmp++);
 				if (a > maxamp)
 					maxamp = a;
 			}


### PR DESCRIPTION
With Emulate TiMidity option on (midi_timiditylike CVAR set to true) GUS emulation tried to output tones with infinite volumes
