### PR TITLE
sv_fastweapons extension

### DIFF
--- a/src/p_pspr.cpp
+++ b/src/p_pspr.cpp
@@ -124,9 +124,18 @@ void P_SetPsprite (player_t *player, int position, FState *state, bool nofunctio
 
 
 		if (sv_fastweapons >= 2 && position == ps_weapon)
-			psp->tics = state->ActionFunc == NULL ? 0 : !(state->GetTics() == 0);
+		{
+			if(state->ActionFunc == NULL)
+			{
+				psp->tics = 0;
+			}
+			else
+			{
+				psp->tics = (state->GetTics() != 0);
+			}
+		}
 		else if (sv_fastweapons)
-			psp->tics = !(state->GetTics() == 0);		// great for producing decals :)
+			psp->tics = (state->GetTics() != 0);		// great for producing decals :)
 		else
 			psp->tics = state->GetTics(); // could be 0
 

--- a/src/p_pspr.cpp
+++ b/src/p_pspr.cpp
@@ -124,9 +124,9 @@ void P_SetPsprite (player_t *player, int position, FState *state, bool nofunctio
 
 
 		if (sv_fastweapons >= 2 && position == ps_weapon)
-			psp->tics = state->ActionFunc == NULL? 0 : 1;
+			psp->tics = state->ActionFunc == NULL ? 0 : !(state->GetTics() == 0);
 		else if (sv_fastweapons)
-			psp->tics = 1;		// great for producing decals :)
+			psp->tics = !(state->GetTics() == 0);		// great for producing decals :)
 		else
 			psp->tics = state->GetTics(); // could be 0
 

--- a/src/p_pspr.cpp
+++ b/src/p_pspr.cpp
@@ -123,7 +123,9 @@ void P_SetPsprite (player_t *player, int position, FState *state, bool nofunctio
 		}
 
 
-		if (sv_fastweapons >= 2 && position == ps_weapon)
+		if (sv_fastweapons == 2 && position == ps_weapon)
+			psp->tics = state->ActionFunc == NULL ? 0 : 1;
+		else if (sv_fastweapons >= 4 && position == ps_weapon)
 		{
 			if(state->ActionFunc == NULL)
 			{
@@ -134,8 +136,10 @@ void P_SetPsprite (player_t *player, int position, FState *state, bool nofunctio
 				psp->tics = (state->GetTics() != 0);
 			}
 		}
+		else if (sv_fastweapons == 3)
+			psp->tics = (state->GetTics() != 0);
 		else if (sv_fastweapons)
-			psp->tics = (state->GetTics() != 0);		// great for producing decals :)
+			psp->tics = 1;		// great for producing decals :)
 		else
 			psp->tics = state->GetTics(); // could be 0
 

--- a/src/p_pspr.cpp
+++ b/src/p_pspr.cpp
@@ -125,17 +125,6 @@ void P_SetPsprite (player_t *player, int position, FState *state, bool nofunctio
 
 		if (sv_fastweapons == 2 && position == ps_weapon)
 			psp->tics = state->ActionFunc == NULL ? 0 : 1;
-		else if (sv_fastweapons >= 4 && position == ps_weapon)
-		{
-			if(state->ActionFunc == NULL)
-			{
-				psp->tics = 0;
-			}
-			else
-			{
-				psp->tics = (state->GetTics() != 0);
-			}
-		}
 		else if (sv_fastweapons == 3)
 			psp->tics = (state->GetTics() != 0);
 		else if (sv_fastweapons)


### PR DESCRIPTION
makes 0-tic frames unaffected by sv_fastweapons 3 (which acts as sv_fastweapons 1 does otherwise)