### PR TITLE
- Fixed build with FMOD 4.40.x-4.42.x.

### DIFF
--- a/src/sound/fmodsound.cpp
+++ b/src/sound/fmodsound.cpp
@@ -198,7 +198,7 @@ static const FEnumList SpeakerModeNames[] =
 	{ "Surround",				FMOD_SPEAKERMODE_SURROUND },
 	{ "5.1",					FMOD_SPEAKERMODE_5POINT1 },
 	{ "7.1",					FMOD_SPEAKERMODE_7POINT1 },
-#if FMOD_VERSION < 0x44400
+#if FMOD_VERSION < 0x44000
 	{ "Prologic",				FMOD_SPEAKERMODE_PROLOGIC },
 #endif
 	{ "1",						FMOD_SPEAKERMODE_MONO },


### PR DESCRIPTION
The 'Prologic' speakermode enumeration is removed since 4.40, not 4.44.
This makes possible to build it on linux x64, as the latest version of FMOD which has the dedicated linux64 download link is 4.42.