### PR TITLE
Improved check for skins and maps in the same WAD

### DIFF
--- a/src/resourcefiles/file_wad.cpp
+++ b/src/resourcefiles/file_wad.cpp
@@ -581,9 +581,18 @@ void FWadFile::SkinHack ()
 				namespc++;
 			}
 		}
-		if (lump->Name[0] == 'M' &&
-			lump->Name[1] == 'A' &&
-			lump->Name[2] == 'P')
+		if ((lump->Name[0] == 'M' &&
+			 lump->Name[1] == 'A' &&
+			 lump->Name[2] == 'P' &&
+			 lump->Name[3] >= '0' && lump->Name[3] <= '9' &&
+			 lump->Name[4] >= '0' && lump->Name[4] <= '9' &&
+			 lump->Name[5] >= '\0')
+			||
+			(lump->Name[0] == 'E' &&
+			 lump->Name[1] >= '0' && lump->Name[1] <= '9' &&
+			 lump->Name[2] == 'M' &&
+			 lump->Name[3] >= '0' && lump->Name[3] <= '9' &&
+			 lump->Name[4] >= '\0'))
 		{
 			hasmap = true;
 		}


### PR DESCRIPTION
The corresponding warning is shown for Doom I mods too. Good example of it is Hyena TC: http://www.doomworld.com/idgames/index.php?file=levels/doom/Ports/megawads/hyena.zip
Reduced chance of false positive for the mentioned warning