### PR TITLE
- Fixed a dangerous typo in xs_Float code.

### DIFF
--- a/src/xs_Float.h
+++ b/src/xs_Float.h
@@ -209,7 +209,7 @@ finline static uint32 xs_FloorToUInt(real64 val)
 
 finline static uint32 xs_CeilToUInt(real64 val)
 {
-	return (uint32)xs_CeilToUInt(val);
+	return (uint32)xs_CeilToInt(val);
 }
 
 finline static uint32 xs_RoundToUInt(real64 val)


### PR DESCRIPTION
The function 'xs_CeilToUInt' would call itself, leading to infinite loop, due to a typo. It should call 'xs_CeilToInt' instead.