### PR TITLE
Fix scaling of 3D floors' wall textures

### DIFF
--- a/src/r_segs.cpp
+++ b/src/r_segs.cpp
@@ -557,8 +557,8 @@ void R_RenderFakeWall(drawseg_t *ds, int x1, int x2, F3DFloor *rover)
 	MaskedSWall = (fixed_t *)(openings + ds->swall) - ds->x1;
 
 	// find positioning
-	xscale = FixedMul(rw_pic->xScale, sidedef->GetTextureXScale(side_t::mid));
-	yscale = FixedMul(rw_pic->yScale, sidedef->GetTextureYScale(side_t::mid));
+	xscale = FixedMul(rw_pic->xScale, curline->sidedef->GetTextureXScale(side_t::mid));
+	yscale = FixedMul(rw_pic->yScale, curline->sidedef->GetTextureYScale(side_t::mid));
 	// encapsulate the lifetime of rowoffset
 	fixed_t rowoffset = curline->sidedef->GetTextureYOffset(side_t::mid) + rover->master->sidedef[0]->GetTextureYOffset(side_t::mid);
 	dc_texturemid = rover->model->GetPlaneTexZ(sector_t::ceiling);

--- a/src/r_segs.cpp
+++ b/src/r_segs.cpp
@@ -557,8 +557,25 @@ void R_RenderFakeWall(drawseg_t *ds, int x1, int x2, F3DFloor *rover)
 	MaskedSWall = (fixed_t *)(openings + ds->swall) - ds->x1;
 
 	// find positioning
-	xscale = FixedMul(rw_pic->xScale, curline->sidedef->GetTextureXScale(side_t::mid));
-	yscale = FixedMul(rw_pic->yScale, curline->sidedef->GetTextureYScale(side_t::mid));
+	side_t *scaledside;
+	side_t::ETexpart scaledpart;
+	if (rover->flags & FF_UPPERTEXTURE)
+	{
+		scaledside = curline->sidedef;
+		scaledpart = side_t::top;
+	}
+	else if (rover->flags & FF_LOWERTEXTURE)
+	{
+		scaledside = curline->sidedef;
+		scaledpart = side_t::bottom;
+	}
+	else
+	{
+		scaledside = rover->master->sidedef[0];
+		scaledpart = side_t::mid;
+	}
+	xscale = FixedMul(rw_pic->xScale, scaledside->GetTextureXScale(scaledpart));
+	yscale = FixedMul(rw_pic->yScale, scaledside->GetTextureYScale(scaledpart));
 	// encapsulate the lifetime of rowoffset
 	fixed_t rowoffset = curline->sidedef->GetTextureYOffset(side_t::mid) + rover->master->sidedef[0]->GetTextureYOffset(side_t::mid);
 	dc_texturemid = rover->model->GetPlaneTexZ(sector_t::ceiling);


### PR DESCRIPTION
Thread with a demo wad: http://forum.zdoom.org/viewtopic.php?f=2&t=43981

This should bring the software renderer in line with GZDoom, which already handles this correctly.  Seems to be a combination of an oversight and an accidental use of the wrong global.