### PR TITLE
[OSX] Fix launch with additional argument in IWAD picker

### DIFF
--- a/src/posix/osx/iwadpicker_cocoa.mm
+++ b/src/posix/osx/iwadpicker_cocoa.mm
@@ -139,7 +139,7 @@ static NSDictionary* GetKnownFileTypes()
 		@"-bex"     , @"bex",
 		@"-exec"    , @"cfg",
 		@"-playdemo", @"lmp",
-		nil];	
+		nil];
 }
 
 static NSArray* GetKnownExtensions()
@@ -156,7 +156,7 @@ static NSArray* GetKnownExtensions()
 {
 	NSString* extension = [[filePath pathExtension] lowercaseString];
 	NSString* parameter = [GetKnownFileTypes() objectForKey:extension];
-	
+
 	if (nil == parameter)
 	{
 		return;
@@ -211,7 +211,7 @@ static NSArray* GetKnownExtensions()
 	{
 		NSArray* files = [openPanel URLs];
 		NSMutableString* parameters = [NSMutableString string];
-		
+
 		for (NSUInteger i = 0, ei = [files count]; i < ei; ++i)
 		{
 			NSString* filePath = [[files objectAtIndex:i] path];
@@ -236,9 +236,9 @@ static NSArray* GetKnownExtensions()
 			{
 				newParameters = [newParameters stringByAppendingString:@" "];
 			}
-			
+
 			newParameters = [newParameters stringByAppendingString:parameters];
-			
+
 			[parametersTextField setStringValue: newParameters];
 		}
 	}
@@ -337,7 +337,7 @@ static NSArray* GetKnownExtensions()
 	[cancelButton setTarget:self];
 	[cancelButton setKeyEquivalent:@"\033"];
 	[[window contentView] addSubview:cancelButton];
-	
+
 	browseButton = [[NSButton alloc] initWithFrame:NSMakeRect(14, 8, 96, 32)];
 	[browseButton setTitle:@"Browse..."];
 	[browseButton setBezelStyle:NSRoundedBezelStyle];
@@ -398,22 +398,22 @@ static NSString* GetArchitectureString()
 static void RestartWithParameters(const char* iwadPath, NSString* parameters)
 {
 	assert(nil != parameters);
-	
+
 	defaultiwad = ExtractFileBase(iwadPath);
-	
+
 	GameConfig->DoGameSetup("Doom");
 	M_SaveDefaults(NULL);
-	
+
 	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 
 	@try
 	{
 		const int commandLineParametersCount = Args->NumArgs();
 		assert(commandLineParametersCount > 0);
-		
+
 		NSString* executablePath = [NSString stringWithUTF8String:Args->GetArg(0)];
 		NSString* architecture   = GetArchitectureString();
-		
+
 		NSMutableArray* arguments = [NSMutableArray arrayWithCapacity:commandLineParametersCount + 6];
 		[arguments addObject:@"-arch"];
 		[arguments addObject:architecture];
@@ -450,7 +450,7 @@ static void RestartWithParameters(const char* iwadPath, NSString* parameters)
 	{
 		NSLog(@"Cannot restart: %@", [e reason]);
 	}
-	
+
 	[pool release];
 }
 


### PR DESCRIPTION
Fixed launching with additional arguments from IWAD picker on OS X 10.4