### PR TITLE
- Added QF_SCALEUP and QF_MAX.

### DIFF
--- a/src/g_shared/a_quake.cpp
+++ b/src/g_shared/a_quake.cpp
@@ -166,7 +166,7 @@ int DEarthquake::StaticGetQuakeIntensities(AActor *victim, quakeInfo &qprop)
 	{
 		return 0;
 	}
-	qprop.isScalingDown = qprop.isScalingUp = false, qprop.preferMaximum = false;
+	qprop.isScalingDown = qprop.isScalingUp = qprop.preferMaximum = qprop.fullIntensity = false;
 	qprop.intensityX = qprop.intensityY = qprop.intensityZ = qprop.relIntensityX = qprop.relIntensityY = qprop.relIntensityZ = 0;
 
 	TThinkerIterator<DEarthquake> iterator(STAT_EARTHQUAKE);
@@ -201,6 +201,7 @@ int DEarthquake::StaticGetQuakeIntensities(AActor *victim, quakeInfo &qprop)
 					qprop.isScalingDown = (quake->m_Flags & QF_SCALEDOWN) ? true : false;
 					qprop.isScalingUp = (quake->m_Flags & QF_SCALEUP) ? true : false;
 					qprop.preferMaximum = (quake->m_Flags & QF_MAX) ? true : false;
+					qprop.fullIntensity = (quake->m_Flags & QF_FULLINTENSITY) ? true : false;
 				}
 				else
 				{

--- a/src/g_shared/a_quake.cpp
+++ b/src/g_shared/a_quake.cpp
@@ -80,7 +80,6 @@ void DEarthquake::Serialize (FArchive &arc)
 	{
 		arc << m_CountdownStart;
 	}
-	
 }
 
 //==========================================================================
@@ -101,7 +100,7 @@ void DEarthquake::Tick ()
 		Destroy ();
 		return;
 	}
-
+	
 	if (!S_IsActorPlayingSomething (m_Spot, CHAN_BODY, m_QuakeSFX))
 	{
 		S_Sound (m_Spot, CHAN_BODY | CHAN_LOOP, m_QuakeSFX, 1, ATTN_NORM);
@@ -141,6 +140,7 @@ void DEarthquake::Tick ()
 			}
 		}
 	}
+	
 	if (--m_Countdown == 0)
 	{
 		if (S_IsActorPlayingSomething(m_Spot, CHAN_BODY, m_QuakeSFX))
@@ -166,7 +166,7 @@ int DEarthquake::StaticGetQuakeIntensities(AActor *victim, quakeInfo &qprop)
 	{
 		return 0;
 	}
-
+	qprop.isScalingDown = qprop.isScalingUp = false, qprop.preferMaximum = false;
 	qprop.intensityX = qprop.intensityY = qprop.intensityZ = qprop.relIntensityX = qprop.relIntensityY = qprop.relIntensityZ = 0;
 
 	TThinkerIterator<DEarthquake> iterator(STAT_EARTHQUAKE);
@@ -194,10 +194,13 @@ int DEarthquake::StaticGetQuakeIntensities(AActor *victim, quakeInfo &qprop)
 					qprop.intensityY = MAX(qprop.intensityY, quake->m_IntensityY);
 					qprop.intensityZ = MAX(qprop.intensityZ, quake->m_IntensityZ);
 				}
-				if (quake->m_Flags & QF_SCALEDOWN)
+				if (quake->m_Flags)
 				{
 					qprop.scaleDownStart = quake->m_CountdownStart;
 					qprop.scaleDown = quake->m_Countdown;
+					qprop.isScalingDown = (quake->m_Flags & QF_SCALEDOWN) ? true : false;
+					qprop.isScalingUp = (quake->m_Flags & QF_SCALEUP) ? true : false;
+					qprop.preferMaximum = (quake->m_Flags & QF_MAX) ? true : false;
 				}
 				else
 				{

--- a/src/g_shared/a_sharedglobal.h
+++ b/src/g_shared/a_sharedglobal.h
@@ -133,17 +133,18 @@ protected:
 
 enum
 {
-	QF_RELATIVE =	1,
-	QF_SCALEDOWN =	1 << 1,
-	QF_SCALEUP =	1 << 2,
-	QF_MAX =		1 << 3,
+	QF_RELATIVE =		1,
+	QF_SCALEDOWN =		1 << 1,
+	QF_SCALEUP =		1 << 2,
+	QF_MAX =			1 << 3,
+	QF_FULLINTENSITY =	1 << 4,
 };
 
 struct quakeInfo
 {
 	int intensityX, intensityY, intensityZ, relIntensityX, relIntensityY, relIntensityZ;
 	double scaleDown, scaleDownStart;
-	bool isScalingDown, isScalingUp, preferMaximum;
+	bool isScalingDown, isScalingUp, preferMaximum, fullIntensity;
 };
 
 class DEarthquake : public DThinker

--- a/src/g_shared/a_sharedglobal.h
+++ b/src/g_shared/a_sharedglobal.h
@@ -136,12 +136,14 @@ enum
 	QF_RELATIVE =	1,
 	QF_SCALEDOWN =	1 << 1,
 	QF_SCALEUP =	1 << 2,
+	QF_MAX =		1 << 3,
 };
 
 struct quakeInfo
 {
 	int intensityX, intensityY, intensityZ, relIntensityX, relIntensityY, relIntensityZ;
 	double scaleDown, scaleDownStart;
+	bool isScalingDown, isScalingUp, preferMaximum;
 };
 
 class DEarthquake : public DThinker

--- a/src/r_utility.cpp
+++ b/src/r_utility.cpp
@@ -792,7 +792,7 @@ static fixed_t QuakePower(double factor, int intensity, quakeInfo quake)
 				if (quake.preferMaximum)
 					result = FLOAT2FIXED((factor * ss) * MAX((scaleDown / scaleDownStart), (scaleDownStart - scaleDown) / scaleDownStart));
 				else
-					result = FLOAT2FIXED((factor * ss) * MIN((scaleDown / scaleDownStart), (scaleDownStart - scaleDown) / scaleDownStart));
+					result = FLOAT2FIXED((factor * ss) * MIN(((scaleDown*2) / scaleDownStart), ((scaleDownStart - scaleDown)*2) / scaleDownStart));
 			}
 			else if (quake.isScalingDown)
 				result = FLOAT2FIXED((factor * ss) * (scaleDown / scaleDownStart));

--- a/src/r_utility.cpp
+++ b/src/r_utility.cpp
@@ -781,13 +781,31 @@ static fixed_t QuakePower(double factor, int intensity, quakeInfo quake)
 	else
 	{
 		double ss = (double)((pr_torchflicker() % (intensity << 2)) - (intensity << 1));
-		if (scaleDownStart == 0)
+		
+		if (quake.isScalingDown || quake.isScalingUp)
 		{
-			return FLOAT2FIXED(factor * ss);
+			fixed_t result;
+			if (scaleDownStart == 0)	scaleDownStart = 1;
+
+			if (quake.isScalingDown && quake.isScalingUp)
+			{
+				if (quake.preferMaximum)
+					result = FLOAT2FIXED((factor * ss) * MAX((scaleDown / scaleDownStart), (scaleDownStart - scaleDown) / scaleDownStart));
+				else
+					result = FLOAT2FIXED((factor * ss) * MIN((scaleDown / scaleDownStart), (scaleDownStart - scaleDown) / scaleDownStart));
+			}
+			else if (quake.isScalingDown)
+				result = FLOAT2FIXED((factor * ss) * (scaleDown / scaleDownStart));
+			else if (quake.isScalingUp)
+				result = FLOAT2FIXED((factor * ss) * ((scaleDownStart - scaleDown) / scaleDownStart));
+			else
+				result = FLOAT2FIXED(factor * ss);
+
+			return result;
 		}
 		else
 		{
-			return FLOAT2FIXED(((factor * ss) * ((scaleDown / scaleDownStart))));
+			return FLOAT2FIXED(factor * ss);
 		}
 	}
 	

--- a/src/r_utility.cpp
+++ b/src/r_utility.cpp
@@ -781,7 +781,7 @@ static fixed_t QuakePower(double factor, int intensity, quakeInfo quake)
 	else
 	{
 		double ss = (double)((pr_torchflicker() % (intensity << 2)) - (intensity << 1));
-		
+		double mtp = (quake.fullIntensity) ? 2.0 : 1.0;
 		if (quake.isScalingDown || quake.isScalingUp)
 		{
 			fixed_t result;
@@ -790,9 +790,9 @@ static fixed_t QuakePower(double factor, int intensity, quakeInfo quake)
 			if (quake.isScalingDown && quake.isScalingUp)
 			{
 				if (quake.preferMaximum)
-					result = FLOAT2FIXED((factor * ss) * MAX((scaleDown / scaleDownStart), (scaleDownStart - scaleDown) / scaleDownStart));
+					result = FLOAT2FIXED((factor * ss) * MAX(((scaleDown*mtp) / scaleDownStart), ((scaleDownStart - scaleDown)*mtp) / scaleDownStart));
 				else
-					result = FLOAT2FIXED((factor * ss) * MIN(((scaleDown*2) / scaleDownStart), ((scaleDownStart - scaleDown)*2) / scaleDownStart));
+					result = FLOAT2FIXED((factor * ss) * MIN(((scaleDown*mtp) / scaleDownStart), ((scaleDownStart - scaleDown)*mtp) / scaleDownStart));
 			}
 			else if (quake.isScalingDown)
 				result = FLOAT2FIXED((factor * ss) * (scaleDown / scaleDownStart));

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -464,6 +464,7 @@ enum
 	QF_RELATIVE =		1,
 	QF_SCALEDOWN =		1 << 1,
 	QF_SCALEUP =		1 << 2,
+	QF_MAX =			1 << 3,
 };
 
 // This is only here to provide one global variable for testing.

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -465,6 +465,7 @@ enum
 	QF_SCALEDOWN =		1 << 1,
 	QF_SCALEUP =		1 << 2,
 	QF_MAX =			1 << 3,
+	QF_FULLINTENSITY =	1 << 4,
 };
 
 // This is only here to provide one global variable for testing.


### PR DESCRIPTION
- QF_SCALEUP behaves like QF_SCALEDOWN: it gradually scales the tremors, only going upwards.
- QF_SCALEUP and QF_SCALEDOWN can be combined to make an earthquake that gradually smoothes in and out.
- QF_MAX can be used to invert this behavior, where it starts at the peak of the amplitude, fades out half way, and then grows back to maximum.