### PR TITLE
- Added TF_OVERRIDE to A_Teleport.

### DIFF
--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -4249,6 +4249,7 @@ enum T_Flags
 	TF_NODESTFOG =		0x00000080, // Don't spawn any fog at the arrival position.
 	TF_USEACTORFOG =	0x00000100, // Use the actor's TeleFogSourceType and TeleFogDestType fogs.
 	TF_NOJUMP =			0x00000200, // Don't jump after teleporting.
+	TF_OVERRIDE =		0x00000400, // Ignore NOTELEPORT.
 };
 
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_Teleport)
@@ -4270,8 +4271,11 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_Teleport)
 		return;
 	}
 
-	if (ref->flags2 & MF2_NOTELEPORT)
+	if ((ref->flags2 & MF2_NOTELEPORT) && !(Flags & TF_OVERRIDE))
+	{
+		ACTION_SET_RESULT(false);
 		return;
+	}
 
 	// Randomly choose not to teleport like A_Srcr2Decide.
 	if (Flags & TF_RANDOMDECIDE)
@@ -4292,15 +4296,21 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_Teleport)
 	}
 
 	DSpotState *state = DSpotState::GetSpotState();
-	if (state == NULL) 
+	if (state == NULL)
+	{
+		ACTION_SET_RESULT(false);
 		return;
+	}
 
 	if (!TargetType) 
 		TargetType = PClass::FindClass("BossSpot");
 
 	AActor * spot = state->GetSpotWithMinMaxDistance(TargetType, ref->x, ref->y, MinDist, MaxDist);
 	if (spot == NULL) 
+	{
+		ACTION_SET_RESULT(false);
 		return;
+	}
 
 	fixed_t prevX = ref->x;
 	fixed_t prevY = ref->y;

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -199,6 +199,7 @@ enum
 	TF_NODESTFOG =		0x00000080, // Don't spawn any fog at the arrival position.
 	TF_USEACTORFOG =	0x00000100, // Use the actor's TeleFogSourceType and TeleFogDestType fogs.
 	TF_NOJUMP =			0x00000200, // Don't jump after teleporting.
+	TF_OVERRIDE =		0x00000400, // Ignore NOTELEPORT.
 
 	TF_KEEPORIENTATION = TF_KEEPVELOCITY|TF_KEEPANGLE,
 	TF_NOFOG = TF_NOSRCFOG|TF_NODESTFOG,


### PR DESCRIPTION
- Overrides the NOTELEPORT flag so actors with velocity don't need to disable it in order to perform A_Teleport, which could be screwed up by a teleporting line or sudden ACS interference.
- Ensure that the result is set to false if it fails prematurely. Wasn't sure if this was needed, but with the upcoming if/else statements, better safe than sorry.