### PR TITLE
- Fixed missing restrictions on non-weapons.

### DIFF
--- a/src/g_doom/a_doomweaps.cpp
+++ b/src/g_doom/a_doomweaps.cpp
@@ -36,7 +36,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_Punch)
 	if (self->player != NULL)
 	{
 		AWeapon *weapon = self->player->ReadyWeapon;
-		if (weapon != NULL && !(weapon->WeaponFlags & WIF_DEHAMMO))
+		if (ACTION_CALL_FROM_WEAPON() && weapon != NULL && !(weapon->WeaponFlags & WIF_DEHAMMO))
 		{
 			if (!weapon->DepleteAmmo (weapon->bAltFire))
 				return;
@@ -76,7 +76,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FirePistol)
 	if (self->player != NULL)
 	{
 		AWeapon *weapon = self->player->ReadyWeapon;
-		if (weapon != NULL)
+		if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 		{
 			if (!weapon->DepleteAmmo (weapon->bAltFire, true, 1))
 				return;
@@ -151,7 +151,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_Saw)
 	slope = P_AimLineAttack (self, angle, Range, &linetarget) + (pr_saw.Random2() * (Spread_Z / 255));
 
 	AWeapon *weapon = self->player->ReadyWeapon;
-	if ((weapon != NULL) && !(Flags & SF_NOUSEAMMO) && !(!linetarget && (Flags & SF_NOUSEAMMOMISS)) && !(weapon->WeaponFlags & WIF_DEHAMMO))
+	if (ACTION_CALL_FROM_WEAPON() && (weapon != NULL) && !(Flags & SF_NOUSEAMMO) && !(!linetarget && (Flags & SF_NOUSEAMMOMISS)) && !(weapon->WeaponFlags & WIF_DEHAMMO))
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;
@@ -254,7 +254,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FireShotgun)
 
 	S_Sound (self, CHAN_WEAPON,  "weapons/shotgf", 1, ATTN_NORM);
 	AWeapon *weapon = self->player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire, true, 1))
 			return;
@@ -285,7 +285,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FireShotgun2)
 
 	S_Sound (self, CHAN_WEAPON, "weapons/sshotf", 1, ATTN_NORM);
 	AWeapon *weapon = self->player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire, true, 2))
 			return;
@@ -394,7 +394,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FireCGun)
 	}
 
 	AWeapon *weapon = player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire, true, 1))
 			return;
@@ -435,7 +435,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FireMissile)
 		return;
 	}
 	AWeapon *weapon = self->player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire, true, 1))
 			return;
@@ -458,7 +458,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FireSTGrenade)
 		return;
 	}
 	AWeapon *weapon = self->player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;
@@ -483,7 +483,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FirePlasma)
 		return;
 	}
 	AWeapon *weapon = self->player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire, true, 1))
 			return;
@@ -501,7 +501,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FirePlasma)
 //
 // [RH] A_FireRailgun
 //
-static void FireRailgun(AActor *self, int offset_xy)
+static void FireRailgun(int offset_xy, DECLARE_PARAMINFO)
 {
 	int damage;
 	player_t *player;
@@ -512,7 +512,7 @@ static void FireRailgun(AActor *self, int offset_xy)
 	}
 
 	AWeapon *weapon = self->player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire, true, 1))
 			return;
@@ -532,17 +532,17 @@ static void FireRailgun(AActor *self, int offset_xy)
 
 DEFINE_ACTION_FUNCTION(AActor, A_FireRailgun)
 {
-	FireRailgun(self, 0);
+	FireRailgun(0, PUSH_PARAMINFO);
 }
 
 DEFINE_ACTION_FUNCTION(AActor, A_FireRailgunRight)
 {
-	FireRailgun(self, 10);
+	FireRailgun(10, PUSH_PARAMINFO);
 }
 
 DEFINE_ACTION_FUNCTION(AActor, A_FireRailgunLeft)
 {
-	FireRailgun(self, -10);
+	FireRailgun(-10, PUSH_PARAMINFO);
 }
 
 DEFINE_ACTION_FUNCTION(AActor, A_RailWait)
@@ -564,7 +564,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FireBFG)
 	}
 
 	AWeapon *weapon = self->player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire, true, deh.BFGCells))
 			return;
@@ -683,7 +683,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FireOldBFG)
 	}
 
 	AWeapon *weapon = self->player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire, true, 1))
 			return;

--- a/src/g_heretic/a_hereticweaps.cpp
+++ b/src/g_heretic/a_hereticweaps.cpp
@@ -76,7 +76,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_StaffAttack)
 	ACTION_PARAM_CLASS(puff, 1);
 
 	AWeapon *weapon = player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;
@@ -114,7 +114,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FireGoldWandPL1)
 	}
 
 	AWeapon *weapon = player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;
@@ -150,7 +150,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FireGoldWandPL2)
 	}
 
 	AWeapon *weapon = player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;
@@ -186,7 +186,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FireCrossbowPL1)
 	}
 
 	AWeapon *weapon = player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;
@@ -212,7 +212,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FireCrossbowPL2)
 	}
 
 	AWeapon *weapon = self->player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;
@@ -251,7 +251,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_GauntletAttack)
 	ACTION_PARAM_INT(power, 0);
 
 	AWeapon *weapon = player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;
@@ -367,36 +367,36 @@ int AMaceFX4::DoSpecialDamage (AActor *target, int damage, FName damagetype)
 //
 //----------------------------------------------------------------------------
 
-void FireMacePL1B (AActor *actor)
+static void FireMacePL1B (DECLARE_PARAMINFO)
 {
 	AActor *ball;
 	angle_t angle;
 	player_t *player;
 
-	if (NULL == (player = actor->player))
+	if (NULL == (player = self->player))
 	{
 		return;
 	}
 
 	AWeapon *weapon = player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;
 	}
-	ball = Spawn("MaceFX2", actor->x, actor->y, actor->z + 28*FRACUNIT 
-		- actor->floorclip, ALLOW_REPLACE);
+	ball = Spawn("MaceFX2", self->x, self->y, self->z + 28*FRACUNIT 
+		- self->floorclip, ALLOW_REPLACE);
 	ball->velz = 2*FRACUNIT+/*((player->lookdir)<<(FRACBITS-5))*/
-		finetangent[FINEANGLES/4-(actor->pitch>>ANGLETOFINESHIFT)];
-	angle = actor->angle;
-	ball->target = actor;
+		finetangent[FINEANGLES/4-(self->pitch>>ANGLETOFINESHIFT)];
+	angle = self->angle;
+	ball->target = self;
 	ball->angle = angle;
-	ball->z += 2*finetangent[FINEANGLES/4-(actor->pitch>>ANGLETOFINESHIFT)];
+	ball->z += 2*finetangent[FINEANGLES/4-(self->pitch>>ANGLETOFINESHIFT)];
 	angle >>= ANGLETOFINESHIFT;
-	ball->velx = (actor->velx>>1) + FixedMul(ball->Speed, finecosine[angle]);
-	ball->vely = (actor->vely>>1) + FixedMul(ball->Speed, finesine[angle]);
+	ball->velx = (self->velx>>1) + FixedMul(ball->Speed, finecosine[angle]);
+	ball->vely = (self->vely>>1) + FixedMul(ball->Speed, finesine[angle]);
 	S_Sound (ball, CHAN_BODY, "weapons/maceshoot", 1, ATTN_NORM);
-	P_CheckMissileSpawn (ball, actor->radius);
+	P_CheckMissileSpawn (ball, self->radius);
 }
 
 //----------------------------------------------------------------------------
@@ -417,11 +417,11 @@ DEFINE_ACTION_FUNCTION(AActor, A_FireMacePL1)
 
 	if (pr_maceatk() < 28)
 	{
-		FireMacePL1B (self);
+		FireMacePL1B (PUSH_PARAMINFO);
 		return;
 	}
 	AWeapon *weapon = player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;
@@ -579,7 +579,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FireMacePL2)
 	}
 
 	AWeapon *weapon = player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;
@@ -773,7 +773,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FireBlasterPL1)
 	}
 
 	AWeapon *weapon = self->player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;
@@ -893,7 +893,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FireSkullRodPL1)
 	}
 
 	AWeapon *weapon = player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;
@@ -926,7 +926,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FireSkullRodPL2)
 		return;
 	}
 	AWeapon *weapon = player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;
@@ -1208,7 +1208,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FirePhoenixPL1)
 	}
 
 	AWeapon *weapon = self->player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;
@@ -1334,7 +1334,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_ShutdownPhoenixPL2)
 	}
 	S_StopSound (self, CHAN_WEAPON);
 	AWeapon *weapon = player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;

--- a/src/g_hexen/a_blastradius.cpp
+++ b/src/g_hexen/a_blastradius.cpp
@@ -111,7 +111,7 @@ DEFINE_ACTION_FUNCTION_PARAMS (AActor, A_Blast)
 	if (self->player && (blastflags & BF_USEAMMO))
 	{
 		AWeapon * weapon = self->player->ReadyWeapon;
-		if (!weapon->DepleteAmmo(weapon->bAltFire))
+		if (ACTION_CALL_FROM_WEAPON() && weapon && !weapon->DepleteAmmo(weapon->bAltFire))
 			return;
 	}
 

--- a/src/g_hexen/a_clericflame.cpp
+++ b/src/g_hexen/a_clericflame.cpp
@@ -76,7 +76,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_CFlameAttack)
 		return;
 	}
 	AWeapon *weapon = self->player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;

--- a/src/g_hexen/a_clericholy.cpp
+++ b/src/g_hexen/a_clericholy.cpp
@@ -215,7 +215,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_CHolyAttack)
 		return;
 	}
 	ACWeapWraithverge *weapon = static_cast<ACWeapWraithverge *> (self->player->ReadyWeapon);
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;

--- a/src/g_hexen/a_clericstaff.cpp
+++ b/src/g_hexen/a_clericstaff.cpp
@@ -89,7 +89,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_CStaffCheck)
 						if (newstate != NULL) P_SetPsprite(player, ps_weapon, newstate);
 					}
 				}
-				if (weapon != NULL)
+				if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 				{
 					weapon->DepleteAmmo (weapon->bAltFire, false);
 				}
@@ -111,7 +111,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_CStaffCheck)
 					pmo->health = player->health = newLife;
 					P_SetPsprite (player, ps_weapon, weapon->FindState ("Drain"));
 				}
-				if (weapon != NULL)
+				if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 				{
 					weapon->DepleteAmmo (weapon->bAltFire, false);
 				}
@@ -138,7 +138,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_CStaffAttack)
 	}
 
 	AWeapon *weapon = self->player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;

--- a/src/g_hexen/a_fighteraxe.cpp
+++ b/src/g_hexen/a_fighteraxe.cpp
@@ -263,7 +263,7 @@ axedone:
 	if (useMana == 2)
 	{
 		AWeapon *weapon = player->ReadyWeapon;
-		if (weapon != NULL)
+		if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 		{
 			weapon->DepleteAmmo (weapon->bAltFire, false);
 

--- a/src/g_hexen/a_fighterhammer.cpp
+++ b/src/g_hexen/a_fighterhammer.cpp
@@ -121,7 +121,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FHammerThrow)
 		return;
 	}
 	AWeapon *weapon = player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire, false))
 			return;

--- a/src/g_hexen/a_fighterquietus.cpp
+++ b/src/g_hexen/a_fighterquietus.cpp
@@ -87,7 +87,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FSwordAttack)
 		return;
 	}
 	AWeapon *weapon = self->player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;

--- a/src/g_hexen/a_magecone.cpp
+++ b/src/g_hexen/a_magecone.cpp
@@ -66,7 +66,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FireConePL1)
 	}
 
 	AWeapon *weapon = self->player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;

--- a/src/g_hexen/a_magelightning.cpp
+++ b/src/g_hexen/a_magelightning.cpp
@@ -285,7 +285,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_MLightningAttack)
 	if (self->player != NULL)
 	{
 		AWeapon *weapon = self->player->ReadyWeapon;
-		if (weapon != NULL)
+		if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 		{
 			weapon->DepleteAmmo (weapon->bAltFire);
 		}

--- a/src/g_hexen/a_magestaff.cpp
+++ b/src/g_hexen/a_magestaff.cpp
@@ -129,7 +129,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_MStaffAttack)
 	}
 
 	AMWeapBloodscourge *weapon = static_cast<AMWeapBloodscourge *> (self->player->ReadyWeapon);
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;

--- a/src/g_strife/a_strifeweapons.cpp
+++ b/src/g_strife/a_strifeweapons.cpp
@@ -250,7 +250,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FireArrow)
 		return;
 
 	AWeapon *weapon = self->player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;
@@ -306,7 +306,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FireAssaultGun)
 	if (self->player != NULL)
 	{
 		AWeapon *weapon = self->player->ReadyWeapon;
-		if (weapon != NULL)
+		if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 		{
 			if (!weapon->DepleteAmmo (weapon->bAltFire))
 				return;
@@ -339,7 +339,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FireMiniMissile)
 		return;
 
 	AWeapon *weapon = self->player->ReadyWeapon;
-	if (weapon != NULL)
+	if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 	{
 		if (!weapon->DepleteAmmo (weapon->bAltFire))
 			return;
@@ -398,7 +398,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FireFlamer)
 	if (player != NULL)
 	{
 		AWeapon *weapon = self->player->ReadyWeapon;
-		if (weapon != NULL)
+		if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 		{
 			if (!weapon->DepleteAmmo (weapon->bAltFire))
 				return;
@@ -430,7 +430,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FireMauler1)
 	if (self->player != NULL)
 	{
 		AWeapon *weapon = self->player->ReadyWeapon;
-		if (weapon != NULL)
+		if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 		{
 			if (!weapon->DepleteAmmo (weapon->bAltFire))
 				return;
@@ -490,7 +490,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FireMauler2)
 	if (self->player != NULL)
 	{
 		AWeapon *weapon = self->player->ReadyWeapon;
-		if (weapon != NULL)
+		if (ACTION_CALL_FROM_WEAPON() && weapon != NULL)
 		{
 			if (!weapon->DepleteAmmo (weapon->bAltFire))
 				return;
@@ -673,7 +673,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FireGrenade)
 	if ((weapon = player->ReadyWeapon) == NULL)
 		return;
 
-	if (!weapon->DepleteAmmo (weapon->bAltFire))
+	if (ACTION_CALL_FROM_WEAPON() && !weapon->DepleteAmmo (weapon->bAltFire))
 		return;
 
 	P_SetPsprite (player, ps_flash, flash);

--- a/src/thingdef/thingdef.h
+++ b/src/thingdef/thingdef.h
@@ -373,16 +373,16 @@ struct StateCallData
 
 // Macros to handle action functions. These are here so that I don't have to
 // change every single use in case the parameters change.
-#define DECLARE_ACTION(name) void AF_##name(AActor *self, AActor *stateowner, FState *, int, StateCallData *);
-#define DECLARE_ACTION_PARAMS(name) void AFP_##name(AActor *self, AActor *stateowner, FState *, int, StateCallData *);
+#define DECLARE_ACTION(name) void AF_##name(AActor *self, AActor *stateowner, FState *CallingState, int ParameterIndex, StateCallData *);
+#define DECLARE_ACTION_PARAMS(name) void AFP_##name(AActor *self, AActor *stateowner, FState *CallingState, int ParameterIndex, StateCallData *);
 
 // This distinction is here so that CALL_ACTION produces errors when trying to
 // access a function that requires parameters.
 #define DEFINE_ACTION_FUNCTION(cls, name) \
-	void AF_##name (AActor *self, AActor *stateowner, FState *, int, StateCallData *); \
+	void AF_##name (AActor *self, AActor *stateowner, FState *CallingState, int ParameterIndex, StateCallData *); \
 	static AFuncDesc info_##cls##_##name = { #name, AF_##name }; \
 	MSVC_ASEG AFuncDesc *infoptr_##cls##_##name GCC_ASEG = &info_##cls##_##name; \
-	void AF_##name (AActor *self, AActor *stateowner, FState *, int, StateCallData *statecall)
+	void AF_##name (AActor *self, AActor *stateowner, FState *CallingState, int ParameterIndex, StateCallData *statecall)
 
 #define DEFINE_ACTION_FUNCTION_PARAMS(cls, name) \
 	void AFP_##name (AActor *self, AActor *stateowner, FState *CallingState, int ParameterIndex, StateCallData *statecall); \

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -1252,7 +1252,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FireBullets)
 	int bslope = 0;
 	int laflags = (Flags & FBF_NORANDOMPUFFZ)? LAF_NORANDOMPUFFZ : 0;
 
-	if ((Flags & FBF_USEAMMO) && weapon)
+	if ((Flags & FBF_USEAMMO) && ACTION_CALL_FROM_WEAPON() && weapon)
 	{
 		if (!weapon->DepleteAmmo(weapon->bAltFire, true)) return;	// out of ammo
 	}
@@ -1338,7 +1338,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FireCustomMissile)
 	AWeapon * weapon=player->ReadyWeapon;
 	AActor *linetarget;
 
-		// Only use ammo if called from a weapon
+	// Only use ammo if called from a weapon
 	if (UseAmmo && ACTION_CALL_FROM_WEAPON() && weapon)
 	{
 		if (!weapon->DepleteAmmo(weapon->bAltFire, true)) return;	// out of ammo
@@ -1429,7 +1429,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_CustomPunch)
 	pitch = P_AimLineAttack (self, angle, Range, &linetarget);
 
 	// only use ammo when actually hitting something!
-	if ((flags & CPF_USEAMMO) && linetarget && weapon)
+	if ((flags & CPF_USEAMMO) && ACTION_CALL_FROM_WEAPON() && linetarget && weapon)
 	{
 		if (!weapon->DepleteAmmo(weapon->bAltFire, true)) return;	// out of ammo
 	}
@@ -1522,7 +1522,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_RailAttack)
 	AWeapon * weapon=self->player->ReadyWeapon;
 
 	// only use ammo when actually hitting something!
-	if (UseAmmo)
+	if (UseAmmo && ACTION_CALL_FROM_WEAPON() && weapon)
 	{
 		if (!weapon->DepleteAmmo(weapon->bAltFire, true)) return;	// out of ammo
 	}


### PR DESCRIPTION
Don't allow non-weapons to use the current ready weapon's ammo at all when using weapon-exclusive Decorate function pointers!