### PR TITLE
Added A_QuakeEx(intensity x, y, z, duration, damrad, tremrad, sound, flags)

### DIFF
--- a/src/g_shared/a_sharedglobal.h
+++ b/src/g_shared/a_sharedglobal.h
@@ -131,23 +131,31 @@ protected:
 	DFlashFader ();
 };
 
+enum
+{
+	QF_RELATIVE = 1,
+};
+
 class DEarthquake : public DThinker
 {
 	DECLARE_CLASS (DEarthquake, DThinker)
 	HAS_OBJECT_POINTERS
 public:
-	DEarthquake (AActor *center, int intensity, int duration, int damrad, int tremrad, FSoundID quakesfx);
+	DEarthquake(AActor *center, int intensityX, int intensityY, int intensityZ, int duration, int damrad, int tremrad, FSoundID quakesfx, int flags);
 
 	void Serialize (FArchive &arc);
 	void Tick ();
-
 	TObjPtr<AActor> m_Spot;
 	fixed_t m_TremorRadius, m_DamageRadius;
 	int m_Intensity;
 	int m_Countdown;
 	FSoundID m_QuakeSFX;
+	int m_Flags;
+	int m_iX, m_iY, m_iZ;
 
-	static int StaticGetQuakeIntensity (AActor *viewer);
+	static int StaticGetQuakeFlags(AActor *viewer);
+	static int StaticGetQuakeIntensity (AActor *viewer, int selector);
+	
 
 private:
 	DEarthquake ();

--- a/src/p_spec.h
+++ b/src/p_spec.h
@@ -929,6 +929,7 @@ void P_DoDeferedScripts (void);
 //
 // [RH] p_quake.c
 //
-bool P_StartQuake (AActor *activator, int tid, int intensity, int duration, int damrad, int tremrad, FSoundID quakesfx);
+bool P_StartQuakeXYZ(AActor *activator, int tid, int intensityX, int intensityY, int intensityZ, int duration, int damrad, int tremrad, FSoundID quakesfx, int flags);
+bool P_StartQuake(AActor *activator, int tid, int intensity, int duration, int damrad, int tremrad, FSoundID quakesfx);
 
 #endif

--- a/src/r_utility.cpp
+++ b/src/r_utility.cpp
@@ -875,13 +875,37 @@ void R_SetupFrame (AActor *actor)
 
 	if (!paused)
 	{
-		int intensity = DEarthquake::StaticGetQuakeIntensity (camera);
-		if (intensity != 0)
+		int intensityX = DEarthquake::StaticGetQuakeIntensity(camera, 0);
+		int intensityY = DEarthquake::StaticGetQuakeIntensity(camera, 1);
+		int intensityZ = DEarthquake::StaticGetQuakeIntensity(camera, 2);
+		int quakeflags = DEarthquake::StaticGetQuakeFlags(camera);
+		if (intensityX || intensityY || intensityZ)
 		{
 			fixed_t quakefactor = FLOAT2FIXED(r_quakeintensity);
 
-			viewx += quakefactor * ((pr_torchflicker() % (intensity<<2)) - (intensity<<1));
-			viewy += quakefactor * ((pr_torchflicker() % (intensity<<2)) - (intensity<<1));
+			if ((quakeflags & QF_RELATIVE) && (intensityX != intensityY))
+			{
+				if (intensityX)
+				{
+					int ang = (camera->angle) >> ANGLETOFINESHIFT;
+					int tflicker = pr_torchflicker();
+					viewx += FixedMul(finecosine[ang], (quakefactor * ((tflicker % (intensityX << 2)) - (intensityX << 1))));
+					viewy += FixedMul(finesine[ang], (quakefactor * ((tflicker % (intensityX << 2)) - (intensityX << 1))));
+				}
+				if (intensityY)
+				{
+					int ang = (camera->angle + ANG90) >> ANGLETOFINESHIFT;
+					int tflicker = pr_torchflicker();
+					viewx += FixedMul(finecosine[ang], (quakefactor * ((tflicker % (intensityY << 2)) - (intensityY << 1))));
+					viewy += FixedMul(finesine[ang], (quakefactor * ((tflicker % (intensityY << 2)) - (intensityY << 1))));
+				}
+			}
+			else
+			{
+				if (intensityX)	viewx += quakefactor * ((pr_torchflicker() % (intensityX << 2)) - (intensityX << 1));
+				if (intensityY)	viewy += quakefactor * ((pr_torchflicker() % (intensityY << 2)) - (intensityY << 1));
+			}
+			if (intensityZ)	viewz += quakefactor * ((pr_torchflicker() % (intensityZ << 2)) - (intensityZ << 1));
 		}
 	}
 

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -4405,6 +4405,28 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_Quake)
 
 //===========================================================================
 //
+// A_QuakeEx
+//
+// Extended version of A_Quake. Takes individual axis into account and can
+// take a flag.
+//===========================================================================
+
+DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_QuakeEx)
+{
+	ACTION_PARAM_START(8);
+	ACTION_PARAM_INT(intensityX, 0);
+	ACTION_PARAM_INT(intensityY, 1);
+	ACTION_PARAM_INT(intensityZ, 2);
+	ACTION_PARAM_INT(duration, 3);
+	ACTION_PARAM_INT(damrad, 4);
+	ACTION_PARAM_INT(tremrad, 5);
+	ACTION_PARAM_SOUND(sound, 6);
+	ACTION_PARAM_INT(flags, 7);
+	P_StartQuakeXYZ(self, 0, intensityX, intensityY, intensityZ, duration, damrad, tremrad, sound, flags);
+}
+
+//===========================================================================
+//
 // A_Weave
 //
 //===========================================================================

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -299,6 +299,7 @@ ACTOR Actor native //: Thinker
 	action native A_SetUserArray(name varname, int index, int value);
 	action native A_SetSpecial(int spec, int arg0 = 0, int arg1 = 0, int arg2 = 0, int arg3 = 0, int arg4 = 0);
 	action native A_Quake(int intensity, int duration, int damrad, int tremrad, sound sfx = "world/quake");
+	action native A_QuakeEx(int intensityX, int intensityY, int intensityZ, int duration, int damrad, int tremrad, sound sfx = "world/quake", int flags = 0);
 	action native A_SetTics(int tics);
 	action native A_SetDamageType(name damagetype);
 	action native A_DropItem(class<Actor> item, int dropamount = -1, int chance = 256);

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -457,6 +457,11 @@ enum
 	FAF_NODISTFACTOR = 8,
 };
 
+// Flags for A_QuakeEx
+enum
+{
+	QF_RELATIVE = 1,
+};
 
 // This is only here to provide one global variable for testing.
 native int testglobalvar;


### PR DESCRIPTION
- Unlocks the full potential of using quakes, including the Z axis. Each intensity applies to X/Y/Z planes whenever a player is experiencing it.
- Flags:
- QF_RELATIVE - Adjusts the quaking of the camera to go in the direction its aiming (X: forward/backward. Y: Left/right.)
- Plans for including pitch will be implemented in the future for the Z axis with relativity.