### PR TITLE
[OSX] Improvements in gaming controller support

### DIFF
--- a/src/posix/cocoa/i_common.h
+++ b/src/posix/cocoa/i_common.h
@@ -47,8 +47,6 @@ inline bool I_IsHiDPISupported()
 
 void I_ProcessEvent(NSEvent* event);
 
-void I_StartupJoysticks();
-void I_ShutdownJoysticks();
 void I_ProcessJoysticks();
 
 NSSize I_GetContentViewSize(const NSWindow* window);

--- a/src/posix/cocoa/i_main.mm
+++ b/src/posix/cocoa/i_main.mm
@@ -214,9 +214,6 @@ int OriginalMain(int argc, char** argv)
 		progdir = [[exePath stringByDeletingLastPathComponent] UTF8String];
 		progdir += "/";
 
-		I_StartupJoysticks();
-		atterm(I_ShutdownJoysticks);
-
 		C_InitConsole(80 * 8, 25 * 8, false);
 		D_DoomMain();
 	}


### PR DESCRIPTION
Manager will be initialized only when joystick support is enabled
Shutdown of gaming controller support will be always executed but only once
Potential crash because of incorrect atterm() functions order is avoided