### PR TITLE
- Fixed: relz was never initialized.

### DIFF
--- a/src/g_shared/a_quake.cpp
+++ b/src/g_shared/a_quake.cpp
@@ -158,7 +158,7 @@ int DEarthquake::StaticGetQuakeIntensities(AActor *victim,
 		return 0;
 	}
 
-	x = y = z = relx = rely = 0;
+	x = y = z = relx = rely = relz = 0;
 
 	TThinkerIterator<DEarthquake> iterator(STAT_EARTHQUAKE);
 	DEarthquake *quake;


### PR DESCRIPTION
- This could cause problems in places like the GZDoom renderer in the odd circumstance, causing the camera to become stuck in the floor or ceiling until the quake expires.