### PR TITLE
- Fixed NODAMAGE being ignored if it was greater than telefrag.

### DIFF
--- a/src/p_interaction.cpp
+++ b/src/p_interaction.cpp
@@ -1119,10 +1119,10 @@ int P_DamageMobj (AActor *target, AActor *inflictor, AActor *source, int damage,
 					return -1;
 				}
 			}
-			if (target->flags5 & MF5_NODAMAGE)
-			{
-				damage = 0;
-			}
+		}
+		if (target->flags5 & MF5_NODAMAGE)
+		{
+			damage = 0;
 		}
 	}
 	if (damage < 0)


### PR DESCRIPTION
It was just one brace too early, meaning it was within the telefrag damage check instead of outside it. This would break behaviors in mods relying on them to block out telefrag+ damage, not just from telestomping (I.e. using A_DamageTarget with a million damage).