### PR TITLE
- Added zero tag handling for Pillar actions.

### DIFF
--- a/src/p_lnspec.cpp
+++ b/src/p_lnspec.cpp
@@ -519,19 +519,19 @@ FUNC(LS_Generic_Stairs)
 FUNC(LS_Pillar_Build)
 // Pillar_Build (tag, speed, height)
 {
-	return EV_DoPillar (DPillar::pillarBuild, arg0, SPEED(arg1), arg2*FRACUNIT, 0, -1, false);
+	return EV_DoPillar (DPillar::pillarBuild, ln, arg0, SPEED(arg1), arg2*FRACUNIT, 0, -1, false);
 }
 
 FUNC(LS_Pillar_BuildAndCrush)
 // Pillar_BuildAndCrush (tag, speed, height, crush, crushtype)
 {
-	return EV_DoPillar (DPillar::pillarBuild, arg0, SPEED(arg1), arg2*FRACUNIT, 0, arg3, CRUSHTYPE(arg4));
+	return EV_DoPillar (DPillar::pillarBuild, ln, arg0, SPEED(arg1), arg2*FRACUNIT, 0, arg3, CRUSHTYPE(arg4));
 }
 
 FUNC(LS_Pillar_Open)
 // Pillar_Open (tag, speed, f_height, c_height)
 {
-	return EV_DoPillar (DPillar::pillarOpen, arg0, SPEED(arg1), arg2*FRACUNIT, arg3*FRACUNIT, -1, false);
+	return EV_DoPillar (DPillar::pillarOpen, ln, arg0, SPEED(arg1), arg2*FRACUNIT, arg3*FRACUNIT, -1, false);
 }
 
 FUNC(LS_Ceiling_LowerByValue)

--- a/src/p_pillar.cpp
+++ b/src/p_pillar.cpp
@@ -212,16 +212,28 @@ DPillar::DPillar (sector_t *sector, EPillar type, fixed_t speed,
 	}
 }
 
-bool EV_DoPillar (DPillar::EPillar type, int tag, fixed_t speed, fixed_t height,
-				  fixed_t height2, int crush, bool hexencrush)
+bool EV_DoPillar (DPillar::EPillar type, line_t *line, int tag,
+				  fixed_t speed, fixed_t height, fixed_t height2, int crush, bool hexencrush)
 {
+	int secnum;
+	sector_t *sec;
 	bool rtn = false;
-	int secnum = -1;
 
-	while ((secnum = P_FindSectorFromTag (tag, secnum)) >= 0)
+	// check if a manual trigger; if so do just the sector on the backside
+	if (tag == 0)
 	{
-		sector_t *sec = &sectors[secnum];
+		if (!line || !(sec = line->backsector))
+			return rtn;
+		secnum = (int)(sec-sectors);
+		goto manual_pillar;
+	}
 
+	secnum = -1;
+	while (tag && (secnum = P_FindSectorFromTag (tag, secnum)) >= 0)
+	{
+		sec = &sectors[secnum];
+
+manual_pillar:
 		if (sec->PlaneMoving(sector_t::floor) || sec->PlaneMoving(sector_t::ceiling))
 			continue;
 

--- a/src/p_spec.h
+++ b/src/p_spec.h
@@ -515,8 +515,8 @@ private:
 	DPillar ();
 };
 
-bool EV_DoPillar (DPillar::EPillar type, int tag, fixed_t speed, fixed_t height,
-				  fixed_t height2, int crush, bool hexencrush);
+bool EV_DoPillar (DPillar::EPillar type, line_t *line, int tag,
+				  fixed_t speed, fixed_t height, fixed_t height2, int crush, bool hexencrush);
 
 //
 // P_DOORS


### PR DESCRIPTION
Pillar actions will refer to the back sector if the tag is set to 0.