### PR TITLE
Change hashfiles filename string to a C string

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -2223,7 +2223,7 @@ void D_DoomMain (void)
 
 	if (Args->CheckParm("-hashfiles"))
 	{
-		FString filename = "fileinfo.txt";
+		const char *filename = "fileinfo.txt";
 		Printf("Hashing loaded content to: %s\n", filename);
 		hashfile = fopen(filename, "w");
 		if (hashfile)


### PR DESCRIPTION
- It seems some compilers don't like passing FNames to Printf, and this might as well be a C string anyway.