### PR TITLE
[OSX] Fixed a very specific issue with game window

### DIFF
--- a/src/posix/cocoa/i_video.mm
+++ b/src/posix/cocoa/i_video.mm
@@ -355,10 +355,14 @@ cycle_t FlipCycles;
 
 CocoaWindow* CreateCocoaWindow(const NSUInteger styleMask)
 {
-	CocoaWindow* window = [[CocoaWindow alloc] initWithContentRect:NSMakeRect(0, 0, 640, 480)
-														 styleMask:styleMask
-														   backing:NSBackingStoreBuffered
-															 defer:NO];
+	static const CGFloat TEMP_WIDTH  = VideoModes[0].width  - 1;
+	static const CGFloat TEMP_HEIGHT = VideoModes[0].height - 1;
+
+	CocoaWindow* const window = [CocoaWindow alloc];
+	[window initWithContentRect:NSMakeRect(0, 0, TEMP_WIDTH, TEMP_HEIGHT)
+					  styleMask:styleMask
+						backing:NSBackingStoreBuffered
+						  defer:NO];
 	[window setOpaque:YES];
 	[window makeFirstResponder:appCtrl];
 	[window setAcceptsMouseMovedEvents:YES];


### PR DESCRIPTION
Fixed a very slim chance that window will be white and empty after startup

There are a few quite specific steps to reproduce this issue:
* 640x480 video resolution
* -iwad ... -warp ... command line parameters
* OS X 10.4 or 10.5 PowerPC, maybe performance related
When all these requirements are met, content view doesn't show up sometimes
The simplest solution for this issue is to set initial window size to non-existent video resolution