### PR TITLE
- Fixed special interactions not working when damage is 0.

### DIFF
--- a/src/p_interaction.cpp
+++ b/src/p_interaction.cpp
@@ -1065,7 +1065,7 @@ int P_DamageMobj (AActor *target, AActor *inflictor, AActor *source, int damage,
 						return -1;
 				}
 			}
-			if (damage > 0)
+			if (damage >= 0)
 				damage = inflictor->DoSpecialDamage (target, damage, mod);
 
 			if ((damage == -1) && (target->player == NULL)) //This isn't meant for the player.


### PR DESCRIPTION
- This broke things like LoreShot when the initial damage was 0.