### PR TITLE
- Fixed bad characters in the info command string.

### DIFF
--- a/src/c_cmds.cpp
+++ b/src/c_cmds.cpp
@@ -900,8 +900,8 @@ CCMD(info)
 			linetarget->SpawnHealth());
 		PrintMiscActorInfo(linetarget);
 	}
-	else Printf("No target found. Info cannot find actors that have\
-				the NOBLOCKMAP flag or have height/radius of 0.\n");
+	else Printf("No target found. Info cannot find actors that have "
+				"the NOBLOCKMAP flag or have height/radius of 0.\n");
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
The '\' character concatenated also all the characters before 'the NOBLOCKMAP' text, ie the 4 tabs, therefore the console would print them (garbage), too.
