### PR TITLE
New functions to manipulate an actor's roll.

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -785,6 +785,7 @@ public:
 	// These also set CF_INTERPVIEW for players.
 	void SetPitch(int p, bool interpolate);
 	void SetAngle(angle_t ang, bool interpolate);
+	void SetRoll(angle_t roll, bool interpolate);
 
 	const PClass *GetBloodType(int type = 0) const
 	{

--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -4440,6 +4440,9 @@ enum EACSFunctions
 	ACSF_CanRaiseActor,
 	ACSF_SetActorTeleFog,		// 86
 	ACSF_SwapActorTeleFog,
+	ACSF_SetActorRoll,
+	ACSF_ChangeActorRoll,
+	ACSF_GetActorRoll,
 
 	/* Zandronum's - these must be skipped when we reach 99!
 	-100:ResetMap(0),
@@ -4747,6 +4750,27 @@ static void SetActorPitch(AActor *activator, int tid, int angle, bool interpolat
 		while ((actor = iterator.Next()))
 		{
 			actor->SetPitch(angle << 16, interpolate);
+		}
+	}
+}
+
+static void SetActorRoll(AActor *activator, int tid, int angle, bool interpolate)
+{
+	if (tid == 0)
+	{
+		if (activator != NULL)
+		{
+			activator->SetRoll(angle << 16, interpolate);
+		}
+	}
+	else
+	{
+		FActorIterator iterator(tid);
+		AActor *actor;
+
+		while ((actor = iterator.Next()))
+		{
+			actor->SetRoll(angle << 16, interpolate);
 		}
 	}
 }
@@ -5831,6 +5855,26 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 				return !canraiseall;
 			}
 			break;
+
+		// [Nash] Actor roll functions. Let's roll!
+		case ACSF_SetActorRoll:
+			actor = SingleActorFromTID(args[0], activator);
+			if (actor != NULL)
+			{
+				actor->SetRoll(args[1] << 16, false);
+			}
+			return 0;
+
+		case ACSF_ChangeActorRoll:
+			if (argCount >= 2)
+			{
+				SetActorRoll(activator, args[0], args[1], argCount > 2 ? !!args[2] : false);
+			}
+			break;
+
+		case ACSF_GetActorRoll:
+			actor = SingleActorFromTID(args[0], activator);
+			return actor != NULL? actor->roll >> 16 : 0;
 
 		default:
 			break;

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -3077,6 +3077,18 @@ void AActor::SetAngle(angle_t ang, bool interpolate)
 	}
 }
 
+void AActor::SetRoll(angle_t r, bool interpolate)
+{
+	if (r != roll)
+	{
+		roll = r;
+		if (player != NULL && interpolate)
+		{
+			player->cheats |= CF_INTERPVIEW;
+		}
+	}
+}
+
 //
 // P_MobjThinker
 //

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -3975,6 +3975,22 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetPitch)
 
 //===========================================================================
 //
+// [Nash] A_SetRoll
+//
+// Set actor's roll (in degrees).
+//
+//===========================================================================
+
+DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetRoll)
+{
+	ACTION_PARAM_START(2);
+	ACTION_PARAM_ANGLE(roll, 0);
+	ACTION_PARAM_INT(flags, 1);
+	self->SetRoll(roll, !!(flags & SPF_INTERPOLATE));
+}
+
+//===========================================================================
+//
 // A_ScaleVelocity
 //
 // Scale actor's velocity.

--- a/src/thingdef/thingdef_expression.cpp
+++ b/src/thingdef/thingdef_expression.cpp
@@ -89,6 +89,7 @@ DEFINE_MEMBER_VARIABLE(radius, AActor)
 DEFINE_MEMBER_VARIABLE(reactiontime, AActor)
 DEFINE_MEMBER_VARIABLE(meleerange, AActor)
 DEFINE_MEMBER_VARIABLE(Speed, AActor)
+DEFINE_MEMBER_VARIABLE(roll, AActor)
 
 
 //==========================================================================

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -68,6 +68,7 @@ ACTOR Actor native //: Thinker
 	native int reactiontime;
 	native fixed_t meleerange;
 	native fixed_t speed;
+	native angle_t roll;
 
 	// Meh, MBF redundant functions. Only for DeHackEd support.
 	action native A_Turn(float angle = 0);
@@ -290,6 +291,7 @@ ACTOR Actor native //: Thinker
 	action native A_MonsterRefire(int chance, state label);
 	action native A_SetAngle(float angle = 0, int flags = 0);
 	action native A_SetPitch(float pitch, int flags = 0);
+	action native A_SetRoll(float roll, int flags = 0);
 	action native A_ScaleVelocity(float scale);
 	action native A_ChangeVelocity(float x = 0, float y = 0, float z = 0, int flags = 0);
 	action native A_SetArg(int pos, int value);

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -346,7 +346,7 @@ Const Int WARPF_TESTONLY = 0x200;
 Const Int WAPRF_ABSOLUTEPOSITION = 0x400;
 Const Int WARPF_ABSOLUTEPOSITION = 0x400;
 
-// flags for A_SetPitch/SetAngle
+// flags for A_SetPitch/SetAngle/SetRoll
 const int SPF_FORCECLAMP = 1;
 const int SPF_INTERPOLATE = 2;
 


### PR DESCRIPTION
- DECORATE functions: A_SetRoll code pointer.
- DECORATE expressions: "roll" variable.
- ACS functions: SetActorRoll, GetActorRoll.

--------------------------------------------------------------------------------
DECORATE: A_SetRoll (float angle, [int flags])

Sets the calling actor's roll angle to angle. It can be used with the roll DECORATE variable to modify the actor's current roll angle.
 
Parameters
angle: the actor's new roll angle, in degrees.
flags: SPF_INTERPOLATE: interpolates the view.

--------------------------------------------------------------------------------
ACS: void SetActorRoll (int tid, fixed angle) 

Sets the actor's roll angle.

Use a value for the roll angle from 0.0 to 1.0. 
tid: TID of thing.
angle: Roll angle to set. This is a fixed point angle.

--------------------------------------------------------------------------------
ACS: void ChangeActorAngle (int tid, fixed angle[, bool interpolate])

This function duplicates and extends on SetActorRoll by having the added option to interpolate the view.