### PR TITLE
Fixed: missing '=' in conversation ID defs

### DIFF
--- a/wadsrc/static/filter/strifeteaser1/mapinfo/conversationids.txt
+++ b/wadsrc/static/filter/strifeteaser1/mapinfo/conversationids.txt
@@ -1,144 +1,144 @@
 conversationids
 {
-	2 WeaponSmith
-	3 BarKeep
-	4 Armorer
-	5 Medic
-	6 Peasant1
-	7 Peasant2
-	8 Peasant3
-	9 Peasant4
-	10 Peasant5
-	11 Peasant6
-	12 Peasant7
-	13 Peasant8
-	14 Peasant9
-	15 Peasant10
-	16 Peasant11
-	17 Peasant12
-	18 Peasant13
-	19 Peasant14
-	20 Peasant15
-	21 Peasant16
-	22 Peasant17
-	23 Peasant18
-	24 Peasant19
-	25 Peasant20
-	26 Peasant21
-	27 Peasant22
-	37 Beggar1
-	38 Beggar2
-	39 Beggar3
-	40 Beggar4
-	41 Beggar5
-	42 Rebel1
-	43 Rebel2
-	44 Rebel3
-	45 Rebel4
-	46 Rebel5
-	47 Rebel6
-	48 Macil1
-	49 Macil2
-	52 AcolyteTan
-	53 AcolyteRed
-	54 AcolyteRust
-	55 AcolyteGray
-	56 AcolyteDGreen
-	57 AcolyteGold
-	58 AcolyteShadow
-	61 Templar
-	62 Oracle
-	63 Loremaster
-	70 AlienSpectre2
-	94 InquisitorArm
-	121 MedPatch
-	122 MedicalKit
-	123 SurgeryKit
-	124 DegninOre
-	125 MetalArmor
-	126 LeatherArmor
-	129 BaseKey
-	130 GovsKey
-	131 Passcard
-	132 IDBadge
-	133 PrisonKey
-	134 SeveredHand
-	135 Power1Key
-	136 Power2Key
-	137 Power3Key
-	138 GoldKey
-	139 IDCard
-	140 SilverKey
-	141 OracleKey
-	142 MilitaryID
-	143 OrderKey
-	144 WarehouseKey
-	145 BrassKey
-	146 RedCrystalKey
-	147 BlueCrystalKey
-	148 ChapelKey
-	149 CatacombKey
-	150 SecurityKey
-	151 CoreKey
-	152 MaulerKey
-	153 FactoryKey
-	154 MineKey
-	155 NewKey5
-	156 ShadowArmor
-	157 EnvironmentalSuit
-	158 GuardUniform
-	159 OfficersUniform
-	160 StrifeMap
-	161 Coin
-	162 Gold10
-	163 Gold25
-	164 Gold50
-	165 BeldinsRing
-	166 OfferingChalice
-	167 Ear
-	168 Communicator
-	169 Targeter
-	170 HEGrenadeRounds
-	171 PhosphorusGrenadeRounds
-	173 ClipOfBullets
-	174 BoxOfBullets
-	175 MiniMissiles
-	176 CrateOfMissiles
-	177 EnergyPod
-	178 EnergyPack
-	179 PoisonBolts
-	180 ElectricBolts
-	181 AmmoSatchel
-	182 AssaultGun
-	183 AssaultGunStanding
-	184 FlameThrower
-	185 FlameThrowerParts
-	186 MiniMissileLauncher
-	187 Mauler
-	188 StrifeCrossbow
-	189 StrifeGrenadeLauncher
-	190 Sigil1
-	191 Sigil2
-	192 Sigil3
-	193 Sigil4
-	194 Sigil5
-	196 RatBuddy
-	230 DeadCrusader
-	280 AmmoFillup
-	281 HealthFillup
-	282 info
-	283 RaiseAlarm
-	284 OpenDoor222
-	285 CloseDoor222
-	286 PrisonPass
-	287 UpgradeStamina
-	288 UpgradeAccuracy
-	289 InterrogatorReport
-	292 OraclePass
-	293 QuestItem1
-	294 QuestItem2
-	295 QuestItem3
-	296 QuestItem4
-	297 QuestItem5
-	298 QuestItem6
+	2 = WeaponSmith
+	3 = BarKeep
+	4 = Armorer
+	5 = Medic
+	6 = Peasant1
+	7 = Peasant2
+	8 = Peasant3
+	9 = Peasant4
+	10 = Peasant5
+	11 = Peasant6
+	12 = Peasant7
+	13 = Peasant8
+	14 = Peasant9
+	15 = Peasant10
+	16 = Peasant11
+	17 = Peasant12
+	18 = Peasant13
+	19 = Peasant14
+	20 = Peasant15
+	21 = Peasant16
+	22 = Peasant17
+	23 = Peasant18
+	24 = Peasant19
+	25 = Peasant20
+	26 = Peasant21
+	27 = Peasant22
+	37 = Beggar1
+	38 = Beggar2
+	39 = Beggar3
+	40 = Beggar4
+	41 = Beggar5
+	42 = Rebel1
+	43 = Rebel2
+	44 = Rebel3
+	45 = Rebel4
+	46 = Rebel5
+	47 = Rebel6
+	48 = Macil1
+	49 = Macil2
+	52 = AcolyteTan
+	53 = AcolyteRed
+	54 = AcolyteRust
+	55 = AcolyteGray
+	56 = AcolyteDGreen
+	57 = AcolyteGold
+	58 = AcolyteShadow
+	61 = Templar
+	62 = Oracle
+	63 = Loremaster
+	70 = AlienSpectre2
+	94 = InquisitorArm
+	121 = MedPatch
+	122 = MedicalKit
+	123 = SurgeryKit
+	124 = DegninOre
+	125 = MetalArmor
+	126 = LeatherArmor
+	129 = BaseKey
+	130 = GovsKey
+	131 = Passcard
+	132 = IDBadge
+	133 = PrisonKey
+	134 = SeveredHand
+	135 = Power1Key
+	136 = Power2Key
+	137 = Power3Key
+	138 = GoldKey
+	139 = IDCard
+	140 = SilverKey
+	141 = OracleKey
+	142 = MilitaryID
+	143 = OrderKey
+	144 = WarehouseKey
+	145 = BrassKey
+	146 = RedCrystalKey
+	147 = BlueCrystalKey
+	148 = ChapelKey
+	149 = CatacombKey
+	150 = SecurityKey
+	151 = CoreKey
+	152 = MaulerKey
+	153 = FactoryKey
+	154 = MineKey
+	155 = NewKey5
+	156 = ShadowArmor
+	157 = EnvironmentalSuit
+	158 = GuardUniform
+	159 = OfficersUniform
+	160 = StrifeMap
+	161 = Coin
+	162 = Gold10
+	163 = Gold25
+	164 = Gold50
+	165 = BeldinsRing
+	166 = OfferingChalice
+	167 = Ear
+	168 = Communicator
+	169 = Targeter
+	170 = HEGrenadeRounds
+	171 = PhosphorusGrenadeRounds
+	173 = ClipOfBullets
+	174 = BoxOfBullets
+	175 = MiniMissiles
+	176 = CrateOfMissiles
+	177 = EnergyPod
+	178 = EnergyPack
+	179 = PoisonBolts
+	180 = ElectricBolts
+	181 = AmmoSatchel
+	182 = AssaultGun
+	183 = AssaultGunStanding
+	184 = FlameThrower
+	185 = FlameThrowerParts
+	186 = MiniMissileLauncher
+	187 = Mauler
+	188 = StrifeCrossbow
+	189 = StrifeGrenadeLauncher
+	190 = Sigil1
+	191 = Sigil2
+	192 = Sigil3
+	193 = Sigil4
+	194 = Sigil5
+	196 = RatBuddy
+	230 = DeadCrusader
+	280 = AmmoFillup
+	281 = HealthFillup
+	282 = info
+	283 = RaiseAlarm
+	284 = OpenDoor222
+	285 = CloseDoor222
+	286 = PrisonPass
+	287 = UpgradeStamina
+	288 = UpgradeAccuracy
+	289 = InterrogatorReport
+	292 = OraclePass
+	293 = QuestItem1
+	294 = QuestItem2
+	295 = QuestItem3
+	296 = QuestItem4
+	297 = QuestItem5
+	298 = QuestItem6
 }


### PR DESCRIPTION
Conversation ID definitions in strifeteaser1 were missing the equal sign
between the ID and actor class name.