### PR TITLE
[DEC] Sound channel decorate properties

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -611,8 +611,6 @@ extern FDropItemPtrArray DropItemList;
 void FreeDropItemChain(FDropItem *chain);
 int StoreDropItemChain(FDropItem *chain);
 
-
-
 // Map Object definition.
 class AActor : public DThinker
 {
@@ -1012,6 +1010,17 @@ public:
 	FSoundIDNoInit BounceSound;
 	FSoundIDNoInit WallBounceSound;
 	FSoundIDNoInit CrushPainSound;
+
+	// [ZK] Property sound channels
+	int SeeSoundChannel;
+	int AttackSoundChannel;
+	int PainSoundChannel;
+	int DeathSoundChannel;
+	int ActiveSoundChannel;
+	int UseSoundChannel;
+	int BounceSoundChannel;
+	int WallBounceSoundChannel;
+	int CrushPainSoundChannel;
 
 	fixed_t Speed;
 	fixed_t FloatSpeed;

--- a/src/fragglescript/t_func.cpp
+++ b/src/fragglescript/t_func.cpp
@@ -4288,7 +4288,7 @@ void FParser::SF_SpawnShot2(void)
 		AActor *mo = Spawn (PClass, source->x, source->y, source->z+z, ALLOW_REPLACE);
 		if (mo) 
 		{
-			S_Sound (mo, CHAN_VOICE, mo->SeeSound, 1, ATTN_NORM);
+			S_Sound (mo, mo->SeeSoundChannel, mo->SeeSound, 1, ATTN_NORM);
 			mo->target = source;
 			P_ThrustMobj(mo, mo->angle = source->angle, mo->Speed);
 			if (!P_CheckMissileSpawn(mo, source->radius)) mo = NULL;

--- a/src/g_shared/a_pickups.h
+++ b/src/g_shared/a_pickups.h
@@ -186,6 +186,9 @@ public:
 
 	FSoundIDNoInit PickupSound;
 
+	// [ZK] Property sound channels
+	int PickupSoundChannel;
+
 	virtual void BecomeItem ();
 	virtual void BecomePickup ();
 	virtual void AttachToOwner (AActor *other);

--- a/src/g_strife/a_strifestuff.cpp
+++ b/src/g_strife/a_strifestuff.cpp
@@ -451,7 +451,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_GetHurt)
 	self->flags4 |= MF4_INCOMBAT;
 	if ((pr_gethurt() % 5) == 0)
 	{
-		S_Sound (self, CHAN_VOICE, self->PainSound, 1, ATTN_NORM);
+		S_Sound (self, self->PainSoundChannel, self->PainSound, 1, ATTN_NORM);
 		self->health--;
 	}
 	if (self->health <= 0)

--- a/src/p_enemy.cpp
+++ b/src/p_enemy.cpp
@@ -2012,11 +2012,11 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_LookEx)
 	{
 		if (flags & LOF_FULLVOLSEESOUND)
 		{ // full volume
-			S_Sound (self, CHAN_VOICE, self->SeeSound, 1, ATTN_NONE);
+			S_Sound (self, self->SeeSoundChannel, self->SeeSound, 1, ATTN_NONE);
 		}
 		else
 		{
-			S_Sound (self, CHAN_VOICE, self->SeeSound, 1, ATTN_NORM);
+			S_Sound (self, self->SeeSoundChannel, self->SeeSound, 1, ATTN_NORM);
 		}
 	}
 

--- a/src/p_enemy.cpp
+++ b/src/p_enemy.cpp
@@ -3188,11 +3188,11 @@ DEFINE_ACTION_FUNCTION(AActor, A_Pain)
 			sfx_id = pain_amount;
 		}
 
-		S_Sound (self, CHAN_VOICE, sfx_id, 1, ATTN_NORM);
+		S_Sound (self, self->PainSoundChannel, sfx_id, 1, ATTN_NORM);
 	}
 	else if (self->PainSound)
 	{
-		S_Sound (self, CHAN_VOICE, self->PainSound, 1, ATTN_NORM);
+		S_Sound (self, self->PainSoundChannel, self->PainSound, 1, ATTN_NORM);
 	}
 }
 

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -5121,7 +5121,7 @@ void P_DoCrunch(AActor *thing, FChangePosition *cpos)
 			}
 			if (thing->CrushPainSound != 0 && !S_GetSoundPlayingInfo(thing, thing->CrushPainSound))
 			{
-				S_Sound(thing, CHAN_VOICE, thing->CrushPainSound, 1.f, ATTN_NORM);
+				S_Sound(thing, thing->CrushPainSoundChannel, thing->CrushPainSound, 1.f, ATTN_NORM);
 			}
 		}
 	}

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -1346,7 +1346,7 @@ void P_ExplodeMissile (AActor *mo, line_t *line, AActor *target)
 	// play the sound before changing the state, so that AActor::Destroy can call S_RelinkSounds on it and the death state can override it.
 	if (mo->DeathSound)
 	{
-		S_Sound (mo, CHAN_VOICE, mo->DeathSound, 1,
+		S_Sound (mo, mo->DeathSoundChannel, mo->DeathSound, 1,
 			(mo->flags3 & MF3_FULLVOLDEATH) ? ATTN_NONE : ATTN_NORM);
 	}
 
@@ -1401,15 +1401,15 @@ void AActor::PlayBounceSound(bool onfloor)
 	{
 		if (BounceFlags & BOUNCE_UseSeeSound)
 		{
-			S_Sound (this, CHAN_VOICE, SeeSound, 1, ATTN_IDLE);
+			S_Sound (this, SeeSoundChannel, SeeSound, 1, ATTN_IDLE);
 		}
 		else if (onfloor || WallBounceSound <= 0)
 		{
-			S_Sound (this, CHAN_VOICE, BounceSound, 1, ATTN_IDLE);
+			S_Sound (this, BounceSoundChannel, BounceSound, 1, ATTN_IDLE);
 		}
 		else
 		{
-			S_Sound (this, CHAN_VOICE, WallBounceSound, 1, ATTN_IDLE);
+			S_Sound (this, WallBounceSoundChannel, WallBounceSound, 1, ATTN_IDLE);
 		}
 	}
 }
@@ -3037,7 +3037,7 @@ void AActor::PlayActiveSound ()
 {
 	if (ActiveSound && !S_IsActorPlayingSomething (this, CHAN_VOICE, -1))
 	{
-		S_Sound (this, CHAN_VOICE, ActiveSound, 1,
+		S_Sound (this, ActiveSoundChannel, ActiveSound, 1,
 			(flags3 & MF3_FULLVOLACTIVE) ? ATTN_NONE : ATTN_IDLE);
 	}
 }
@@ -5060,11 +5060,11 @@ AActor *P_SpawnPuff (AActor *source, const PClass *pufftype, fixed_t x, fixed_t 
 
 		if ((flags & PF_HITTHING) && puff->SeeSound)
 		{ // Hit thing sound
-			S_Sound (puff, CHAN_BODY, puff->SeeSound, 1, ATTN_NORM);
+			S_Sound (puff, puff->SeeSoundChannel, puff->SeeSound, 1, ATTN_NORM);
 		}
 		else if (puff->AttackSound)
 		{
-			S_Sound (puff, CHAN_BODY, puff->AttackSound, 1, ATTN_NORM);
+			S_Sound (puff, puff->AttackSoundChannel, puff->AttackSound, 1, ATTN_NORM);
 		}
 	}
 
@@ -5631,18 +5631,18 @@ void P_PlaySpawnSound(AActor *missile, AActor *spawner)
 	{
 		if (!(missile->flags & MF_SPAWNSOUNDSOURCE))
 		{
-			S_Sound (missile, CHAN_VOICE, missile->SeeSound, 1, ATTN_NORM);
+			S_Sound (missile, missile->SeeSoundChannel, missile->SeeSound, 1, ATTN_NORM);
 		}
 		else if (spawner != NULL)
 		{
-			S_Sound (spawner, CHAN_WEAPON, missile->SeeSound, 1, ATTN_NORM);
+			S_Sound (spawner, spawner->SeeSoundChannel, missile->SeeSound, 1, ATTN_NORM);
 		}
 		else
 		{
 			// If there is no spawner use the spawn position.
 			// But not in a silenced sector.
 			if (!(missile->Sector->Flags & SECF_SILENT))
-				S_Sound (missile->x, missile->y, missile->z, CHAN_WEAPON, missile->SeeSound, 1, ATTN_NORM);
+				S_Sound (missile->x, missile->y, missile->z, missile->SeeSoundChannel, missile->SeeSound, 1, ATTN_NORM);
 		}
 	}
 }

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -3035,7 +3035,7 @@ bool AActor::AdjustReflectionAngle (AActor *thing, angle_t &angle)
 
 void AActor::PlayActiveSound ()
 {
-	if (ActiveSound && !S_IsActorPlayingSomething (this, CHAN_VOICE, -1))
+	if (ActiveSound && !S_IsActorPlayingSomething (this, ActiveSoundChannel, -1))
 	{
 		S_Sound (this, ActiveSoundChannel, ActiveSound, 1,
 			(flags3 & MF3_FULLVOLACTIVE) ? ATTN_NONE : ATTN_IDLE);

--- a/src/p_user.cpp
+++ b/src/p_user.cpp
@@ -813,7 +813,7 @@ bool APlayerPawn::UseInventory (AInventory *item)
 	}
 	if (player == &players[consoleplayer])
 	{
-		S_Sound (this, CHAN_ITEM, item->UseSound, 1, ATTN_NORM);
+		S_Sound (this, item->UseSoundChannel, item->UseSound, 1, ATTN_NORM);
 		StatusBar->FlashItem (itemtype);
 	}
 	return true;

--- a/src/thingdef/olddecorations.cpp
+++ b/src/thingdef/olddecorations.cpp
@@ -554,6 +554,23 @@ static void ParseInsideDecoration (Baggage &bag, AActor *defaults,
 			sc.MustGetString ();
 			defaults->SeeSound = sc.String;
 		}
+		// [ZK] Property sound channels
+		else if ((def == DEF_BreakableDecoration || def == DEF_Projectile) &&
+			sc.Compare("DeathSoundChannel"))
+		{
+			sc.MustGetNumber();
+			defaults->DeathSoundChannel = sc.Number;
+		}
+		else if (def == DEF_BreakableDecoration && sc.Compare("BurnDeathSoundChannel"))
+		{
+			sc.MustGetNumber();
+			defaults->ActiveSoundChannel = sc.Number;
+		}
+		else if (def == DEF_Projectile && sc.Compare("SpawnSoundChannel"))
+		{
+			sc.MustGetNumber();
+			defaults->SeeSoundChannel = sc.Number;
+		}
 		else if (def == DEF_Projectile && sc.Compare ("DoomBounce"))
 		{
 			defaults->BounceFlags = BOUNCE_DoomCompat;
@@ -570,6 +587,12 @@ static void ParseInsideDecoration (Baggage &bag, AActor *defaults,
 		{
 			sc.MustGetString ();
 			inv->PickupSound = sc.String;
+		}
+		// [ZK] Property sound channels
+		else if (def == DEF_Pickup && sc.Compare("PickupSoundChannel"))
+		{
+			sc.MustGetNumber();
+			inv->PickupSoundChannel = sc.Number;
 		}
 		else if (def == DEF_Pickup && sc.Compare ("PickupMessage"))
 		{

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -529,7 +529,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_BulletAttack)
 
 	slope = P_AimLineAttack (self, bangle, MISSILERANGE);
 
-	S_Sound (self, CHAN_WEAPON, self->AttackSound, 1, ATTN_NORM);
+	S_Sound (self, self->AttackSoundChannel, self->AttackSound, 1, ATTN_NORM);
 	for (i = self->GetMissileDamage (0, 1); i > 0; --i)
     {
 		int angle = bangle + (pr_cabullet.Random2() << 20);
@@ -1092,7 +1092,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_CustomBulletAttack)
 
 		if (!(Flags & CBAF_NOPITCH)) bslope = P_AimLineAttack (self, bangle, MISSILERANGE);
 
-		S_Sound (self, CHAN_WEAPON, self->AttackSound, 1, ATTN_NORM);
+		S_Sound (self, self->AttackSoundChannel, self->AttackSound, 1, ATTN_NORM);
 		for (i=0 ; i<NumBullets ; i++)
 		{
 			int angle = bangle;
@@ -1269,7 +1269,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FireBullets)
 
 	if (weapon != NULL)
 	{
-		S_Sound (self, CHAN_WEAPON, weapon->AttackSound, 1, ATTN_NORM);
+		S_Sound (self, weapon->AttackSoundChannel, weapon->AttackSound, 1, ATTN_NORM);
 	}
 
 	if ((NumberOfBullets==1 && !player->refire) || NumberOfBullets==0)
@@ -1471,7 +1471,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_CustomPunch)
 
 		if (weapon != NULL)
 		{
-			S_Sound (self, CHAN_WEAPON, weapon->AttackSound, 1, ATTN_NORM);
+			S_Sound (self, weapon->AttackSoundChannel, weapon->AttackSound, 1, ATTN_NORM);
 		}
 
 		if (!(flags & CPF_NOTURN))

--- a/src/thingdef/thingdef_properties.cpp
+++ b/src/thingdef/thingdef_properties.cpp
@@ -744,6 +744,78 @@ DEFINE_PROPERTY(crushpainsound, S, Actor)
 }
 
 //==========================================================================
+// [ZK] Property sound channels
+//==========================================================================
+DEFINE_PROPERTY(seesoundchannel, I, Actor)
+{
+	PROP_INT_PARM(chan, 0);
+	defaults->SeeSoundChannel = chan;
+}
+
+//==========================================================================
+//
+//==========================================================================
+DEFINE_PROPERTY(attacksoundchannel, I, Actor)
+{
+	PROP_INT_PARM(chan, 0);
+	defaults->AttackSoundChannel = chan;
+}
+
+//==========================================================================
+//
+//==========================================================================
+DEFINE_PROPERTY(bouncesoundchannel, I, Actor)
+{
+	PROP_INT_PARM(chan, 0);
+	defaults->BounceSoundChannel = chan;
+}
+
+//==========================================================================
+//
+//==========================================================================
+DEFINE_PROPERTY(wallbouncesoundchannel, I, Actor)
+{
+	PROP_INT_PARM(chan, 0);
+	defaults->WallBounceSoundChannel = chan;
+}
+
+//==========================================================================
+//
+//==========================================================================
+DEFINE_PROPERTY(painsoundchannel, I, Actor)
+{
+	PROP_INT_PARM(chan, 0);
+	defaults->PainSoundChannel = chan;
+}
+
+//==========================================================================
+//
+//==========================================================================
+DEFINE_PROPERTY(deathsoundchannel, I, Actor)
+{
+	PROP_INT_PARM(chan, 0);
+	defaults->DeathSoundChannel = chan;
+}
+
+//==========================================================================
+//
+//==========================================================================
+DEFINE_PROPERTY(activesoundchannel, I, Actor)
+{
+	PROP_INT_PARM(chan, 0);
+	defaults->ActiveSoundChannel = chan;
+}
+
+//==========================================================================
+//
+//==========================================================================
+DEFINE_PROPERTY(crushpainsoundchannel, I, Actor)
+{
+	PROP_INT_PARM(chan, 0);
+	defaults->CrushPainSoundChannel = chan;
+}
+
+//==========================================================================
 //
 //==========================================================================
 DEFINE_PROPERTY(dropitem, S_i_i, Actor)
@@ -1730,6 +1802,15 @@ DEFINE_CLASS_PROPERTY(pickupsound, S, Inventory)
 }
 
 //==========================================================================
+// [ZK] Property sound channels
+//==========================================================================
+DEFINE_CLASS_PROPERTY(pickupsoundchannel, I, Inventory)
+{
+	PROP_INT_PARM(chan, 0);
+	defaults->PickupSoundChannel = chan;
+}
+
+//==========================================================================
 // Dummy for Skulltag compatibility...
 //==========================================================================
 DEFINE_CLASS_PROPERTY(pickupannouncerentry, S, Inventory)
@@ -1752,6 +1833,15 @@ DEFINE_CLASS_PROPERTY(usesound, S, Inventory)
 {
 	PROP_STRING_PARM(str, 0);
 	defaults->UseSound = str;
+}
+
+//==========================================================================
+// [ZK] Property sound channels
+//==========================================================================
+DEFINE_CLASS_PROPERTY(usesoundchannel, I, Inventory)
+{
+	PROP_INT_PARM(chan, 0);
+	defaults->UseSoundChannel = chan;
 }
 
 //==========================================================================

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -31,7 +31,7 @@ ACTOR Actor native //: Thinker
 	RipperLevel 0
 	RipLevelMin 0
 	RipLevelMax 0
-	SeeSoundChannel 4        // CHAN_BODY
+	SeeSoundChannel 2        // CHAN_VOICE
 	AttackSoundChannel 1     // CHAN_WEAPON
 	PainSoundChannel 2       // CHAN_VOICE
 	CrushPainSoundChannel 2  // CHAN_VOICE

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -31,6 +31,14 @@ ACTOR Actor native //: Thinker
 	RipperLevel 0
 	RipLevelMin 0
 	RipLevelMax 0
+	SeeSoundChannel 4        // CHAN_BODY
+	AttackSoundChannel 1     // CHAN_WEAPON
+	PainSoundChannel 2       // CHAN_VOICE
+	CrushPainSoundChannel 2  // CHAN_VOICE
+	DeathSoundChannel 2      // CHAN_VOICE
+	ActiveSoundChannel 2     // CHAN_VOICE
+	BounceSoundChannel 2     // CHAN_VOICE
+	WallBounceSoundChannel 2 // CHAN_VOICE
 
 	// Variables for the expression evaluator
 	// NOTE: fixed_t and angle_t are only used here to ensure proper conversion

--- a/wadsrc/static/actors/shared/inventory.txt
+++ b/wadsrc/static/actors/shared/inventory.txt
@@ -6,7 +6,7 @@ ACTOR Inventory native
 	Inventory.UseSound "misc/invuse"
 	Inventory.UseSoundChannel 3 // CHAN_ITEM
 	Inventory.PickupSound "misc/i_pkup"
-	Inventory.PickupSoundChannel 2 // CHAN_VOICE
+	Inventory.PickupSoundChannel 3 // CHAN_ITEM
 	Inventory.PickupMessage "$TXT_DEFAULTPICKUPMSG"
 	
 	action native A_JumpIfNoAmmo(state label);

--- a/wadsrc/static/actors/shared/inventory.txt
+++ b/wadsrc/static/actors/shared/inventory.txt
@@ -4,7 +4,9 @@ ACTOR Inventory native
 	Inventory.MaxAmount 1
 	Inventory.InterHubAmount 1
 	Inventory.UseSound "misc/invuse"
+	Inventory.UseSoundChannel 3 // CHAN_ITEM
 	Inventory.PickupSound "misc/i_pkup"
+	Inventory.PickupSoundChannel 2 // CHAN_VOICE
 	Inventory.PickupMessage "$TXT_DEFAULTPICKUPMSG"
 	
 	action native A_JumpIfNoAmmo(state label);


### PR DESCRIPTION
Added the following decorate properties:
SeeSoundChannel, AttackSoundChannel, PainSoundChannel, CrushPainSoundChannel, DeathSoundChannel, ActiveSoundChannel, BounceSoundChannel, WallBounceSoundChannel, Inventory.UseSoundChannel and Inventory.PickupSoundChannel.