### PR TITLE
Pointer Additions

### DIFF
--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -4129,7 +4129,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_ScaleVelocity)
 
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_ChangeVelocity)
 {
-	ACTION_PARAM_START(4);
+	ACTION_PARAM_START(5);
 	ACTION_PARAM_FIXED(x, 0);
 	ACTION_PARAM_FIXED(y, 1);
 	ACTION_PARAM_FIXED(z, 2);
@@ -4170,7 +4170,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_ChangeVelocity)
 
 	if (was_moving)
 	{
-		CheckStopped(self);
+		CheckStopped(ref);
 	}
 }
 

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -4107,7 +4107,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_ScaleVelocity)
 		return;
 	}
 
-	INTBOOL was_moving = self->velx | self->vely | self->velz;
+	INTBOOL was_moving = ref->velx | ref->vely | ref->velz;
 
 	ref->velx = FixedMul(ref->velx, scale);
 	ref->vely = FixedMul(ref->vely, scale);

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -2540,8 +2540,16 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetMass)
 {
 	ACTION_PARAM_START(2);
 	ACTION_PARAM_INT(mass, 0);
+	ACTION_PARAM_INT(ptr, 1);
 
-	self->Mass = mass;
+	AActor *mobj = COPY_AAPTR(self, ptr);
+
+	if (!mobj)
+	{
+		ACTION_SET_RESULT(false);
+		return;
+	}
+	mobj->Mass = mass;
 }
 
 //===========================================================================
@@ -2769,15 +2777,23 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_CheckRange)
 //===========================================================================
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_DropInventory)
 {
-	ACTION_PARAM_START(1);
+	ACTION_PARAM_START(2);
 	ACTION_PARAM_CLASS(drop, 0);
+	ACTION_PARAM_INT(ptr, 1);
+
+	AActor *mobj = COPY_AAPTR(self, ptr);
+
+	if (!mobj)
+	{
+		return;
+	}
 
 	if (drop)
 	{
-		AInventory * inv = self->FindInventory(drop);
+		AInventory * inv = mobj->FindInventory(drop);
 		if (inv)
 		{
-			self->DropInventory(inv);
+			mobj->DropInventory(inv);
 		}
 	}
 }
@@ -5155,10 +5171,19 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetTics)
 
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetDamageType)
 {
-	ACTION_PARAM_START(1);
+	ACTION_PARAM_START(2);
 	ACTION_PARAM_NAME(damagetype, 0);
+	ACTION_PARAM_INT(ptr, 1);
 
-	self->DamageType = damagetype;
+	AActor *mobj = COPY_AAPTR(self, ptr);
+
+	if (!mobj)
+	{
+		ACTION_SET_RESULT(false);
+		return;
+	}
+
+	mobj->DamageType = damagetype;
 }
 
 //==========================================================================
@@ -5169,12 +5194,21 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetDamageType)
 
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_DropItem)
 {
-	ACTION_PARAM_START(3);
+	ACTION_PARAM_START(4);
 	ACTION_PARAM_CLASS(spawntype, 0);
 	ACTION_PARAM_INT(amount, 1);
 	ACTION_PARAM_INT(chance, 2);
+	ACTION_PARAM_INT(ptr, 3);
 
-	P_DropItem(self, spawntype, amount, chance);
+	AActor *mobj = COPY_AAPTR(self, ptr);
+
+	if (!mobj)
+	{
+		ACTION_SET_RESULT(false);
+		return;
+	}
+
+	P_DropItem(mobj, spawntype, amount, chance);
 }
 
 //==========================================================================
@@ -5225,8 +5259,9 @@ static bool DoCheckClass(AActor *mo, const PClass *filterClass, bool exclude)
 // Species: Specified species is the only type allowed to be affected.
 //
 // Examples: 
-// A_Damage(20,"Normal",DMSS_FOILINVUL,0,"DemonicSpecies") <--Only actors 
-//	with a species "DemonicSpecies" will be affected. Use 0 to not filter by actor.
+// A_Damage(20,"Normal",DMSS_FOILINVUL,None,"DemonicSpecies") 
+//	Only actors with a species "DemonicSpecies" will be affected. 
+//	Use None to not filter by actor without quotes ("").
 //
 //===========================================================================
 
@@ -5272,6 +5307,31 @@ static void DoDamage(AActor *dmgtarget, AActor *self, int amount, FName DamageTy
 			P_GiveBody(dmgtarget, amount);
 		}
 	}
+}
+
+//===========================================================================
+//
+//
+//
+//===========================================================================
+DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_Damage)
+{
+	ACTION_PARAM_START(6);
+	ACTION_PARAM_INT(ptr, 0);
+	ACTION_PARAM_INT(amount, 1);
+	ACTION_PARAM_NAME(DamageType, 2);
+	ACTION_PARAM_INT(flags, 3);
+	ACTION_PARAM_CLASS(filter, 4);
+	ACTION_PARAM_NAME(species, 5);
+
+	AActor *mobj = COPY_AAPTR(self, ptr);
+
+	if (!mobj)
+	{
+		ACTION_SET_RESULT(false);
+		return;
+	}
+	DoDamage(mobj, self, amount, DamageType, flags, filter, species);
 }
 
 //===========================================================================
@@ -5456,10 +5516,33 @@ static void DoKill(AActor *killtarget, AActor *self, FName damagetype, int flags
 	}
 }
 
+//===========================================================================
+//
+// A_Kill(ptr, damagetype, int flags, filter, species)
+//
+//===========================================================================
+DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_Kill)
+{
+	ACTION_PARAM_START(5);
+	ACTION_PARAM_INT(ptr, 0);
+	ACTION_PARAM_NAME(damagetype, 1);
+	ACTION_PARAM_INT(flags, 2);
+	ACTION_PARAM_CLASS(filter, 3);
+	ACTION_PARAM_NAME(species, 4);
+
+	AActor *mobj = COPY_AAPTR(self, ptr);
+
+	if (!mobj)
+	{
+		ACTION_SET_RESULT(false);
+		return;
+	}
+	DoKill(mobj, self, damagetype, flags, filter, species);
+}
 
 //===========================================================================
 //
-// A_KillTarget(damagetype, int flags)
+// A_KillTarget(damagetype, int flags, filter, species)
 //
 //===========================================================================
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_KillTarget)
@@ -5478,7 +5561,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_KillTarget)
 
 //===========================================================================
 //
-// A_KillTracer(damagetype, int flags)
+// A_KillTracer(damagetype, int flags, filter, species)
 //
 //===========================================================================
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_KillTracer)
@@ -5497,7 +5580,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_KillTracer)
 
 //===========================================================================
 //
-// A_KillMaster(damagetype, int flags)
+// A_KillMaster(damagetype, int flags, filter, species)
 //
 //===========================================================================
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_KillMaster)
@@ -5516,7 +5599,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_KillMaster)
 
 //===========================================================================
 //
-// A_KillChildren(damagetype, int flags)
+// A_KillChildren(damagetype, int flags, filter, species)
 //
 //===========================================================================
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_KillChildren)
@@ -5541,7 +5624,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_KillChildren)
 
 //===========================================================================
 //
-// A_KillSiblings(damagetype, int flags)
+// A_KillSiblings(damagetype, int flags, filter, species)
 //
 //===========================================================================
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_KillSiblings)
@@ -5745,12 +5828,21 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_Remove)
 
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetTeleFog)
 {
-	ACTION_PARAM_START(2);
+	ACTION_PARAM_START(3);
 	ACTION_PARAM_CLASS(oldpos, 0);
 	ACTION_PARAM_CLASS(newpos, 1);
+	ACTION_PARAM_INT(ptr, 2);
 
-	self->TeleFogSourceType = oldpos;
-	self->TeleFogDestType = newpos;
+	AActor *mobj = COPY_AAPTR(self, ptr);
+
+	if (!mobj)
+	{
+		ACTION_SET_RESULT(false);
+		return;
+	}
+
+	mobj->TeleFogSourceType = oldpos;
+	mobj->TeleFogDestType = newpos;
 }
 
 //===========================================================================
@@ -5760,13 +5852,23 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetTeleFog)
 // Switches the source and dest telefogs around. 
 //===========================================================================
 
-DEFINE_ACTION_FUNCTION(AActor, A_SwapTeleFog)
+DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SwapTeleFog)
 {
-	if ((self->TeleFogSourceType != self->TeleFogDestType)) //Does nothing if they're the same.
+	ACTION_PARAM_START(1);
+	ACTION_PARAM_INT(ptr, 0);
+
+	AActor *mobj = COPY_AAPTR(self, ptr);
+
+	if (!mobj)
 	{
-		const PClass *temp = self->TeleFogSourceType;
-		self->TeleFogSourceType = self->TeleFogDestType;
-		self->TeleFogDestType = temp;
+		ACTION_SET_RESULT(false);
+		return;
+	}
+	if ((mobj->TeleFogSourceType != mobj->TeleFogDestType)) //Does nothing if they're the same.
+	{
+		const PClass *temp = mobj->TeleFogSourceType;
+		mobj->TeleFogSourceType = mobj->TeleFogDestType;
+		mobj->TeleFogDestType = temp;
 	}
 }
 
@@ -5779,12 +5881,21 @@ DEFINE_ACTION_FUNCTION(AActor, A_SwapTeleFog)
 
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetFloatBobPhase)
 {
-	ACTION_PARAM_START(1);
+	ACTION_PARAM_START(2);
 	ACTION_PARAM_INT(bob, 0);
+	ACTION_PARAM_INT(ptr, 1);
+
+	AActor *mobj = COPY_AAPTR(self, ptr);
+
+	if (!mobj)
+	{
+		ACTION_SET_RESULT(false);
+		return;
+	}
 
 	//Respect float bob phase limits.
-	if (self && (bob >= 0 && bob <= 63))
-		self->FloatBobPhase = bob;
+	if (mobj && (bob >= 0 && bob <= 63))
+		mobj->FloatBobPhase = bob;
 }
 
 //===========================================================================
@@ -5899,9 +6010,18 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_JumpIfHigherOrLower)
 //===========================================================================
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetRipperLevel)
 {
-	ACTION_PARAM_START(1);
+	ACTION_PARAM_START(2);
 	ACTION_PARAM_INT(level, 0);
-	self->RipperLevel = level;
+	ACTION_PARAM_INT(ptr, 1);
+
+	AActor *mobj = COPY_AAPTR(self, ptr);
+
+	if (!mobj)
+	{
+		ACTION_SET_RESULT(false);
+		return;
+	}
+	mobj->RipperLevel = level;
 }
 
 //===========================================================================
@@ -5912,9 +6032,18 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetRipperLevel)
 //===========================================================================
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetRipMin)
 {
-	ACTION_PARAM_START(1);
+	ACTION_PARAM_START(2);
 	ACTION_PARAM_INT(min, 0);
-	self->RipLevelMin = min; 
+	ACTION_PARAM_INT(ptr, 1);
+
+	AActor *mobj = COPY_AAPTR(self, ptr);
+
+	if (!mobj)
+	{
+		ACTION_SET_RESULT(false);
+		return;
+	}
+	mobj->RipLevelMin = min; 
 }
 
 //===========================================================================
@@ -5925,7 +6054,16 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetRipMin)
 //===========================================================================
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetRipMax)
 {
-	ACTION_PARAM_START(1);
+	ACTION_PARAM_START(2);
 	ACTION_PARAM_INT(max, 0);
-	self->RipLevelMax = max;
+	ACTION_PARAM_INT(ptr, 1);
+
+	AActor *mobj = COPY_AAPTR(self, ptr);
+
+	if (!mobj)
+	{
+		ACTION_SET_RESULT(false);
+		return;
+	}
+	mobj->RipLevelMax = max;
 }

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -232,11 +232,11 @@ ACTOR Actor native //: Thinker
 	action native A_FadeOut(float reduce = 0.1, int flags = 1); //bool remove == true
 	action native A_FadeTo(float target, float amount = 0.1, int flags = 0);
 	action native A_SetScale(float scalex, float scaley = 0, int ptr = AAPTR_DEFAULT);
-	action native A_SetMass(int mass);
+	action native A_SetMass(int mass, int ptr = AAPTR_DEFAULT);
 	action native A_SpawnDebris(class<Actor> spawntype, bool transfer_translation = false, float mult_h = 1, float mult_v = 1);
 	action native A_CheckSight(state label);
 	action native A_ExtChase(bool usemelee, bool usemissile, bool playactive = true, bool nightmarefast = false);
-	action native A_DropInventory(class<Inventory> itemtype);
+	action native A_DropInventory(class<Inventory> itemtype, int ptr = AAPTR_DEFAULT);
 	action native A_SetBlend(color color1, float alpha, int tics, color color2 = "");
 	action native A_ChangeFlag(string flagname, bool value);
 	action native A_CheckFlag(string flagname, state label, int check_pointer = AAPTR_DEFAULT);
@@ -301,15 +301,17 @@ ACTOR Actor native //: Thinker
 	action native A_Quake(int intensity, int duration, int damrad, int tremrad, sound sfx = "world/quake");
 	action native A_QuakeEx(int intensityX, int intensityY, int intensityZ, int duration, int damrad, int tremrad, sound sfx = "world/quake", int flags = 0, float mulWaveX = 1, float mulWaveY = 1, float mulWaveZ = 1);
 	action native A_SetTics(int tics);
-	action native A_SetDamageType(name damagetype);
-	action native A_DropItem(class<Actor> item, int dropamount = -1, int chance = 256);
+	action native A_SetDamageType(name damagetype, int ptr = AAPTR_DEFAULT);
+	action native A_DropItem(class<Actor> item, int dropamount = -1, int chance = 256, int ptr = AAPTR_DEFAULT);
 	action native A_SetSpeed(float speed, int ptr = AAPTR_DEFAULT);
+	action native A_Damage(int ptr, int amount, name damagetype = "none", int flags = 0, class<Actor> filter = "None", name species = "None");
 	action native A_DamageSelf(int amount, name damagetype = "none", int flags = 0, class<Actor> filter = "None", name species = "None");
 	action native A_DamageTarget(int amount, name damagetype = "none", int flags = 0, class<Actor> filter = "None", name species = "None");
 	action native A_DamageMaster(int amount, name damagetype = "none", int flags = 0, class<Actor> filter = "None", name species = "None");
 	action native A_DamageTracer(int amount, name damagetype = "none", int flags = 0, class<Actor> filter = "None", name species = "None");
 	action native A_DamageChildren(int amount, name damagetype = "none", int flags = 0, class<Actor> filter = "None", name species = "None");
 	action native A_DamageSiblings(int amount, name damagetype = "none", int flags = 0, class<Actor> filter = "None", name species = "None");
+	action native A_Kill(int ptr, name damagetype = "none", int flags = 0, class<Actor> filter = "None", name species = "None");
 	action native A_KillTarget(name damagetype = "none", int flags = 0, class<Actor> filter = "None", name species = "None");
 	action native A_KillMaster(name damagetype = "none", int flags = 0, class<Actor> filter = "None", name species = "None");
 	action native A_KillTracer(name damagetype = "none", int flags = 0, class<Actor> filter = "None", name species = "None");
@@ -325,15 +327,15 @@ ACTOR Actor native //: Thinker
 	action native A_GiveToSiblings(class<Inventory> itemtype, int amount = 0);
 	action native A_TakeFromChildren(class<Inventory> itemtype, int amount = 0);
 	action native A_TakeFromSiblings(class<Inventory> itemtype, int amount = 0);
-	action native A_SetTeleFog(class<Actor> oldpos, class<Actor> newpos);
-	action native A_SwapTeleFog();
-	action native A_SetFloatBobPhase(int bob);
+	action native A_SetTeleFog(class<Actor> oldpos, class<Actor> newpos, int ptr = AAPTR_DEFAULT);
+	action native A_SwapTeleFog(int ptr = AAPTR_DEFAULT);
+	action native A_SetFloatBobPhase(int bob, int ptr = AAPTR_DEFAULT);
 	action native A_SetHealth(int health, int ptr = AAPTR_DEFAULT);
 	action native A_ResetHealth(int ptr = AAPTR_DEFAULT);
 	action native A_JumpIfHigherOrLower(state high, state low, float offsethigh = 0, float offsetlow = 0, bool includeHeight = true, int ptr = AAPTR_TARGET);
-	action native A_SetRipperLevel(int level);
-	action native A_SetRipMin(int min);
-	action native A_SetRipMax(int max);
+	action native A_SetRipperLevel(int level, int ptr = AAPTR_DEFAULT);
+	action native A_SetRipMin(int min, int ptr = AAPTR_DEFAULT);
+	action native A_SetRipMax(int max, int ptr = AAPTR_DEFAULT);
 
 	action native A_CheckSightOrRange(float distance, state label, bool two_dimension = false);
 	action native A_CheckRange(float distance, state label, bool two_dimension = false);

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -222,15 +222,15 @@ ACTOR Actor native //: Thinker
 	action native A_GiveInventory(class<Inventory> itemtype, int amount = 0, int giveto = AAPTR_DEFAULT);
 	action native A_TakeInventory(class<Inventory> itemtype, int amount = 0, int flags = 0, int giveto = AAPTR_DEFAULT);
 	action native A_SpawnItem(class<Actor> itemtype = "Unknown", float distance = 0, float zheight = 0, bool useammo = true, bool transfer_translation = false);
-	action native A_SpawnItemEx(class<Actor> itemtype, float xofs = 0, float yofs = 0, float zofs = 0, float xvel = 0, float yvel = 0, float zvel = 0, float angle = 0, int flags = 0, int failchance = 0, int tid=0);
+	action native A_SpawnItemEx(class<Actor> itemtype, float xofs = 0, float yofs = 0, float zofs = 0, float xvel = 0, float yvel = 0, float zvel = 0, float angle = 0, int flags = 0, int failchance = 0, int tid = 0, int ptr = AAPTR_DEFAULT);
 	action native A_Print(string whattoprint, float time = 0, string fontname = "");
 	action native A_PrintBold(string whattoprint, float time = 0, string fontname = "");
 	action native A_Log(string whattoprint);
 	action native A_LogInt(int whattoprint);
 	action native A_SetTranslucent(float alpha, int style = 0);
-	action native A_FadeIn(float reduce = 0.1, int flags = 0);
-	action native A_FadeOut(float reduce = 0.1, int flags = 1); //bool remove == true
-	action native A_FadeTo(float target, float amount = 0.1, int flags = 0);
+	action native A_FadeIn(float reduce = 0.1, int flags = 0, int ptr = AAPTR_DEFAULT);
+	action native A_FadeOut(float reduce = 0.1, int flags = 1, int ptr = AAPTR_DEFAULT); //bool remove == true
+	action native A_FadeTo(float target, float amount = 0.1, int flags = 0, int ptr = AAPTR_DEFAULT);
 	action native A_SetScale(float scalex, float scaley = 0, int ptr = AAPTR_DEFAULT);
 	action native A_SetMass(int mass, int ptr = AAPTR_DEFAULT);
 	action native A_SpawnDebris(class<Actor> spawntype, bool transfer_translation = false, float mult_h = 1, float mult_v = 1);
@@ -300,7 +300,7 @@ ACTOR Actor native //: Thinker
 	action native A_SetSpecial(int spec, int arg0 = 0, int arg1 = 0, int arg2 = 0, int arg3 = 0, int arg4 = 0);
 	action native A_Quake(int intensity, int duration, int damrad, int tremrad, sound sfx = "world/quake");
 	action native A_QuakeEx(int intensityX, int intensityY, int intensityZ, int duration, int damrad, int tremrad, sound sfx = "world/quake", int flags = 0, float mulWaveX = 1, float mulWaveY = 1, float mulWaveZ = 1);
-	action native A_SetTics(int tics);
+	action native A_SetTics(int tics, int ptr = AAPTR_DEFAULT);
 	action native A_SetDamageType(name damagetype, int ptr = AAPTR_DEFAULT);
 	action native A_DropItem(class<Actor> item, int dropamount = -1, int chance = 256, int ptr = AAPTR_DEFAULT);
 	action native A_SetSpeed(float speed, int ptr = AAPTR_DEFAULT);

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -74,6 +74,7 @@ const int SXF_NOPOINTERS =				1 << 22;
 const int SXF_ORIGINATOR =				1 << 23;
 const int SXF_TRANSFERSPRITEFRAME	=	1 << 24;
 const int SXF_TRANSFERROLL =			1 << 25;
+const int SXF_POINTERISCALLER =			1 << 26;
 
 // Flags for A_Chase
 const int CHF_FASTCHASE = 1;
@@ -137,6 +138,7 @@ const int MRF_FAILNOLAUGH = 32;
 const int MRF_WHENINVULNERABLE = 64;
 const int MRF_LOSEACTUALWEAPON = 128;
 const int MRF_NEWTIDBEHAVIOUR = 256;
+const int MRF_NEWTIDBEHAVIOR = 256;
 const int MRF_UNDOBYDEATH = 512;
 const int MRF_UNDOBYDEATHFORCED = 1024;
 const int MRF_UNDOBYDEATHSAVES = 2048;


### PR DESCRIPTION
- Added pointer affecting to the following:
- A_SetMass
- A_DropInventory
- A_SetDamageType
- A_DropItem
- A_SetTeleFog
- A_SwapTeleFog
- A_SetRipperLevel
- A_SetRipMin/Max
- A_SetFloatBobPhase
- A_SpawnItemEx
- A_FadeIn/Out/To
- A_SetTics
- Added A_Damage(ptr, amount, damagetype, flags, filter, species). A pointer is required first. You can now damage players, line target pointers, etc directly with this function, so storing AAPTR_TARGET and the likes into a user variable are now possible.
- Added A_Kill(ptr, damagetype, flags, filter, species). A pointer is required in the first.
- Added corrected spelling version of MRF_NEWTIDBEHAVIOR.