### PR TITLE
Don't allow pressing a checkswitchrange switch that's in the floor

### DIFF
--- a/src/p_switch.cpp
+++ b/src/p_switch.cpp
@@ -177,7 +177,7 @@ bool P_CheckSwitchRange(AActor *user, line_t *line, int sideno)
 
 	if ((TexMan.FindSwitch(side->GetTexture(side_t::top))) != NULL)
 	{
-		return (user->z + user->height >= open.top);
+		return (user->z + user->height > open.top);
 	}
 	else if ((TexMan.FindSwitch(side->GetTexture(side_t::bottom))) != NULL)
 	{
@@ -194,7 +194,7 @@ bool P_CheckSwitchRange(AActor *user, line_t *line, int sideno)
 	else
 	{
 		// no switch found. Check whether the player can touch either top or bottom texture
-		return (user->z + user->height >= open.top) || (user->z < open.bottom);
+		return (user->z + user->height > open.top) || (user->z < open.bottom);
 	}
 }
 

--- a/src/p_switch.cpp
+++ b/src/p_switch.cpp
@@ -181,7 +181,7 @@ bool P_CheckSwitchRange(AActor *user, line_t *line, int sideno)
 	}
 	else if ((TexMan.FindSwitch(side->GetTexture(side_t::bottom))) != NULL)
 	{
-		return (user->z <= open.bottom);
+		return (user->z < open.bottom);
 	}
 	else if ((flags & ML_3DMIDTEX) || (TexMan.FindSwitch(side->GetTexture(side_t::mid))) != NULL)
 	{
@@ -194,7 +194,7 @@ bool P_CheckSwitchRange(AActor *user, line_t *line, int sideno)
 	else
 	{
 		// no switch found. Check whether the player can touch either top or bottom texture
-		return (user->z + user->height >= open.top) || (user->z <= open.bottom);
+		return (user->z + user->height >= open.top) || (user->z < open.bottom);
 	}
 }
 


### PR DESCRIPTION
As I understand it, this is one of the two problems `checkswitchrange` is intended to solve, so it seems weird that it doesn't actually solve it.  :)  Curiously, GZDoom doesn't have the same problem.

Trivial example WAD: http://stuff.veekun.com/volatile/checkswitchrange.wad
Immediately in front of the player 1 start is an Exit_Normal line marked `checkswitchrange`.  Both sectors have the same floor and ceiling height.  On master, loading the map and immediately pressing +use ends the label; with this patch, it doesn't.