### PR TITLE
- Fixed an uninitialized variable in stairs code.

### DIFF
--- a/src/p_floor.cpp
+++ b/src/p_floor.cpp
@@ -727,6 +727,7 @@ bool EV_BuildStairs (int tag, DFloor::EStair type, line_t *line,
 				floor->m_Type = DFloor::buildStair;	//jff 3/31/98 do not leave uninited
 				//jff 2/27/98 fix uninitialized crush field
 				floor->m_Crush = (!usespecials && speed == 4*FRACUNIT) ? 10 : -1;
+				floor->m_Hexencrush = false;
 				floor->m_ResetCount = reset;	// [RH] Tics until reset (0 if never)
 				floor->m_OrgDist = sec->floorplane.d;	// [RH] Height to reset to
 			}


### PR DESCRIPTION
'floor->m_Hexencrush' was left uninitialized in all the floor movers after the first one.