### PR TITLE
Remove redundant code in polydoor swing code.

### DIFF
--- a/src/po_man.cpp
+++ b/src/po_man.cpp
@@ -679,10 +679,6 @@ void DPolyDoor::Tick ()
 		if (m_Dist <= 0 || poly->RotatePolyobj (m_Speed))
 		{
 			absSpeed = abs (m_Speed);
-			if (m_Dist == -1)
-			{ // perpetual polyobj
-				return;
-			}
 			m_Dist -= absSpeed;
 			if (m_Dist <= 0)
 			{


### PR DESCRIPTION
'Perpetual' check does not make sense for poly doors.