### PR TITLE
Added -hashfiles command

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -214,6 +214,7 @@ bool autostart;
 FString StoredWarp;
 bool advancedemo;
 FILE *debugfile;
+FILE *hashfile;
 event_t events[MAXEVENTS];
 int eventhead;
 int eventtail;
@@ -2220,6 +2221,26 @@ void D_DoomMain (void)
 		execLogfile(logfile);
 	}
 
+	if (Args->CheckParm("-hashfiles"))
+	{
+		FString filename = "fileinfo.txt";
+		Printf("Hashing loaded content to: %s\n", filename);
+		hashfile = fopen(filename, "w");
+		if (hashfile)
+		{
+			fprintf(hashfile, "%s version %s (%s)\n", GAMENAME, GetVersionString(), GetGitHash());
+#ifdef __VERSION__
+			fprintf(hashfile, "Compiler version: %s\n", __VERSION__);
+#endif
+			fprintf(hashfile, "Command line:");
+			for (int i = 0; i < Args->NumArgs(); ++i)
+			{
+				fprintf(hashfile, " %s", Args->GetArg(i));
+			}
+			fprintf(hashfile, "\n");
+		}
+	}
+
 	D_DoomInit();
 	PClass::StaticInit ();
 	atterm(FinalGC);
@@ -2288,6 +2309,11 @@ void D_DoomMain (void)
 		// Since this function will never leave we must delete this array here manually.
 		pwads.Clear();
 		pwads.ShrinkToFit();
+
+		if (hashfile)
+		{
+			Printf("Notice: File hashing is incredibly verbose. Expect loading files to take much longer then usual.\n");
+		}
 
 		Printf ("W_Init: Init WADfiles.\n");
 		Wads.InitMultipleFiles (allwads);

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -172,6 +172,7 @@ extern	bool	 		playeringame[/*MAXPLAYERS*/];
 
 // File handling stuff.
 extern	FILE*			debugfile;
+extern	FILE*			hashfile;
 
 // if true, load all graphics at level load
 extern	bool	 		precache;


### PR DESCRIPTION
Adds a -hashfiles command that produces an file with a hash of every lump, for the purposes of synchronization diagnostics.