### PR TITLE
DamageTypeDefinition::Apply's definition didn't match its prototype

### DIFF
--- a/src/info.cpp
+++ b/src/info.cpp
@@ -577,7 +577,7 @@ CCMD (summonfoe)
 
 TMap<FName, DamageTypeDefinition> GlobalDamageDefinitions;
 
-void DamageTypeDefinition::Apply(FName type) 
+void DamageTypeDefinition::Apply(FName const &type) 
 { 
 	GlobalDamageDefinitions[type] = *this; 
 }


### PR DESCRIPTION
was causing an error when i tried to build