### PR TITLE
Transfer TERRAIN friction and damage to 3D floors

### DIFF
--- a/src/p_3dfloors.cpp
+++ b/src/p_3dfloors.cpp
@@ -41,6 +41,7 @@
 #include "w_wad.h"
 #include "sc_man.h"
 #include "g_level.h"
+#include "p_terrain.h"
 #include "r_data/colormaps.h"
 
 #ifdef _3DFLOORS
@@ -341,8 +342,15 @@ void P_PlayerOnSpecial3DFloor(player_t* player)
 				(player->mo->z + player->mo->height) < rover->bottom.plane->ZatPoint(player->mo->x, player->mo->y))
 				continue;
 		}
-		
-		if (rover->model->special || rover->model->damage) P_PlayerInSpecialSector(player, rover->model);
+
+		// Apply sector specials
+		if (rover->model->special || rover->model->damage)
+			P_PlayerInSpecialSector(player, rover->model);
+
+		// Apply flat specials (using the ceiling!)
+		P_PlayerOnSpecialFlat(
+			player, TerrainTypes[rover->model->GetTexture(sector_t::ceiling)]);
+
 		break;
 	}
 }

--- a/src/p_spec.cpp
+++ b/src/p_spec.cpp
@@ -738,12 +738,13 @@ void P_PlayerOnSpecialFlat (player_t *player, int floorType)
 			}
 		}
 
+		int damage = 0;
 		if (ironfeet == NULL)
 		{
-			P_DamageMobj (player->mo, NULL, NULL, Terrains[floorType].DamageAmount,
+			damage = P_DamageMobj (player->mo, NULL, NULL, Terrains[floorType].DamageAmount,
 				Terrains[floorType].DamageMOD);
 		}
-		if (Terrains[floorType].Splash != -1)
+		if (damage > 0 && Terrains[floorType].Splash != -1)
 		{
 			S_Sound (player->mo, CHAN_AUTO,
 				Splashes[Terrains[floorType].Splash].NormalSplashSound, 1,

--- a/src/p_spec.cpp
+++ b/src/p_spec.cpp
@@ -718,12 +718,6 @@ void P_GiveSecret(AActor *actor, bool printmessage, bool playsound, int sectornu
 
 void P_PlayerOnSpecialFlat (player_t *player, int floorType)
 {
-	if (player->mo->z > player->mo->Sector->floorplane.ZatPoint (
-		player->mo->x, player->mo->y) &&
-		!player->mo->waterlevel)
-	{ // Player is not touching the floor
-		return;
-	}
 	if (Terrains[floorType].DamageAmount &&
 		!(level.time & Terrains[floorType].DamageTimeMask))
 	{

--- a/src/p_user.cpp
+++ b/src/p_user.cpp
@@ -2535,7 +2535,13 @@ void P_PlayerThink (player_t *player)
 		{
 			P_PlayerInSpecialSector (player);
 		}
-		P_PlayerOnSpecialFlat (player, P_GetThingFloorType (player->mo));
+		if (player->mo->z <= player->mo->Sector->floorplane.ZatPoint(
+			player->mo->x, player->mo->y) ||
+			player->mo->waterlevel)
+		{
+			// Player must be touching the floor
+			P_PlayerOnSpecialFlat(player, P_GetThingFloorType(player->mo));
+		}
 		if (player->mo->velz <= -player->mo->FallingScreamMinSpeed &&
 			player->mo->velz >= -player->mo->FallingScreamMaxSpeed && !player->morphTics &&
 			player->mo->waterlevel == 0)


### PR DESCRIPTION
Thread with a demo WAD: http://forum.zdoom.org/viewtopic.php?f=2&t=48776

- Friction defined by a TERRAIN lump previously only applied when standing atop a solid 3D floor; now it also applies when inside a swimmable 3D floor.  (Applying it to non-solid floors seems wrong, since the floor is "hollow", so there's nothing to impede your movement, right?)

    I notice that friction doesn't apply to vertical movement, which is noticeably weird in extreme friction, but fixing that seems a bit more invasive  :)

- The TERRAIN splash sound normally plays whenever the flat inflicts damage on the player.  If it didn't inflict damage, whether due to IronFeet or a damage mod, the sound shouldn't play.

- Damage defined by a TERRAIN lump didn't apply to 3D floors.  Now it does!  (Including non-solid ones.)  Only the ceiling is consulted.

I notice there's a `FF_INVERTSECTOR` flag that swaps the floor and ceiling for some kind of Vavoom hack.  It wasn't handled before, and it's not handled now.