### PR TITLE
Extended check for embedded WADs with one special case

### DIFF
--- a/src/resourcefiles/resourcefile.cpp
+++ b/src/resourcefiles/resourcefile.cpp
@@ -150,11 +150,22 @@ void FResourceLump::LumpNameSetup(const char *iname)
 //
 //==========================================================================
 
+static bool IsWadInFolder(const char* const fullName)
+{
+	// Checks a special case when <myfile.wad> was put in
+	// <myfile> directory inside <myfile.zip>
+
+	const FString baseName = ExtractFileBase(fullName);
+	const FString fileName = baseName + '/' + baseName + ".wad";
+
+	return 0 == fileName.CompareNoCase(fullName);
+}
+
 void FResourceLump::CheckEmbedded()
 {
 	// Checks for embedded archives
 	const char *c = strstr(FullName, ".wad");
-	if (c && strlen(c) == 4 && !strchr(FullName, '/'))
+	if (c && strlen(c) == 4 && (!strchr(FullName, '/') || IsWadInFolder(FullName)))
 	{
 		// Mark all embedded WADs
 		Flags |= LUMPF_EMBEDDED;


### PR DESCRIPTION
Added loading of embedded WAD file if `myfile.wad` is placed in `myfile` directory inside `myfile.zip`
This helps with an unpleasant and very annoying fashion to zip a folder instead of just .wad and .txt files.
Recent examples include
Monster Hunter Ltd.: http://www.doomworld.com/idgames/?id=17601 and http://www.doomworld.com/idgames/?id=17625
Hell Awakened 2 Episode 1: http://www.doomworld.com/idgames/?id=17795
Bauhaus: http://www.doomworld.com/idgames/?id=17954