### PR TITLE
Add missing MF7_FORCEDECAL flag for rail attacks, and changed operation to doubles

### DIFF
--- a/src/p_effect.cpp
+++ b/src/p_effect.cpp
@@ -586,12 +586,12 @@ void P_DrawSplash2 (int count, fixed_t x, fixed_t y, fixed_t z, angle_t angle, i
 	}
 }
 
-void P_DrawRailTrail (AActor *source, const FVector3 &start, const FVector3 &end, int color1, int color2, float maxdiff, int flags, const PClass *spawnclass, angle_t angle, int duration, float sparsity, float drift, int SpiralOffset)
+void P_DrawRailTrail(AActor *source, const TVector3<double> &start, const TVector3<double> &end, int color1, int color2, double maxdiff, int flags, const PClass *spawnclass, angle_t angle, int duration, double sparsity, double drift, int SpiralOffset)
 {
 	double length, lengthsquared;
 	int steps, i;
-	FAngle deg;
-	FVector3 step, dir, pos, extend;
+	TAngle<double> deg;
+	TVector3<double> step, dir, pos, extend;
 	bool fullbright;
 
 	dir = end - start;
@@ -615,9 +615,9 @@ void P_DrawRailTrail (AActor *source, const FVector3 &start, const FVector3 &end
 			// The railgun's sound is special. It gets played from the
 			// point on the slug's trail that is closest to the hearing player.
 			AActor *mo = players[consoleplayer].camera;
-			FVector3 point;
+			TVector3<double> point;
 			double r;
-			float dirz;
+			double dirz;
 
 			if (abs(mo->x - FLOAT2FIXED(start.X)) < 20 * FRACUNIT
 				&& (mo->y - FLOAT2FIXED(start.Y)) < 20 * FRACUNIT)
@@ -630,7 +630,7 @@ void P_DrawRailTrail (AActor *source, const FVector3 &start, const FVector3 &end
 				// Only consider sound in 2D (for now, anyway)
 				// [BB] You have to divide by lengthsquared here, not multiply with it.
 
-				r = ((start.Y - FIXED2FLOAT(mo->y)) * (-dir.Y) - (start.X - FIXED2FLOAT(mo->x)) * (dir.X)) / lengthsquared;
+				r = ((start.Y - FIXED2DBL(mo->y)) * (-dir.Y) - (start.X - FIXED2DBL(mo->x)) * (dir.X)) / lengthsquared;
 				r = clamp<double>(r, 0., 1.);
 
 				dirz = dir.Z;
@@ -662,7 +662,7 @@ void P_DrawRailTrail (AActor *source, const FVector3 &start, const FVector3 &end
 			minelem = fabs(dir[i]);
 		}
 	}
-	FVector3 tempvec(0,0,0);
+	TVector3<double> tempvec(0, 0, 0);
 	tempvec[epos] = 1;
 	extend = tempvec - (dir | tempvec) * dir;
 	//
@@ -673,16 +673,16 @@ void P_DrawRailTrail (AActor *source, const FVector3 &start, const FVector3 &end
 	// Create the outer spiral.
 	if (color1 != -1 && (!r_rail_smartspiral || color2 == -1) && r_rail_spiralsparsity > 0 && (spawnclass == NULL))
 	{
-		FVector3 spiral_step = step * r_rail_spiralsparsity * sparsity;
+		TVector3<double> spiral_step = step * r_rail_spiralsparsity * sparsity;
 		int spiral_steps = (int)(steps * r_rail_spiralsparsity / sparsity);
 		
 		color1 = color1 == 0 ? -1 : ParticleColor(color1);
 		pos = start;
-		deg = FAngle(SpiralOffset);
+		deg = TAngle<double>(SpiralOffset);
 		for (i = spiral_steps; i; i--)
 		{
 			particle_t *p = NewParticle ();
-			FVector3 tempvec;
+			TVector3<double> tempvec;
 
 			if (!p)
 				return;
@@ -695,7 +695,7 @@ void P_DrawRailTrail (AActor *source, const FVector3 &start, const FVector3 &end
 			p->size = 3;
 			p->bright = fullbright;
 
-			tempvec = FMatrix3x3(dir, deg) * extend;
+			tempvec = TMatrix3x3<double>(dir, deg) * extend;
 			p->velx = FLOAT2FIXED(tempvec.X * drift)>>4;
 			p->vely = FLOAT2FIXED(tempvec.Y * drift)>>4;
 			p->velz = FLOAT2FIXED(tempvec.Z * drift)>>4;
@@ -704,7 +704,7 @@ void P_DrawRailTrail (AActor *source, const FVector3 &start, const FVector3 &end
 			p->y = FLOAT2FIXED(tempvec.Y);
 			p->z = FLOAT2FIXED(tempvec.Z);
 			pos += spiral_step;
-			deg += FAngle(r_rail_spiralsparsity * 14);
+			deg += TAngle<double>(r_rail_spiralsparsity * 14);
 
 			if (color1 == -1)
 			{
@@ -729,18 +729,18 @@ void P_DrawRailTrail (AActor *source, const FVector3 &start, const FVector3 &end
 	// Create the inner trail.
 	if (color2 != -1 && r_rail_trailsparsity > 0 && spawnclass == NULL)
 	{
-		FVector3 trail_step = step * r_rail_trailsparsity * sparsity;
+		TVector3<double> trail_step = step * r_rail_trailsparsity * sparsity;
 		int trail_steps = xs_FloorToInt(steps * r_rail_trailsparsity / sparsity);
 
 		color2 = color2 == 0 ? -1 : ParticleColor(color2);
-		FVector3 diff(0, 0, 0);
+		TVector3<double> diff(0, 0, 0);
 
 		pos = start;
 		for (i = trail_steps; i; i--)
 		{
 			// [XA] inner trail uses a different default duration (33).
 			int innerduration = (duration == 0) ? 33 : duration;
-			particle_t *p = JitterParticle (innerduration, drift);
+			particle_t *p = JitterParticle (innerduration, (float)drift);
 
 			if (!p)
 				return;
@@ -749,14 +749,14 @@ void P_DrawRailTrail (AActor *source, const FVector3 &start, const FVector3 &end
 			{
 				int rnd = M_Random ();
 				if (rnd & 1)
-					diff.X = clamp<float> (diff.X + ((rnd & 8) ? 1 : -1), -maxdiff, maxdiff);
+					diff.X = clamp<double>(diff.X + ((rnd & 8) ? 1 : -1), -maxdiff, maxdiff);
 				if (rnd & 2)
-					diff.Y = clamp<float> (diff.Y + ((rnd & 16) ? 1 : -1), -maxdiff, maxdiff);
+					diff.Y = clamp<double>(diff.Y + ((rnd & 16) ? 1 : -1), -maxdiff, maxdiff);
 				if (rnd & 4)
-					diff.Z = clamp<float> (diff.Z + ((rnd & 32) ? 1 : -1), -maxdiff, maxdiff);
+					diff.Z = clamp<double>(diff.Z + ((rnd & 32) ? 1 : -1), -maxdiff, maxdiff);
 			}
 
-			FVector3 postmp = pos + diff;
+			TVector3<double> postmp = pos + diff;
 
 			p->size = 2;
 			p->x = FLOAT2FIXED(postmp.X);
@@ -791,9 +791,9 @@ void P_DrawRailTrail (AActor *source, const FVector3 &start, const FVector3 &end
 		if (sparsity < 1)
 			sparsity = 32;
 
-		FVector3 trail_step = (step / 3) * sparsity;
+		TVector3<double> trail_step = (step / 3) * sparsity;
 		int trail_steps = (int)((steps * 3) / sparsity);
-		FVector3 diff(0, 0, 0);
+		TVector3<double> diff(0, 0, 0);
 
 		pos = start;
 		for (i = trail_steps; i; i--)
@@ -802,13 +802,13 @@ void P_DrawRailTrail (AActor *source, const FVector3 &start, const FVector3 &end
 			{
 				int rnd = pr_railtrail();
 				if (rnd & 1)
-					diff.X = clamp<float> (diff.X + ((rnd & 8) ? 1 : -1), -maxdiff, maxdiff);
+					diff.X = clamp<double>(diff.X + ((rnd & 8) ? 1 : -1), -maxdiff, maxdiff);
 				if (rnd & 2)
-					diff.Y = clamp<float> (diff.Y + ((rnd & 16) ? 1 : -1), -maxdiff, maxdiff);
+					diff.Y = clamp<double>(diff.Y + ((rnd & 16) ? 1 : -1), -maxdiff, maxdiff);
 				if (rnd & 4)
-					diff.Z = clamp<float> (diff.Z + ((rnd & 32) ? 1 : -1), -maxdiff, maxdiff);
+					diff.Z = clamp<double>(diff.Z + ((rnd & 32) ? 1 : -1), -maxdiff, maxdiff);
 			}			
-			FVector3 postmp = pos + diff;
+			TVector3<double> postmp = pos + diff;
 
 			AActor *thing = Spawn (spawnclass, FLOAT2FIXED(postmp.X), FLOAT2FIXED(postmp.Y), FLOAT2FIXED(postmp.Z), ALLOW_REPLACE);
 			if (thing)

--- a/src/p_effect.h
+++ b/src/p_effect.h
@@ -88,7 +88,7 @@ void P_RunEffects (void);
 
 void P_RunEffect (AActor *actor, int effects);
 
-void P_DrawRailTrail (AActor *source, const FVector3 &start, const FVector3 &end, int color1, int color2, float maxdiff = 0, int flags = 0, const PClass *spawnclass = NULL, angle_t angle = 0, int duration = 35, float sparsity = 1.0, float drift = 1.0, int SpiralOffset = 270);
+void P_DrawRailTrail(AActor *source, const TVector3<double> &start, const TVector3<double> &end, int color1, int color2, double maxdiff = 0, int flags = 0, const PClass *spawnclass = NULL, angle_t angle = 0, int duration = 35, double sparsity = 1.0, double drift = 1.0, int SpiralOffset = 270);
 void P_DrawSplash (int count, fixed_t x, fixed_t y, fixed_t z, angle_t angle, int kind);
 void P_DrawSplash2 (int count, fixed_t x, fixed_t y, fixed_t z, angle_t angle, int updown, int kind);
 void P_DisconnectEffect (AActor *actor);

--- a/src/p_enemy.cpp
+++ b/src/p_enemy.cpp
@@ -2931,7 +2931,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_MonsterRail)
 	if (linetarget == NULL)
 	{
 		// We probably won't hit the target, but aim at it anyway so we don't look stupid.
-		FVector2 xydiff(self->target->x - self->x, self->target->y - self->y);
+		TVector2<double> xydiff(self->target->x - self->x, self->target->y - self->y);
 		double zdiff = (self->target->z + (self->target->height>>1)) -
 						(self->z + (self->height>>1) - self->floorclip);
 		self->pitch = int(atan2(zdiff, xydiff.Length()) * ANGLE_180 / -M_PI);

--- a/src/p_local.h
+++ b/src/p_local.h
@@ -475,7 +475,7 @@ void	P_TraceBleed (int damage, AActor *target);		// random direction version
 bool	P_HitFloor (AActor *thing);
 bool	P_HitWater (AActor *thing, sector_t *sec, fixed_t splashx = FIXED_MIN, fixed_t splashy = FIXED_MIN, fixed_t splashz=FIXED_MIN, bool checkabove = false, bool alert = true);
 void	P_CheckSplash(AActor *self, fixed_t distance);
-void	P_RailAttack (AActor *source, int damage, int offset_xy, fixed_t offset_z = 0, int color1 = 0, int color2 = 0, float maxdiff = 0, int flags = 0, const PClass *puff = NULL, angle_t angleoffset = 0, angle_t pitchoffset = 0, fixed_t distance = 8192*FRACUNIT, int duration = 0, float sparsity = 1.0, float drift = 1.0, const PClass *spawnclass = NULL, int SpiralOffset = 270);	// [RH] Shoot a railgun
+void	P_RailAttack (AActor *source, int damage, int offset_xy, fixed_t offset_z = 0, int color1 = 0, int color2 = 0, double maxdiff = 0, int flags = 0, const PClass *puff = NULL, angle_t angleoffset = 0, angle_t pitchoffset = 0, fixed_t distance = 8192*FRACUNIT, int duration = 0, double sparsity = 1.0, double drift = 1.0, const PClass *spawnclass = NULL, int SpiralOffset = 270);	// [RH] Shoot a railgun
 
 enum	// P_RailAttack / A_RailAttack / A_CustomRailgun / P_DrawRailTrail flags
 {	

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -4150,12 +4150,12 @@ static ETraceStatus ProcessRailHit(FTraceResults &res, void *userdata)
 //
 //
 //==========================================================================
-void P_RailAttack(AActor *source, int damage, int offset_xy, fixed_t offset_z, int color1, int color2, float maxdiff, int railflags, const PClass *puffclass, angle_t angleoffset, angle_t pitchoffset, fixed_t distance, int duration, float sparsity, float drift, const PClass *spawnclass, int SpiralOffset)
+void P_RailAttack(AActor *source, int damage, int offset_xy, fixed_t offset_z, int color1, int color2, double maxdiff, int railflags, const PClass *puffclass, angle_t angleoffset, angle_t pitchoffset, fixed_t distance, int duration, double sparsity, double drift, const PClass *spawnclass, int SpiralOffset)
 {
 	fixed_t vx, vy, vz;
 	angle_t angle, pitch;
 	fixed_t x1, y1;
-	FVector3 start, end;
+	TVector3<double> start, end;
 	FTraceResults trace;
 	fixed_t shootz;
 
@@ -4304,9 +4304,9 @@ void P_RailAttack(AActor *source, int damage, int offset_xy, fixed_t offset_z, i
 	}
 
 	// Draw the slug's trail.
-	end.X = FIXED2FLOAT(trace.X);
-	end.Y = FIXED2FLOAT(trace.Y);
-	end.Z = FIXED2FLOAT(trace.Z);
+	end.X = FIXED2DBL(trace.X);
+	end.Y = FIXED2DBL(trace.Y);
+	end.Z = FIXED2DBL(trace.Z);
 	P_DrawRailTrail(source, start, end, color1, color2, maxdiff, railflags, spawnclass, source->angle + angleoffset, duration, sparsity, drift, SpiralOffset);
 }
 

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -4275,11 +4275,16 @@ void P_RailAttack(AActor *source, int damage, int offset_xy, fixed_t offset_z, i
 	// Spawn a decal or puff at the point where the trace ended.
 	if (trace.HitType == TRACE_HitWall)
 	{
-		SpawnShootDecal(source, trace);
+		AActor* puff = NULL;
+
 		if (puffclass != NULL && puffDefaults->flags3 & MF3_ALWAYSPUFF)
 		{
-			P_SpawnPuff(source, puffclass, trace.X, trace.Y, trace.Z, (source->angle + angleoffset) - ANG90, 1, 0);
+			puff = P_SpawnPuff(source, puffclass, trace.X, trace.Y, trace.Z, (source->angle + angleoffset) - ANG90, 1, 0);
 		}
+		if (puff != NULL && puffDefaults->flags7 & MF7_FORCEDECAL && puff->DecalGenerator)
+			SpawnShootDecal(puff, trace);
+		else
+			SpawnShootDecal(source, trace);
 
 	}
 	if (thepuff != NULL)

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -1502,14 +1502,14 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_RailAttack)
 	ACTION_PARAM_COLOR(Color1, 3);
 	ACTION_PARAM_COLOR(Color2, 4);
 	ACTION_PARAM_INT(Flags, 5);
-	ACTION_PARAM_FLOAT(MaxDiff, 6);
+	ACTION_PARAM_DOUBLE(MaxDiff, 6);
 	ACTION_PARAM_CLASS(PuffType, 7);
 	ACTION_PARAM_ANGLE(Spread_XY, 8);
 	ACTION_PARAM_ANGLE(Spread_Z, 9);
 	ACTION_PARAM_FIXED(Range, 10);
 	ACTION_PARAM_INT(Duration, 11);
-	ACTION_PARAM_FLOAT(Sparsity, 12);
-	ACTION_PARAM_FLOAT(DriftSpeed, 13);
+	ACTION_PARAM_DOUBLE(Sparsity, 12);
+	ACTION_PARAM_DOUBLE(DriftSpeed, 13);
 	ACTION_PARAM_CLASS(SpawnClass, 14);
 	ACTION_PARAM_FIXED(Spawnofs_Z, 15);
 	ACTION_PARAM_INT(SpiralOffset, 16);
@@ -1566,14 +1566,14 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_CustomRailgun)
 	ACTION_PARAM_COLOR(Color2, 3);
 	ACTION_PARAM_INT(Flags, 4);
 	ACTION_PARAM_INT(aim, 5);
-	ACTION_PARAM_FLOAT(MaxDiff, 6);
+	ACTION_PARAM_DOUBLE(MaxDiff, 6);
 	ACTION_PARAM_CLASS(PuffType, 7);
 	ACTION_PARAM_ANGLE(Spread_XY, 8);
 	ACTION_PARAM_ANGLE(Spread_Z, 9);
 	ACTION_PARAM_FIXED(Range, 10);
 	ACTION_PARAM_INT(Duration, 11);
-	ACTION_PARAM_FLOAT(Sparsity, 12);
-	ACTION_PARAM_FLOAT(DriftSpeed, 13);
+	ACTION_PARAM_DOUBLE(Sparsity, 12);
+	ACTION_PARAM_DOUBLE(DriftSpeed, 13);
 	ACTION_PARAM_CLASS(SpawnClass, 14);
 	ACTION_PARAM_FIXED(Spawnofs_Z, 15);
 	ACTION_PARAM_INT(SpiralOffset, 16);
@@ -1612,7 +1612,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_CustomRailgun)
 	if (linetarget == NULL && aim)
 	{
 		// We probably won't hit the target, but aim at it anyway so we don't look stupid.
-		FVector2 xydiff(self->target->x - self->x, self->target->y - self->y);
+		TVector2<double> xydiff(self->target->x - self->x, self->target->y - self->y);
 		double zdiff = (self->target->z + (self->target->height>>1)) -
 						(self->z + (self->height>>1) - self->floorclip);
 		self->pitch = int(atan2(zdiff, xydiff.Length()) * ANGLE_180 / -M_PI);


### PR DESCRIPTION
 - Puffs with MF7_FORCEDECAL were missing effect on Rail attacks for decals
 - Changed all floats in the Railgun functions to doubles for 32/64bit build sync-compatibility. (May have been a little overkill for the particles, but I don't notice any actual performance difference regardless, nor really expected one.)