### PR TITLE
Added FPF_TRANSFERPITCH to A_FireCustomMissile

### DIFF
--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -1318,6 +1318,7 @@ enum FP_Flags
 {
 	FPF_AIMATANGLE = 1,
 	FPF_TRANSFERTRANSLATION = 2,
+	FPF_TRANSFERPITCH = 4,
 };
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FireCustomMissile)
 {
@@ -1357,6 +1358,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FireCustomMissile)
 		fixed_t SavedPlayerPitch = self->pitch;
 		self->pitch -= pitch;
 		AActor * misl=P_SpawnPlayerMissile (self, x, y, z, ti, shootangle, &linetarget);
+		if (Flags & FPF_TRANSFERPITCH)	misl->SetPitch(self->pitch, 0);
 		self->pitch = SavedPlayerPitch;
 
 		// automatic handling of seeker missiles

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -181,9 +181,10 @@ const int CPF_NORANDOMPUFFZ = 8;
 const int CPF_NOTURN = 16;
 const int CPF_STEALARMOR = 32;
 
-// Flags for A_CustomMissile
+// Flags for A_FireCustomMissile
 const int FPF_AIMATANGLE = 1;
 const int FPF_TRANSFERTRANSLATION = 2;
+const int FPF_TRANSFERPITCH = 4;
 
 // Flags for A_Teleport
 enum


### PR DESCRIPTION
- Transfers the player's pitch, including the offsetted pitch in the seventh parameter, to the missile for accuracy.