### PR TITLE
(openal) fix menus muting themselves when the volume is changed

### DIFF
--- a/src/sound/oalsound.cpp
+++ b/src/sound/oalsound.cpp
@@ -924,6 +924,8 @@ void OpenALSoundRenderer::SetSfxVolume(float volume)
         schan = schan->NextChan;
     }
 
+    alProcessUpdatesSOFT();
+
     getALError();
 }
 


### PR DESCRIPTION
since sounds aren't processed until the game is running, changing the sound volumes (which defers sound processing) would "mute" the menus until the game runs