### PR TITLE
LookupLevelName fix

### DIFF
--- a/src/g_mapinfo.cpp
+++ b/src/g_mapinfo.cpp
@@ -314,10 +314,11 @@ FString level_info_t::LookupLevelName()
 			}
 			else
 			{
+				// make sure nothing is stripped.
 				checkstring[0] = '\0';
 			}
 			thename = strstr (lookedup, checkstring);
-			if (thename == NULL)
+			if (thename == NULL || thename == lookedup)
 			{
 				thename = lookedup;
 			}

--- a/src/g_mapinfo.cpp
+++ b/src/g_mapinfo.cpp
@@ -312,6 +312,10 @@ FString level_info_t::LookupLevelName()
 			{
 				mysnprintf (checkstring, countof(checkstring), "%d: ", atoi(&MapName[5]));
 			}
+			else
+			{
+				checkstring[0] = '\0';
+			}
 			thename = strstr (lookedup, checkstring);
 			if (thename == NULL)
 			{


### PR DESCRIPTION
If the map name neither matched 'ExMy', 'MAPxy' or 'LEVELxy', 'checkstring' was left uninitialized before using as argument to 'strstr', leading to undefined results.

Spotted with Valgrind.