### PR TITLE
A_FireCustomMissile's useammo parameter should NOT use ammo if not calle...

### DIFF
--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -1337,7 +1337,8 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FireCustomMissile)
 	AWeapon * weapon=player->ReadyWeapon;
 	AActor *linetarget;
 
-	if (UseAmmo && weapon)
+		// Only use ammo if called from a weapon
+	if (UseAmmo && ACTION_CALL_FROM_WEAPON() && weapon)
 	{
 		if (!weapon->DepleteAmmo(weapon->bAltFire, true)) return;	// out of ammo
 	}


### PR DESCRIPTION
...d from a weapon

Resolves http://forum.zdoom.org/viewtopic.php?f=2&t=47149 -- A_FireCustomMissile's documentation states that useammo is irrelevant if used in a custom inventory. Based on previous discussion as well as similar situations (specifically, http://zdoom.org/wiki/A_ThrowGrenade), I corrected the behavior to reflect the documentation.