### PR TITLE
- Added A_JumpIfHigherOrLower.

### DIFF
--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -5858,12 +5858,12 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_ResetHealth)
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_JumpIfHigherOrLower)
 {
 	ACTION_PARAM_START(6);
-	ACTION_PARAM_INT(ptr, 0);
-	ACTION_PARAM_STATE(high, 1);
-	ACTION_PARAM_STATE(low, 2);
-	ACTION_PARAM_FIXED(offsethigh, 3);
-	ACTION_PARAM_FIXED(offsetlow, 4);
-	ACTION_PARAM_BOOL(includeHeight, 5);
+	ACTION_PARAM_STATE(high, 0);
+	ACTION_PARAM_STATE(low, 1);
+	ACTION_PARAM_FIXED(offsethigh, 2);
+	ACTION_PARAM_FIXED(offsetlow, 3);
+	ACTION_PARAM_BOOL(includeHeight, 4);
+	ACTION_PARAM_INT(ptr, 5);
 
 	AActor *mobj = COPY_AAPTR(self, ptr);
 

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -5845,6 +5845,43 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_ResetHealth)
 }
 
 //===========================================================================
+// A_JumpIfHigherOrLower
+//
+// Jumps if a target, master, or tracer is higher or lower than the calling 
+// actor. Can also specify how much higher/lower the actor needs to be than 
+// itself. Can also take into account the height of the actor in question,
+// depending on which it's checking. This means adding height of the
+// calling actor's self if the pointer is higher, or height of the pointer 
+// if its lower.
+//===========================================================================
+
+DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_JumpIfHigherOrLower)
+{
+	ACTION_PARAM_START(6);
+	ACTION_PARAM_INT(ptr, 0);
+	ACTION_PARAM_STATE(high, 1);
+	ACTION_PARAM_STATE(low, 2);
+	ACTION_PARAM_FIXED(offsethigh, 3);
+	ACTION_PARAM_FIXED(offsetlow, 4);
+	ACTION_PARAM_BOOL(includeHeight, 5);
+
+	AActor *mobj = COPY_AAPTR(self, ptr);
+
+
+	if (!mobj || (mobj == self)) //AAPTR_DEFAULT is completely useless in this regard.
+	{
+		return;
+	}
+	ACTION_SET_RESULT(false); //No inventory jump chains please.
+
+	if ((high) && (mobj->z > ((includeHeight ? self->height : 0) + self->z + offsethigh)))
+		ACTION_JUMP(high);
+	else if ((low) && (mobj->z + (includeHeight ? mobj->height : 0)) < (self->z + offsetlow))
+		ACTION_JUMP(low);
+}
+
+
+//===========================================================================
 //
 // A_SetRipperLevel(int level)
 //

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -330,6 +330,7 @@ ACTOR Actor native //: Thinker
 	action native A_SetFloatBobPhase(int bob);
 	action native A_SetHealth(int health, int ptr = AAPTR_DEFAULT);
 	action native A_ResetHealth(int ptr = AAPTR_DEFAULT);
+	action native A_JumpIfHigherOrLower(int ptr = AAPTR_TARGET, state high, state low, float offsethigh = 0, float offsetlow = 0, bool includeHeight = true);
 	action native A_SetRipperLevel(int level);
 	action native A_SetRipMin(int min);
 	action native A_SetRipMax(int max);

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -330,7 +330,7 @@ ACTOR Actor native //: Thinker
 	action native A_SetFloatBobPhase(int bob);
 	action native A_SetHealth(int health, int ptr = AAPTR_DEFAULT);
 	action native A_ResetHealth(int ptr = AAPTR_DEFAULT);
-	action native A_JumpIfHigherOrLower(int ptr = AAPTR_TARGET, state high, state low, float offsethigh = 0, float offsetlow = 0, bool includeHeight = true);
+	action native A_JumpIfHigherOrLower(state high, state low, float offsethigh = 0, float offsetlow = 0, bool includeHeight = true, int ptr = AAPTR_TARGET);
 	action native A_SetRipperLevel(int level);
 	action native A_SetRipMin(int min);
 	action native A_SetRipMax(int max);


### PR DESCRIPTION
- (state high, state low, float offsethigh = 0, float offsetlow = 0, bool includeHeight = true, int ptr = AAPTR_TARGET)
- Jumps if the pointer of the calling actor is higher or lower than itself, adding (or subtracting) offsethigh or offsetlow to it.
- includeHeight works twofold.
- Includes the height of the calling actor if the pointer is higher to truly determine if they are completely above them or not.
- Includes the height of the pointer if the pointer is lower.
- Disable it to only check z differences without adding height.