### PR TITLE
- Added WARPF_QTR, MID, and TOP

### DIFF
--- a/src/p_local.h
+++ b/src/p_local.h
@@ -198,6 +198,9 @@ enum WARPF
 	WARPF_MOVEPTR          = 0x1000,
 	WARPF_USEPTR           = 0x2000,
 	WARPF_USETID           = 0x2000,
+	WARPF_QTR				= 0x00004000,
+	WARPF_MID				= 0x00008000,
+	WARPF_TOP				= 0x00010000,		
 };
 
 

--- a/src/p_things.cpp
+++ b/src/p_things.cpp
@@ -692,6 +692,23 @@ int P_Thing_Warp(AActor *caller, AActor *reference, fixed_t xofs, fixed_t yofs, 
 	fixed_t	oldx = caller->x;
 	fixed_t	oldy = caller->y;
 	fixed_t	oldz = caller->z;
+	fixed_t newz = 0;
+
+	if ((flags & WARPF_QTR) && (flags & WARPF_MID))
+	{
+		newz = reference->height - (reference->height / 4);
+	}
+	else
+	{
+		if (flags & WARPF_MID)
+			newz = reference->height / 2;
+		else if (flags & WARPF_QTR)
+			newz = reference->height / 4;
+	}
+	if (flags & WARPF_TOP)
+	{
+		newz = reference->height;
+	}
 
 	if (!(flags & WARPF_ABSOLUTEANGLE))
 	{
@@ -719,7 +736,7 @@ int P_Thing_Warp(AActor *caller, AActor *reference, fixed_t xofs, fixed_t yofs, 
 			caller->SetOrigin(
 				reference->x + xofs,
 				reference->y + yofs,
-				reference->z);
+				reference->z + newz);
 
 			// now the caller's floorz should be appropriate for the assigned xy-position
 			// assigning position again with
@@ -730,14 +747,14 @@ int P_Thing_Warp(AActor *caller, AActor *reference, fixed_t xofs, fixed_t yofs, 
 				caller->SetOrigin(
 					caller->x,
 					caller->y,
-					caller->floorz + zofs);
+					caller->floorz + zofs + newz);
 			}
 			else
 			{
 				// if there is no offset, there should be no ill effect from moving down to the already defined floor
 
 				// A_Teleport does the same thing anyway
-				caller->z = caller->floorz;
+				caller->z = caller->floorz + newz;
 			}
 		}
 		else
@@ -745,18 +762,18 @@ int P_Thing_Warp(AActor *caller, AActor *reference, fixed_t xofs, fixed_t yofs, 
 			caller->SetOrigin(
 				reference->x + xofs,
 				reference->y + yofs,
-				reference->z + zofs);
+				reference->z + zofs + newz);
 		}
 	}
 	else // [MC] The idea behind "absolute" is meant to be "absolute". Override everything, just like A_SpawnItemEx's.
 	{
 		if (flags & WARPF_TOFLOOR)
 		{
-			caller->SetOrigin(xofs, yofs, caller->floorz + zofs);
+			caller->SetOrigin(xofs, yofs, caller->floorz + zofs + newz);
 		}
 		else
 		{
-			caller->SetOrigin(xofs, yofs, zofs);
+			caller->SetOrigin(xofs, yofs, zofs + newz);
 		}
 	}
 

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -358,6 +358,9 @@ Const Int WARPF_ABSOLUTEPOSITION = 0x400;
 Const Int WARPF_BOB = 0x800;
 Const Int WARPF_MOVEPTR = 0x1000;
 Const Int WARPF_USETID = 0x2000;
+Const Int WARPF_QTR				= 0x00004000;
+Const Int WARPF_MID				= 0x00008000;
+Const Int WARPF_TOP				= 0x00010000;	
 
 // flags for A_SetPitch/SetAngle/SetRoll
 const int SPF_FORCECLAMP = 1;


### PR DESCRIPTION
- QTR offsets the warping actor by 1/4th the target's height.
- MID offsets by 1/2. Combine with QTR to offset by 3/4.
- TOP puts the calling actor directly on top of it. Top takes precedence over QTR and MID.