### PR TITLE
Added control of automatic graphics switching on OS X

### DIFF
--- a/src/posix/cocoa/i_video.mm
+++ b/src/posix/cocoa/i_video.mm
@@ -72,6 +72,11 @@ CUSTOM_CVAR(Bool, fullscreen, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 	setmodeneeded = true;
 }
 
+CUSTOM_CVAR(Bool, vid_autoswitch, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_NOINITCALL)
+{
+	Printf("You must restart " GAMENAME " to apply graphics switching mode\n");
+}
+
 
 RenderBufferOptions rbOpts;
 
@@ -398,6 +403,11 @@ CocoaVideo::CocoaVideo(const int multisample)
 	attributes[i++] = NSOpenGLPixelFormatAttribute(24);
 	attributes[i++] = NSOpenGLPFAStencilSize;
 	attributes[i++] = NSOpenGLPixelFormatAttribute(8);
+
+	if (!vid_autoswitch)
+	{
+		attributes[i++] = NSOpenGLPFAAllowOfflineRenderers;
+	}
 
 	if (multisample)
 	{

--- a/src/posix/osx/zdoom-info.plist
+++ b/src/posix/osx/zdoom-info.plist
@@ -43,5 +43,7 @@
 	</array>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<string>YES</string>
 </dict>
 </plist>


### PR DESCRIPTION
Automatic graphics switching is enabled by default
Set vid_autoswitch CVAR to false to disable it