### PR TITLE
- Fixed imprecise bound checking in ACS code.

### DIFF
--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -8790,7 +8790,7 @@ scriptwait:
 			break;
 
 		case PCD_PLAYERINGAME:
-			if (STACK(1) < 0 || STACK(1) > MAXPLAYERS)
+			if (STACK(1) < 0 || STACK(1) >= MAXPLAYERS)
 			{
 				STACK(1) = false;
 			}
@@ -8801,7 +8801,7 @@ scriptwait:
 			break;
 
 		case PCD_PLAYERISBOT:
-			if (STACK(1) < 0 || STACK(1) > MAXPLAYERS || !playeringame[STACK(1)])
+			if (STACK(1) < 0 || STACK(1) >= MAXPLAYERS || !playeringame[STACK(1)])
 			{
 				STACK(1) = false;
 			}


### PR DESCRIPTION
It was possible to access 'playeringame[8]', outside the [0:7] buffer range. Discovered with GCC 4.9 + Address Sanitizer.