### PR TITLE
- Fixed a KEYCONF parser issue with empty lines.

### DIFF
--- a/src/keysections.cpp
+++ b/src/keysections.cpp
@@ -177,6 +177,11 @@ void D_LoadWadSettings ()
 			{
 				cmd[i] = conf[i];
 			}
+			if (i == 0)
+			{
+				conf++;
+				continue;
+			}
 			cmd[i] = 0;
 			conf += i;
 			if (*conf == '\n')


### PR DESCRIPTION
The code attempted to access an array outside its bounds when it tried to parse empty lines.
Discovered with the Address Sanitizer.