### PR TITLE
- Fixed another erroneous FString comparison.

### DIFF
--- a/src/g_strife/strife_sbar.cpp
+++ b/src/g_strife/strife_sbar.cpp
@@ -601,7 +601,7 @@ private:
 			screen->DrawText(SmallFont2, CR_UNTRANSLATED, left + 210 * xscale, top + 8 * yscale, buff,
 				DTA_CleanNoMove, true, TAG_DONE);
 
-			if (CPlayer->LogText != NULL)
+			if (CPlayer->LogText.IsNotEmpty())
 			{
 				FBrokenLines *lines = V_BreakLines(SmallFont2, 272, CPlayer->LogText);
 				for (i = 0; lines[i].Width >= 0; ++i)


### PR DESCRIPTION
A comparison between an FString object and 'NULL' doesn't check for the emptiness of the examined string.


I noticed it by adding the 'operator !=' as a private member function of the FString class. Would it make sense to effectively include that, in order to prevent mistakes the next time?