### PR TITLE
- Enhancements for ripper levels based on randi's suggestions.

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -609,8 +609,7 @@ extern FDropItemPtrArray DropItemList;
 
 void FreeDropItemChain(FDropItem *chain);
 int StoreDropItemChain(FDropItem *chain);
-
-
+typedef TMap<FName, bool> RipList;
 
 // Map Object definition.
 class AActor : public DThinker
@@ -868,6 +867,8 @@ public:
 	// Triggers SECSPAC_Exit/SECSPAC_Enter and related events if oldsec != current sector
 	void CheckSectorTransition(sector_t *oldsec);
 
+	void SetRipDenial(FName type, bool deny);
+
 // info for drawing
 // NOTE: The first member variable *must* be x.
 	fixed_t	 		x,y,z;
@@ -1030,6 +1031,8 @@ public:
 	int RipperLevel;
 	int RipLevelMin;
 	int RipLevelMax;
+	FNameNoInit RipType;	
+	RipList *DeniedRips;
 
 	FState *SpawnState;
 	FState *SeeState;
@@ -1159,6 +1162,23 @@ public:
 		} while (actor && !actor->IsKindOf (type));
 		return actor;
 	}
+};
+
+struct RipperDenyDefinition
+{
+public:
+	RipperDenyDefinition() { Clear(); }
+
+	bool DenyRipperType;
+
+	void Apply(FName const type);
+	void Clear()
+	{
+		DenyRipperType = false;
+	}
+
+	static RipperDenyDefinition *Get(FName const type);
+	static bool IsTypeDeniedRip(FName const type, RipList * list);
 };
 
 bool P_IsTIDUsed(int tid);

--- a/src/dobjtype.cpp
+++ b/src/dobjtype.cpp
@@ -139,6 +139,11 @@ void PClass::StaticFreeData (PClass *type)
 {
 	if (type->Defaults != NULL)
 	{
+		if (((AActor*)(type->Defaults))->DeniedRips)
+		{
+			delete ((AActor*)(type->Defaults))->DeniedRips;
+			((AActor*)(type->Defaults))->DeniedRips = NULL;
+		}
 		M_Free(type->Defaults);
 		type->Defaults = NULL;
 	}

--- a/src/gi.cpp
+++ b/src/gi.cpp
@@ -354,7 +354,9 @@ void FMapInfoParser::ParseGameInfo()
 		GAMEINFOKEY_PATCH(mStatscreenFinishedFont, "statscreen_finishedpatch")
 		GAMEINFOKEY_PATCH(mStatscreenEnteringFont, "statscreen_enteringpatch")
 		GAMEINFOKEY_BOOL(norandomplayerclass, "norandomplayerclass")
-
+		GAMEINFOKEY_INT(RipperLevel, "ripperlevel")
+		GAMEINFOKEY_INT(RipLevelMin, "riplevelmin")
+		GAMEINFOKEY_INT(RipLevelMax, "riplevelmax")
 		else
 		{
 			// ignore unkown keys.

--- a/src/gi.h
+++ b/src/gi.h
@@ -173,6 +173,9 @@ struct gameinfo_t
 	FGIFont mStatscreenFinishedFont;
 	FGIFont mStatscreenEnteringFont;
 	bool norandomplayerclass;
+	int RipperLevel;
+	int RipLevelMin;
+	int RipLevelMax;
 
 	const char *GetFinalePage(unsigned int num) const;
 };

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -898,8 +898,15 @@ bool PIT_CheckLine(line_t *ld, const FBoundingBox &box, FCheckPosition &tm)
 
 static bool CheckRipLevel(AActor *victim, AActor *projectile)
 {
-	if (victim->RipLevelMin > 0 && projectile->RipperLevel < victim->RipLevelMin) return false;
-	if (victim->RipLevelMax > 0 && projectile->RipperLevel > victim->RipLevelMax) return false;
+	RipList *v = victim->DeniedRips;
+	FName prtype = projectile->RipType;
+	bool denied = false;
+
+	denied = !!(RipperDenyDefinition::IsTypeDeniedRip(prtype, v)); //If there's no type denial, check the ripper levels next.
+
+	if (denied) return false;
+	if ((victim->RipLevelMin > 0) && (projectile->RipperLevel < victim->RipLevelMin)) return false;
+	if ((victim->RipLevelMax > 0) && (projectile->RipperLevel > victim->RipLevelMax)) return false;
 	return true;
 }
 

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -344,6 +344,10 @@ void AActor::Serialize (FArchive &arc)
 			<< RipLevelMin
 			<< RipLevelMax;
 	}
+	if (SaveVersion >= 4524)
+	{
+		arc << RipType;
+	}
 
 	{
 		FString tagstr;
@@ -3151,6 +3155,53 @@ void AActor::SetRoll(angle_t r, bool interpolate)
 	}
 }
 
+void AActor::SetRipDenial(FName type, bool deny)
+{
+	if (DeniedRips == NULL)
+	{
+		DeniedRips = new RipList;
+	}
+	// Now modify the custom one.
+	DeniedRips->Insert(type, deny);
+}
+
+TMap <FName, RipperDenyDefinition> GlobalDeniedRippers;
+
+void RipperDenyDefinition::Apply(FName const type)
+{
+	GlobalDeniedRippers[type] = *this;
+}
+
+RipperDenyDefinition *RipperDenyDefinition::Get(FName const type)
+{
+	return GlobalDeniedRippers.CheckKey(type);
+}
+
+bool RipperDenyDefinition::IsTypeDeniedRip(FName const type, RipList * list)
+{
+	if (list)
+	{
+		//If the actor has a specific named type, look for that factor.
+		bool *pdf = list->CheckKey(type);
+		if (pdf)	return *pdf;
+
+		//If it was non-specific, don't fall back to non-specific search.
+		if (type == NAME_None)
+			return false;
+	}
+	else if (type == NAME_None)
+	{
+		//Allow this to pass. RipperLevels will be the next thing to check, then.
+		return false;
+	}
+	else
+	{
+		RipperDenyDefinition *rdd = Get(type);
+		return !!(rdd);
+	}
+	return false;
+}
+
 //
 // P_MobjThinker
 //
@@ -4286,6 +4337,12 @@ void AActor::Deactivate (AActor *activator)
 
 void AActor::Destroy ()
 {
+	if (DeniedRips && DeniedRips != GetDefault()->DeniedRips)
+	{
+		delete DeniedRips;
+		DeniedRips = NULL;
+	}
+
 	// [RH] Destroy any inventory this actor is carrying
 	DestroyAllInventory ();
 

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -5984,7 +5984,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetRipTypeStatus)
 	ACTION_PARAM_INT(ptr, 2);
 	AActor *mobj = COPY_AAPTR(self, ptr);
 
-	if (!mobj)
+	if (!mobj || type == NAME_None)
 	{
 		return;
 	}

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -5892,40 +5892,101 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_JumpIfHigherOrLower)
 
 
 //===========================================================================
+// A_SetRipperLevel(int level, ptr)
 //
-// A_SetRipperLevel(int level)
-//
-// Sets the ripper level of the calling actor.
+// Sets the ripper level of the calling actor('s pointer).
 //===========================================================================
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetRipperLevel)
 {
-	ACTION_PARAM_START(1);
+	ACTION_PARAM_START(2);
 	ACTION_PARAM_INT(level, 0);
-	self->RipperLevel = level;
+	ACTION_PARAM_INT(ptr, 1);
+	AActor *mobj = COPY_AAPTR(self, ptr);
+
+	if (!mobj) 
+	{
+		return;
+	}
+	mobj->RipperLevel = level;
 }
 
 //===========================================================================
+// A_SetRipMin(int min, ptr)
 //
-// A_SetRipMin(int min)
-//
-// Sets the minimum level a ripper must be in order to rip through this actor.
+// Sets the minimum level a ripper must be in order to rip through 
+// this actor('s pointer).
 //===========================================================================
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetRipMin)
 {
-	ACTION_PARAM_START(1);
+	ACTION_PARAM_START(2);
 	ACTION_PARAM_INT(min, 0);
-	self->RipLevelMin = min; 
+	ACTION_PARAM_INT(ptr, 1);
+	AActor *mobj = COPY_AAPTR(self, ptr);
+
+	if (!mobj)
+	{
+		return;
+	}
+	mobj->RipLevelMin = min;
 }
 
 //===========================================================================
+// A_SetRipMax(int max, ptr)
 //
-// A_SetRipMax(int max)
-//
-// Sets the minimum level a ripper must be in order to rip through this actor.
+// Sets the minimum level a ripper must be in order to rip through 
+// this actor('s pointer).
 //===========================================================================
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetRipMax)
 {
-	ACTION_PARAM_START(1);
+	ACTION_PARAM_START(2);
 	ACTION_PARAM_INT(max, 0);
-	self->RipLevelMax = max;
+	ACTION_PARAM_INT(ptr, 1);
+	AActor *mobj = COPY_AAPTR(self, ptr);
+
+	if (!mobj)
+	{
+		return;
+	}
+	mobj->RipLevelMax = max;
+}
+
+//===========================================================================
+// A_SetRipType(name, ptr)
+//
+// Sets the ripper type of this actor('s pointer). 
+// This function is only useful for projectiles.
+//===========================================================================
+DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetRipType)
+{
+	ACTION_PARAM_START(2);
+	ACTION_PARAM_NAME(type, 0);
+	ACTION_PARAM_INT(ptr, 1);
+	AActor *mobj = COPY_AAPTR(self, ptr);
+
+	if (!mobj)
+	{
+		return;
+	}
+	mobj->RipType = type;
+}
+
+//===========================================================================
+// A_SetRipTypeStatus(name, bool deny, ptr)
+//
+// Sets the ripper type can rip through this actor('s pointer) or not. 
+// This function is only useful for shootables.
+//===========================================================================
+DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetRipTypeStatus)
+{
+	ACTION_PARAM_START(3);
+	ACTION_PARAM_NAME(type, 0);
+	ACTION_PARAM_BOOL(deny, 1);
+	ACTION_PARAM_INT(ptr, 2);
+	AActor *mobj = COPY_AAPTR(self, ptr);
+
+	if (!mobj)
+	{
+		return;
+	}
+	mobj->SetRipDenial(type, deny);
 }

--- a/src/thingdef/thingdef_parse.cpp
+++ b/src/thingdef/thingdef_parse.cpp
@@ -1230,6 +1230,27 @@ static void ParseDamageDefinition(FScanner &sc)
 
 //==========================================================================
 //
+// Reads a ripper type definition
+//
+//==========================================================================
+
+static void ParseRipTypeDeniedDefinition(FScanner &sc)
+{
+	sc.SetCMode(true); // This may be 100% irrelevant for such a simple syntax, but I don't know
+
+	// Get Ripper Types Denied
+	RipperDenyDefinition rad;
+	sc.MustGetString();
+	FName ripType = sc.String;
+	sc.MustGetToken(';');
+
+	rad.Apply(ripType);
+
+	sc.SetCMode(false); // (set to true earlier in function)
+}
+
+//==========================================================================
+//
 // ParseDecorate
 //
 // Parses a single DECORATE lump
@@ -1313,6 +1334,11 @@ void ParseDecorate (FScanner &sc)
 			else if (sc.Compare("DAMAGETYPE"))
 			{
 				ParseDamageDefinition(sc);
+				break;
+			}
+			else if (sc.Compare("DENYRIPTYPE"))
+			{
+				ParseRipTypeDeniedDefinition(sc);
 				break;
 			}
 		default:

--- a/src/thingdef/thingdef_properties.cpp
+++ b/src/thingdef/thingdef_properties.cpp
@@ -1428,11 +1428,23 @@ DEFINE_PROPERTY(telefogdesttype, S, Actor)
 DEFINE_PROPERTY(ripperlevel, I, Actor)
 {
 	PROP_INT_PARM(id, 0);
-	if (id < 0)
+	if (id < -1)
 	{
 		I_Error ("RipperLevel must not be negative");
 	}
-	defaults->RipperLevel = id;
+	else if (gameinfo.RipperLevel < 0)
+	{
+		I_Error("MAPINFO's RipperLevel must not be negative");
+	}
+	else
+	{
+
+		if (id == -1)
+			defaults->RipperLevel = gameinfo.RipperLevel;
+		else
+			defaults->RipperLevel = id;
+
+	}
 }
 
 //==========================================================================
@@ -1441,11 +1453,22 @@ DEFINE_PROPERTY(ripperlevel, I, Actor)
 DEFINE_PROPERTY(riplevelmin, I, Actor)
 {
 	PROP_INT_PARM(id, 0);
-	if (id < 0)
+	if (id < -1)
 	{
-		I_Error ("RipLevelMin must not be negative");
+		I_Error("RipLevelMin must not be negative");
 	}
-	defaults->RipLevelMin = id;
+	else if (gameinfo.RipLevelMin < 0)
+	{
+		I_Error("MAPINFO's RipLevelMin must not be negative");
+	}
+	else
+	{
+		if (id == -1)
+			defaults->RipLevelMin = gameinfo.RipLevelMin;
+		else
+			defaults->RipLevelMin = id;
+	}
+	
 }
 
 //==========================================================================
@@ -1454,11 +1477,49 @@ DEFINE_PROPERTY(riplevelmin, I, Actor)
 DEFINE_PROPERTY(riplevelmax, I, Actor)
 {
 	PROP_INT_PARM(id, 0);
-	if (id < 0)
+	if (id < -1)
 	{
-		I_Error ("RipLevelMax must not be negative");
+		I_Error("RipLevelMax must not be negative");
 	}
-	defaults->RipLevelMax = id;
+	else if (gameinfo.RipLevelMax < 0)
+	{
+		I_Error("MAPINFO's RipLevelMax must not be negative");
+	}
+	else
+	{
+		if (id == -1)
+			defaults->RipLevelMax = gameinfo.RipLevelMax;
+		else
+			defaults->RipLevelMax = id;
+	}
+}
+
+//==========================================================================
+//
+//==========================================================================
+DEFINE_PROPERTY(riptype, S, Actor)
+{
+	PROP_STRING_PARM(str, 0);
+	defaults->RipType = str;
+}
+
+//==========================================================================
+//
+//==========================================================================
+DEFINE_PROPERTY(denyrip, S, Actor)
+{
+	PROP_STRING_PARM(str, 0);
+	defaults->SetRipDenial(str, true);
+}
+
+//==========================================================================
+// Use this to override the global DenyRipType <name>; feature on specific 
+// actors.
+//==========================================================================
+DEFINE_PROPERTY(allowrip, S, Actor)
+{
+	PROP_STRING_PARM(str, 0);
+	defaults->SetRipDenial(str, false);
 }
 
 //==========================================================================

--- a/src/version.h
+++ b/src/version.h
@@ -76,7 +76,7 @@ const char *GetVersionString();
 
 // Use 4500 as the base git save version, since it's higher than the
 // SVN revision ever got.
-#define SAVEVER 4523
+#define SAVEVER 4524
 
 #define SAVEVERSTRINGIFY2(x) #x
 #define SAVEVERSTRINGIFY(x) SAVEVERSTRINGIFY2(x)

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -28,9 +28,9 @@ ACTOR Actor native //: Thinker
 	DeathType Normal
 	TeleFogSourceType "TeleportFog"
 	TeleFogDestType "TeleportFog"
-	RipperLevel 0
-	RipLevelMin 0
-	RipLevelMax 0
+	RipperLevel -1	//[MC] -1 causes the game to look towards the gameinfo part of MAPINFO. 
+	RipLevelMin -1	//It was the only way I could get it to work.
+	RipLevelMax -1
 
 	// Variables for the expression evaluator
 	// NOTE: fixed_t and angle_t are only used here to ensure proper conversion
@@ -331,9 +331,11 @@ ACTOR Actor native //: Thinker
 	action native A_SetHealth(int health, int ptr = AAPTR_DEFAULT);
 	action native A_ResetHealth(int ptr = AAPTR_DEFAULT);
 	action native A_JumpIfHigherOrLower(state high, state low, float offsethigh = 0, float offsetlow = 0, bool includeHeight = true, int ptr = AAPTR_TARGET);
-	action native A_SetRipperLevel(int level);
-	action native A_SetRipMin(int min);
-	action native A_SetRipMax(int max);
+	action native A_SetRipperLevel(int level, int ptr = AAPTR_DEFAULT);
+	action native A_SetRipMin(int min, int ptr = AAPTR_DEFAULT);
+	action native A_SetRipMax(int max, int ptr = AAPTR_DEFAULT);
+	action native A_SetRipType(name type, int ptr = AAPTR_DEFAULT);
+	action native A_SetRipTypeStatus(name type, bool deny, int ptr = AAPTR_DEFAULT);
 
 	action native A_CheckSightOrRange(float distance, state label, bool two_dimension = false);
 	action native A_CheckRange(float distance, state label, bool two_dimension = false);

--- a/wadsrc/static/mapinfo/mindefaults.txt
+++ b/wadsrc/static/mapinfo/mindefaults.txt
@@ -54,6 +54,9 @@ gameinfo
 	statscreen_mapnamefont = "BigFont"
 	statscreen_finishedpatch = "WIF"
 	statscreen_enteringpatch = "WIENTER"
+	RipperLevel = 0
+	RipLevelMin = 0
+	RipLevelMax = 0
 }
 
 include "mapinfo/common.txt"


### PR DESCRIPTION
* Added AllowRip and DenyRip <name>.
* Added global denial setting in DECORATE: "DenyRipType SmallRipper;" without quotes (the semicolon is required.) This can be overridden using the above properties.
* Added ability to define default RipperLevel, RipLevelMin and RipLevelMax via MAPINFO's gameinfo section.
* Added pointer capabilities to A_SetRipperLevel, A_SetRipMin/Max.
* Added A_SetRipType(name type, ptr),  A_SetRipTypeStatus(name type, bool deny, ptr).