### PR TITLE
- Fixed a very old issue with swinging polydoors.

### DIFF
--- a/src/po_man.cpp
+++ b/src/po_man.cpp
@@ -676,7 +676,7 @@ void DPolyDoor::Tick ()
 		break;
 
 	case PODOOR_SWING:
-		if (poly->RotatePolyobj (m_Speed))
+		if (m_Dist <= 0 || poly->RotatePolyobj (m_Speed))
 		{
 			absSpeed = abs (m_Speed);
 			if (m_Dist == -1)


### PR DESCRIPTION
This happened when the polydoor was open. If a mobj blocked the poly door, such that the door could not move from its open position, the poly door could rotate a little bit more than needed, making the door partially closing when the door managed to close later.