### PR TITLE
Fixed crash in lump filtering caused by uninitialized variables

### DIFF
--- a/src/resourcefiles/resourcefile.cpp
+++ b/src/resourcefiles/resourcefile.cpp
@@ -450,6 +450,8 @@ bool FResourceFile::FindPrefixRange(FString filter, void *lumps, size_t lumpsize
 	FResourceLump *lump;
 	int cmp;
 
+	end = start = 0;
+
 	// Pretend that our range starts at 1 instead of 0 so that we can avoid
 	// unsigned overflow if the range starts at the first lump.
 	lumps = (BYTE *)lumps - lumpsize;


### PR DESCRIPTION
Call stack example for crash with Doom 2 IWAD alone:
```
FString::CompareNoCase(this=0x0000002d0143dec0, other=0x00007fff5fbfd490, len=7) const + 23 at zstring.h:279
FResourceFile::FindPrefixRange(this=0x0000608000042a90, filter=(Chars = "filter/"), lumps=0x0000000101857bb0, lumpsize=88, maxlump=4294869567, start=0x00007fff5fbfd4a0, end=0x00007fff5fbfd49c) + 174 at resourcefile.cpp:465  
FResourceFile::JunkLeftoverFilters(this=0x0000608000042a90, lumps=0x0000000101857c08, lumpsize=88, max=4294869567) + 96 at resourcefile.cpp:421
FResourceFile::PostProcessArchive(this=0x0000608000042a90, lumps=0x0000000101857c08, lumpsize=88) + 317 at resourcefile.cpp:351
FZipFile::Open(this=0x0000608000042a90, quiet=false) + 2404 at file_zip.cpp:265
CheckZip(filename=0x0000608000083a7c, file=0x0000608000042af0, quiet=false) + 324 at file_zip.cpp:412
FResourceFile::OpenResourceFile(filename=0x0000608000083a7c, file=0x0000608000042af0, quiet=false) + 244 at resourcefile.cpp:289
FWadCollection::AddFile(this=0x00000001007cc760, filename=0x0000608000083a7c, wadinfo=0x0000608000042af0) + 500 at w_wad.cpp:264
FWadCollection::InitMultipleFiles(this=0x00000001007cc760, filenames=0x00000001006fbb20) + 126 at w_wad.cpp:177
D_DoomMain() + 2094 at d_main.cpp:2322
```
