### PR TITLE
(Better version) Overhauled RipperLevels completely.

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -1121,6 +1121,25 @@ public:
 	}
 };
 
+struct RipperLevelDefinition
+{
+public:
+	RipperLevelDefinition() { Clear(); }
+
+	int DefaultLevel;
+	bool ReplaceLevel;
+
+	void Apply(FName const type);
+	void Clear()
+	{
+		DefaultLevel = 0;
+		ReplaceLevel = false;
+	}
+
+	static RipperLevelDefinition *Get(FName const type);
+	static int ApplyMobjRipperLevel(int level, FName const type, RipLevelList * factors);
+};
+
 bool P_IsTIDUsed(int tid);
 int P_FindUniqueTID(int start_tid, int limit);
 

--- a/src/actor.h
+++ b/src/actor.h
@@ -575,7 +575,7 @@ extern FDropItemPtrArray DropItemList;
 void FreeDropItemChain(FDropItem *chain);
 int StoreDropItemChain(FDropItem *chain);
 
-
+typedef TMap<FName, int> RipLevelList;
 
 // Map Object definition.
 class AActor : public DThinker
@@ -827,6 +827,9 @@ public:
 	// Triggers SECSPAC_Exit/SECSPAC_Enter and related events if oldsec != current sector
 	void CheckSectorTransition(sector_t *oldsec);
 
+
+	void SetRipLevel(FName type, int riplevel);
+
 // info for drawing
 // NOTE: The first member variable *must* be x.
 	fixed_t	 		x,y,z;
@@ -980,14 +983,13 @@ public:
 	FNameNoInit DamageTypeReceived;
 	fixed_t DamageFactor;
 	fixed_t DamageMultiply;
-
+	RipLevelList *RipLevels;
+	FNameNoInit RipType;
 	FNameNoInit PainType;
 	FNameNoInit DeathType;
 	const PClass *TeleFogSourceType;
 	const PClass *TeleFogDestType;
 	int RipperLevel;
-	int RipLevelMin;
-	int RipLevelMax;
 
 	FState *SpawnState;
 	FState *SeeState;

--- a/src/dobjtype.cpp
+++ b/src/dobjtype.cpp
@@ -139,6 +139,11 @@ void PClass::StaticFreeData (PClass *type)
 {
 	if (type->Defaults != NULL)
 	{
+		if (((AActor*)(type->Defaults))->RipLevels)
+		{
+			delete ((AActor*)(type->Defaults))->RipLevels;
+			((AActor*)(type->Defaults))->RipLevels = NULL;
+		}
 		M_Free(type->Defaults);
 		type->Defaults = NULL;
 	}

--- a/src/g_strife/a_loremaster.cpp
+++ b/src/g_strife/a_loremaster.cpp
@@ -23,7 +23,7 @@ int ALoreShot::DoSpecialDamage (AActor *target, int damage, FName damagetype)
 {
 	FVector3 thrust;
 	
-	if (this->target != NULL)
+	if (this->target != NULL && !(target->flags7 & MF7_DONTTHRUST))
 	{
 		thrust.X = float(this->target->x - target->x);
 		thrust.Y = float(this->target->y - target->y);

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -897,11 +897,13 @@ bool PIT_CheckLine(line_t *ld, const FBoundingBox &box, FCheckPosition &tm)
 static bool CheckRipLevel(AActor *victim, AActor *projectile)
 {
 	RipLevelList *v = victim->RipLevels;
-	int *vrt = v->CheckKey((projectile->RipType));
 	int rip = victim->RipperLevel;
-	
-	if (vrt != NULL)
-		rip = *vrt;
+	if (v != NULL)
+	{
+		int *vrt = v->CheckKey((projectile->RipType));
+		if (vrt != NULL)
+			rip = *vrt;
+	}
 
 	if (rip > 0 && projectile->RipperLevel < rip) return false;
 	return true;

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -896,8 +896,14 @@ bool PIT_CheckLine(line_t *ld, const FBoundingBox &box, FCheckPosition &tm)
 
 static bool CheckRipLevel(AActor *victim, AActor *projectile)
 {
-	if (victim->RipLevelMin > 0 && projectile->RipperLevel < victim->RipLevelMin) return false;
-	if (victim->RipLevelMax > 0 && projectile->RipperLevel > victim->RipLevelMax) return false;
+	RipLevelList *v = victim->RipLevels;
+	int *vrt = v->CheckKey((projectile->RipType));
+	int rip = victim->RipperLevel;
+	
+	if (vrt != NULL)
+		rip = *vrt;
+
+	if (rip > 0 && projectile->RipperLevel < rip) return false;
 	return true;
 }
 

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -896,8 +896,10 @@ bool PIT_CheckLine(line_t *ld, const FBoundingBox &box, FCheckPosition &tm)
 
 static bool CheckRipLevel(AActor *victim, AActor *projectile)
 {
+	
 	RipLevelList *v = victim->RipLevels;
 	int rip = victim->RipperLevel;
+	FName temp = projectile->RipType;
 	if (v != NULL)
 	{
 		int *vrt = v->CheckKey((projectile->RipType));
@@ -905,7 +907,8 @@ static bool CheckRipLevel(AActor *victim, AActor *projectile)
 			rip = *vrt;
 	}
 
-	if (rip > 0 && projectile->RipperLevel < rip) return false;
+	int proj = RipperLevelDefinition::ApplyMobjRipperLevel(rip, temp, v);
+	if (proj > 0 && projectile->RipperLevel < proj) return false;
 	return true;
 }
 

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -340,9 +340,11 @@ void AActor::Serialize (FArchive &arc)
 	}
 	if (SaveVersion >= 4518)
 	{
-		arc << RipperLevel
-			<< RipLevelMin
-			<< RipLevelMax;
+		arc << RipperLevel;
+	}
+	if (SaveVersion >= 4519)
+	{
+		arc << RipType;
 	}
 
 	{
@@ -3696,6 +3698,20 @@ void AActor::Tick ()
 			return;
 
 		P_NightmareRespawn (this);
+	}
+}
+
+void AActor::SetRipLevel(FName type, int riplevel)
+{
+	if (riplevel >= 0)
+	{
+		if (RipLevels == NULL) RipLevels = new RipLevelList;
+			RipLevels->Insert(type, riplevel);
+	}
+	else
+	{
+		if (RipLevels != NULL)
+			RipLevels->Remove(type);
 	}
 }
 

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -3711,15 +3711,14 @@ void AActor::Tick ()
 
 void AActor::SetRipLevel(FName type, int riplevel)
 {
-	if (riplevel >= 0)
+	if (RipLevels == GetDefault()->RipLevels)
 	{
-		if (RipLevels == NULL) RipLevels = new RipLevelList;
-			RipLevels->Insert(type, riplevel);
-	}
-	else
-	{
-		if (RipLevels != NULL)
-			RipLevels->Remove(type);
+		// copy list from default
+		RipLevels = new RipLevelList;
+		*RipLevels = *GetDefault()->RipLevels;
+
+		// modify custom list
+		RipLevels->Insert(type, riplevel);
 	}
 }
 
@@ -4297,6 +4296,11 @@ void AActor::Deactivate (AActor *activator)
 
 void AActor::Destroy ()
 {
+	if (RipLevels && RipLevels != GetDefault()->RipLevels)
+	{
+		delete RipLevels;
+		RipLevels = NULL;
+	}
 	// [RH] Destroy any inventory this actor is carrying
 	DestroyAllInventory ();
 

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -5616,42 +5616,40 @@ DEFINE_ACTION_FUNCTION(AActor, A_SwapTeleFog)
 
 //===========================================================================
 //
-// A_SetRipperLevel(int level)
+// A_SetRipperLevel(int level, str id)
 //
 // Sets the ripper level/requirement of the calling actor.
 // Also sets the minimum and maximum levels to rip through.
 //===========================================================================
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetRipperLevel)
 {
-	ACTION_PARAM_START(1);
+	ACTION_PARAM_START(2);
 	ACTION_PARAM_INT(level, 0);
-	self->RipperLevel = level;
-}
+	ACTION_PARAM_NAME(id, 1);
+	ACTION_PARAM_BOOL(notype, 2);
 
-//===========================================================================
-//
-// A_SetRipMin(int min)
-//
-// Sets the ripper level/requirement of the calling actor.
-// Also sets the minimum and maximum levels to rip through.
-//===========================================================================
-DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetRipMin)
-{
-	ACTION_PARAM_START(1);
-	ACTION_PARAM_INT(min, 1);
-	self->RipLevelMin = min; 
-}
+	if (id == NAME_None || !stricmp(id, "none") || !stricmp(id, "null"))
+	{
 
-//===========================================================================
-//
-// A_SetRipMin(int min)
-//
-// Sets the ripper level/requirement of the calling actor.
-// Also sets the minimum and maximum levels to rip through.
-//===========================================================================
-DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetRipMax)
-{
-	ACTION_PARAM_START(1);
-	ACTION_PARAM_INT(max, 1);
-	self->RipLevelMax = max;
+		//Monsters and projectiles will use the same global ripper level
+		//when no type is specified. If notype is true, reset the
+		//type to none. Otherwise, don't modify it.
+		self->RipperLevel = level;
+		if (notype)
+			self->RipType = NAME_None;
+	}
+	else
+	{
+		if (self->flags & MF_SHOOTABLE)
+		{
+			//Don't bother setting this for non-shootable entities.
+			self->SetRipLevel(id, level);	
+		}
+		else
+		{
+			//All others will have their levels adjusted and their rip types set.
+			self->RipperLevel = level;
+			self->RipType = id;
+		}
+	}
 }

--- a/src/thingdef/thingdef_parse.cpp
+++ b/src/thingdef/thingdef_parse.cpp
@@ -1229,6 +1229,47 @@ static void ParseDamageDefinition(FScanner &sc)
 
 //==========================================================================
 //
+// Reads a ripper list definition
+//
+//==========================================================================
+
+static void ParseRipperDefinition(FScanner &sc)
+{
+	sc.SetCMode(true); // This may be 100% irrelevant for such a simple syntax, but I don't know
+
+	// Get RipperLevel
+
+	sc.MustGetString();
+	FName ripperType = sc.String;
+
+	RipperLevelDefinition rld;
+
+	sc.MustGetToken('{');
+	while (sc.MustGetAnyToken(), sc.TokenType != '}')
+	{
+		if (sc.Compare("LEVEL"))
+		{
+			sc.MustGetNumber();
+			rld.DefaultLevel = sc.Number;
+			if (!rld.DefaultLevel) rld.ReplaceLevel = true;
+		}
+		else if (sc.Compare("REPLACELEVEL"))
+		{
+			rld.ReplaceLevel = true;
+		}
+		else
+		{
+			sc.ScriptError("Unexpected data (%s) in ripper level definition.", sc.String);
+		}
+	}
+
+	rld.Apply(ripperType);
+
+	sc.SetCMode(false); // (set to true earlier in function)
+}
+
+//==========================================================================
+//
 // ParseDecorate
 //
 // Parses a single DECORATE lump
@@ -1312,6 +1353,11 @@ void ParseDecorate (FScanner &sc)
 			else if (sc.Compare("DAMAGETYPE"))
 			{
 				ParseDamageDefinition(sc);
+				break;
+			}
+			else if (sc.Compare("MONRIPPERLEVEL"))
+			{
+				ParseRipperDefinition(sc);
 				break;
 			}
 		default:

--- a/src/thingdef/thingdef_properties.cpp
+++ b/src/thingdef/thingdef_properties.cpp
@@ -1442,7 +1442,7 @@ DEFINE_PROPERTY(telefogdesttype, S, Actor)
 DEFINE_PROPERTY(riptype, S, Actor)
 {
 	PROP_STRING_PARM(str, 0);
-	if (!stricmp(str, "Normal")) defaults->RipType = NAME_None;
+	if (!str || !stricmp(str, "none") || !stricmp(str, "null")) defaults->RipType = NAME_None;
 	else defaults->RipType = str;
 }
 
@@ -1464,7 +1464,7 @@ DEFINE_PROPERTY(ripperlevel, ZI, Actor)
 	else
 	{
 		FName ripType;
-		if (!stricmp(str, "Normal")) ripType = NAME_None;
+		if (!str || !stricmp(str, "none") || !stricmp(str, "null")) ripType = NAME_None;
 		else ripType = str;
 
 		defaults->SetRipLevel(ripType, id);

--- a/src/thingdef/thingdef_properties.cpp
+++ b/src/thingdef/thingdef_properties.cpp
@@ -1437,42 +1437,38 @@ DEFINE_PROPERTY(telefogdesttype, S, Actor)
 }
 
 //==========================================================================
-//
+
 //==========================================================================
-DEFINE_PROPERTY(ripperlevel, I, Actor)
+DEFINE_PROPERTY(riptype, S, Actor)
 {
-	PROP_INT_PARM(id, 0);
-	if (id < 0)
-	{
-		I_Error ("RipperLevel must not be negative");
-	}
-	defaults->RipperLevel = id;
+	PROP_STRING_PARM(str, 0);
+	if (!stricmp(str, "Normal")) defaults->RipType = NAME_None;
+	else defaults->RipType = str;
 }
 
 //==========================================================================
 //
 //==========================================================================
-DEFINE_PROPERTY(riplevelmin, I, Actor)
+DEFINE_PROPERTY(ripperlevel, ZI, Actor)
 {
-	PROP_INT_PARM(id, 0);
+	PROP_STRING_PARM(str, 0);
+	PROP_INT_PARM(id, 1);
 	if (id < 0)
 	{
-		I_Error ("RipLevelMin must not be negative");
+		I_Error("RipperLevel must not be negative");
 	}
-	defaults->RipLevelMin = id;
-}
+	else if (str == NULL)
+	{
+		defaults->RipperLevel = id;
+	}
+	else
+	{
+		FName ripType;
+		if (!stricmp(str, "Normal")) ripType = NAME_None;
+		else ripType = str;
 
-//==========================================================================
-//
-//==========================================================================
-DEFINE_PROPERTY(riplevelmax, I, Actor)
-{
-	PROP_INT_PARM(id, 0);
-	if (id < 0)
-	{
-		I_Error ("RipLevelMax must not be negative");
+		defaults->SetRipLevel(ripType, id);
 	}
-	defaults->RipLevelMax = id;
 }
 
 //==========================================================================

--- a/src/version.h
+++ b/src/version.h
@@ -76,7 +76,7 @@ const char *GetVersionString();
 
 // Use 4500 as the base git save version, since it's higher than the
 // SVN revision ever got.
-#define SAVEVER 4518
+#define SAVEVER 4519
 
 #define SAVEVERSTRINGIFY2(x) #x
 #define SAVEVERSTRINGIFY(x) SAVEVERSTRINGIFY2(x)

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -29,8 +29,7 @@ ACTOR Actor native //: Thinker
 	TeleFogSourceType "TeleportFog"
 	TeleFogDestType "TeleportFog"
 	RipperLevel 0
-	RipLevelMin 0
-	RipLevelMax 0
+	RipType Normal
 
 	// Variables for the expression evaluator
 	// NOTE: fixed_t and angle_t are only used here to ensure proper conversion
@@ -324,9 +323,7 @@ ACTOR Actor native //: Thinker
 	action native A_TakeFromSiblings(class<Inventory> itemtype, int amount = 0);
 	action native A_SetTeleFog(name oldpos, name newpos);
 	action native A_SwapTeleFog();
-	action native A_SetRipperLevel(int level);
-	action native A_SetRipMin(int min);
-	action native A_SetRipMax(int max);
+	action native A_SetRipperLevel(int level, name id = "None", bool notype = false);
 
 	action native A_CheckSightOrRange(float distance, state label);
 	action native A_CheckRange(float distance, state label);


### PR DESCRIPTION
- Removed: RipLevelMin, RipLevelMax, and associated functions.
- This will break mods using these properties and functions.
- Added: RipType "name". Used by projectiles exclusively, and in unison with RipperLevel <int level>.
- Added: RipperLevel "name", <int level>. Names are exclusively used by monsters only. For projectiles, only use the level parameter: RipperLevel 5. Defaults to RipperLevel None, 0.
- Added globalization for ripper levels. Works similarly to DamageType, syntax and all.
- I.e. MonRipperLevel FunkyRipper { Level 7      [<optional>ReplaceLevel] }