### PR TITLE
Added QF_WAVE for A_QuakeEx.

### DIFF
--- a/src/g_shared/a_sharedglobal.h
+++ b/src/g_shared/a_sharedglobal.h
@@ -138,6 +138,7 @@ enum
 	QF_SCALEUP =		1 << 2,
 	QF_MAX =			1 << 3,
 	QF_FULLINTENSITY =	1 << 4,
+	QF_WAVE =			1 << 5,
 };
 
 class DEarthquake : public DThinker
@@ -145,7 +146,8 @@ class DEarthquake : public DThinker
 	DECLARE_CLASS (DEarthquake, DThinker)
 	HAS_OBJECT_POINTERS
 public:
-	DEarthquake(AActor *center, int intensityX, int intensityY, int intensityZ, int duration, int damrad, int tremrad, FSoundID quakesfx, int flags);
+	DEarthquake(AActor *center, int intensityX, int intensityY, int intensityZ, int duration, int damrad, int tremrad, FSoundID quakesfx, int flags, 
+		double m_mulWaveX, double m_mulWaveY, double m_mulWaveZ);
 
 	void Serialize (FArchive &arc);
 	void Tick ();
@@ -156,12 +158,18 @@ public:
 	FSoundID m_QuakeSFX;
 	int m_Flags;
 	int m_IntensityX, m_IntensityY, m_IntensityZ;
+	fixed_t m_mulWaveX, m_mulWaveY, m_mulWaveZ;
 
-	fixed_t GetModIntensity(int intensity) const;
+	fixed_t GetModIntensity(fixed_t intensity, fixed_t time, bool isWave = 0) const;
+	fixed_t GetModWave(fixed_t waveMultiplier, fixed_t time) const;
+	fixed_t GetModCountdown(fixed_t countdown, bool up) const;
 
 	static int StaticGetQuakeIntensities(AActor *viewer,
 		fixed_t &intensityX, fixed_t &intensityY, fixed_t &intensityZ,
-		fixed_t &relIntensityX, fixed_t &relIntensityY, fixed_t &relIntensityZ);
+		fixed_t &relIntensityX, fixed_t &relIntensityY, fixed_t &relIntensityZ, 
+		bool &sineOriented, 
+		fixed_t &mulWaveX, fixed_t &mulWaveY, fixed_t &mulWaveZ, 
+		fixed_t &relmulWaveX, fixed_t &relmulWaveY, fixed_t &relmulWaveZ, int &countdown);
 
 private:
 	DEarthquake ();

--- a/src/p_spec.h
+++ b/src/p_spec.h
@@ -929,7 +929,7 @@ void P_DoDeferedScripts (void);
 //
 // [RH] p_quake.c
 //
-bool P_StartQuakeXYZ(AActor *activator, int tid, int intensityX, int intensityY, int intensityZ, int duration, int damrad, int tremrad, FSoundID quakesfx, int flags);
+bool P_StartQuakeXYZ(AActor *activator, int tid, int intensityX, int intensityY, int intensityZ, int duration, int damrad, int tremrad, FSoundID quakesfx, int flags, double mulWaveX, double mulWaveY, double mulWaveZ);
 bool P_StartQuake(AActor *activator, int tid, int intensity, int duration, int damrad, int tremrad, FSoundID quakesfx);
 
 #endif

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -4419,7 +4419,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_Quake)
 
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_QuakeEx)
 {
-	ACTION_PARAM_START(8);
+	ACTION_PARAM_START(11);
 	ACTION_PARAM_INT(intensityX, 0);
 	ACTION_PARAM_INT(intensityY, 1);
 	ACTION_PARAM_INT(intensityZ, 2);
@@ -4428,7 +4428,10 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_QuakeEx)
 	ACTION_PARAM_INT(tremrad, 5);
 	ACTION_PARAM_SOUND(sound, 6);
 	ACTION_PARAM_INT(flags, 7);
-	P_StartQuakeXYZ(self, 0, intensityX, intensityY, intensityZ, duration, damrad, tremrad, sound, flags);
+	ACTION_PARAM_FLOAT(mulWaveX, 8);
+	ACTION_PARAM_FLOAT(mulWaveY, 9);
+	ACTION_PARAM_FLOAT(mulWaveZ, 10);
+	P_StartQuakeXYZ(self, 0, intensityX, intensityY, intensityZ, duration, damrad, tremrad, sound, flags, mulWaveX, mulWaveY, mulWaveZ);
 }
 
 //===========================================================================

--- a/src/version.h
+++ b/src/version.h
@@ -76,7 +76,7 @@ const char *GetVersionString();
 
 // Use 4500 as the base git save version, since it's higher than the
 // SVN revision ever got.
-#define SAVEVER 4520
+#define SAVEVER 4521
 
 #define SAVEVERSTRINGIFY2(x) #x
 #define SAVEVERSTRINGIFY(x) SAVEVERSTRINGIFY2(x)

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -299,7 +299,7 @@ ACTOR Actor native //: Thinker
 	action native A_SetUserArray(name varname, int index, int value);
 	action native A_SetSpecial(int spec, int arg0 = 0, int arg1 = 0, int arg2 = 0, int arg3 = 0, int arg4 = 0);
 	action native A_Quake(int intensity, int duration, int damrad, int tremrad, sound sfx = "world/quake");
-	action native A_QuakeEx(int intensityX, int intensityY, int intensityZ, int duration, int damrad, int tremrad, sound sfx = "world/quake", int flags = 0);
+	action native A_QuakeEx(int intensityX, int intensityY, int intensityZ, int duration, int damrad, int tremrad, sound sfx = "world/quake", int flags = 0, float mulWaveX = 1, float mulWaveY = 1, float mulWaveZ = 1);
 	action native A_SetTics(int tics);
 	action native A_SetDamageType(name damagetype);
 	action native A_DropItem(class<Actor> item, int dropamount = -1, int chance = 256);

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -466,6 +466,7 @@ enum
 	QF_SCALEUP =		1 << 2,
 	QF_MAX =			1 << 3,
 	QF_FULLINTENSITY =	1 << 4,
+	QF_WAVE =			1 << 5,
 };
 
 // This is only here to provide one global variable for testing.


### PR DESCRIPTION
- Changes the random quakes into a sine wave (see Shadow Warrior/Rise of the Triad reboots, Hard Reset, etc.)
- Added 3 properties to control waves per second along each individual axis. Only works with QF_WAVE.
- Intensity X/Y/Z property becomes the amplitude of the wave.
- Stacks with regular quakes, allowing shaking along the camera which must be called using A_QuakeEx WITHOUT the flag, or the other quaking functions.
- Uses the youngest quake's time for positioning.