### PR TITLE
- Adjusted default ripperlevel, riplevelmin and riplevelmax to 5.

### DIFF
--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -28,9 +28,9 @@ ACTOR Actor native //: Thinker
 	DeathType Normal
 	TeleFogSourceType "TeleportFog"
 	TeleFogDestType "TeleportFog"
-	RipperLevel 0
-	RipLevelMin 0
-	RipLevelMax 0
+	RipperLevel 5
+	RipLevelMin 5
+	RipLevelMax 5
 
 	// Variables for the expression evaluator
 	// NOTE: fixed_t and angle_t are only used here to ensure proper conversion


### PR DESCRIPTION
- This will make it so modders don't have to adjust all the monsters -- they can just backtrack a little.
