### PR TITLE
- Added ThrustFactor.

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -373,6 +373,7 @@ enum ActorFlag7
 	MF7_NODECAL			= 0x00040000,	// [ZK] Forces puff to have no impact decal
 	MF7_FORCEDECAL		= 0x00080000,	// [ZK] Forces puff's decal to override the weapon's.
 	MF7_LAXTELEFRAGDMG	= 0x00100000,	// [MC] Telefrag damage can be reduced.
+	MF7_NOIMPACTDMG		= 0x00200000,	// [MC] Actor cannot give or receive impact damage from being blasted.
 };
 
 // --- mobj.renderflags ---
@@ -611,7 +612,7 @@ extern FDropItemPtrArray DropItemList;
 void FreeDropItemChain(FDropItem *chain);
 int StoreDropItemChain(FDropItem *chain);
 
-
+typedef TMap<FName, fixed_t> ThrustFactorList;
 
 // Map Object definition.
 class AActor : public DThinker
@@ -827,6 +828,9 @@ public:
 	void SetPitch(int p, bool interpolate, bool forceclamp = false);
 	void SetAngle(angle_t ang, bool interpolate);
 	void SetRoll(angle_t roll, bool interpolate);
+	void SetThrustFactor(FName dmgtype, fixed_t amount);
+	fixed_t GetThrustFactor(FName dmgtype = NAME_None);
+	bool CheckThrustType(FName dmgtype);
 
 	const PClass *GetBloodType(int type = 0) const
 	{
@@ -1031,6 +1035,9 @@ public:
 	int RipperLevel;
 	int RipLevelMin;
 	int RipLevelMax;
+
+	fixed_t ThrustFactor;
+	ThrustFactorList *ThrustFactors;
 
 	FState *SpawnState;
 	FState *SeeState;

--- a/src/dobjtype.cpp
+++ b/src/dobjtype.cpp
@@ -139,6 +139,11 @@ void PClass::StaticFreeData (PClass *type)
 {
 	if (type->Defaults != NULL)
 	{
+		if (((AActor*)(type->Defaults))->ThrustFactors)
+		{
+			delete ((AActor*)(type->Defaults))->ThrustFactors;
+			((AActor*)(type->Defaults))->ThrustFactors = NULL;
+		}
 		M_Free(type->Defaults);
 		type->Defaults = NULL;
 	}

--- a/src/g_doom/a_archvile.cpp
+++ b/src/g_doom/a_archvile.cpp
@@ -121,7 +121,9 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_VileAttack)
 		
 	if (NULL == (target = self->target))
 		return;
-	
+
+	fixed_t thrustmul = target->GetThrustFactor(dmgtype);
+
 	A_FaceTarget (self);
 
 	if (!P_CheckSight (self, target, 0) )
@@ -152,5 +154,6 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_VileAttack)
 		P_RadiusAttack (fire, self, blastdmg, blastrad, dmgtype, 0);
 	}
 	if (!(target->flags7 & MF7_DONTTHRUST))
-		target->velz = Scale(thrust, 1000, target->Mass);
+		target->velz = Scale(thrust, 1000, target->Mass) * thrustmul;
+
 }

--- a/src/g_heretic/a_ironlich.cpp
+++ b/src/g_heretic/a_ironlich.cpp
@@ -27,12 +27,13 @@ IMPLEMENT_CLASS(AWhirlwind)
 int AWhirlwind::DoSpecialDamage (AActor *target, int damage, FName damagetype)
 {
 	int randVal;
+	fixed_t thrustmul = target->GetThrustFactor(damagetype);
 
 	if (!(target->flags7 & MF7_DONTTHRUST))
 	{
 		target->angle += pr_foo.Random2() << 20;
-		target->velx += pr_foo.Random2() << 10;
-		target->vely += pr_foo.Random2() << 10;
+		target->velx += (pr_foo.Random2() << 10) * thrustmul;
+		target->vely += (pr_foo.Random2() << 10) * thrustmul;
 	}
 
 	if ((level.time & 16) && !(target->flags2 & MF2_BOSS) && !(target->flags7 & MF7_DONTTHRUST))
@@ -42,9 +43,10 @@ int AWhirlwind::DoSpecialDamage (AActor *target, int damage, FName damagetype)
 		{
 			randVal = 160;
 		}
-		target->velz += randVal << 11;
+		target->velz += (randVal << 11) * thrustmul;
 		if (target->velz > 12*FRACUNIT)
 		{
+
 			target->velz = 12*FRACUNIT;
 		}
 	}

--- a/src/g_hexen/a_blastradius.cpp
+++ b/src/g_hexen/a_blastradius.cpp
@@ -26,7 +26,7 @@ void BlastActor (AActor *victim, fixed_t strength, fixed_t speed, AActor * Owner
 {
 	angle_t angle,ang;
 	AActor *mo;
-	fixed_t x,y,z;
+	fixed_t x,y,z, velmul;
 
 	if (!victim->SpecialBlastHandling (Owner, strength))
 	{
@@ -35,9 +35,10 @@ void BlastActor (AActor *victim, fixed_t strength, fixed_t speed, AActor * Owner
 
 	angle = R_PointToAngle2 (Owner->x, Owner->y, victim->x, victim->y);
 	angle >>= ANGLETOFINESHIFT;
-	victim->velx = FixedMul (speed, finecosine[angle]);
-	victim->vely = FixedMul (speed, finesine[angle]);
-
+	velmul = victim->GetThrustFactor(NAME_Melee);
+	victim->velx = FixedMul ((speed*velmul), finecosine[angle]);
+	victim->vely = FixedMul ((speed*velmul), finesine[angle]);
+	
 	// Spawn blast puff
 	ang = R_PointToAngle2 (victim->x, victim->y, Owner->x, Owner->y);
 	ang >>= ANGLETOFINESHIFT;
@@ -55,19 +56,19 @@ void BlastActor (AActor *victim, fixed_t strength, fixed_t speed, AActor * Owner
 		// [RH] Floor and ceiling huggers should not be blasted vertically.
 		if (!(victim->flags3 & (MF3_FLOORHUGGER|MF3_CEILINGHUGGER)))
 		{
-			victim->velz = 8*FRACUNIT;
+			victim->velz = (8*FRACUNIT)*velmul;
 			mo->velz = victim->velz;
 		}
 	}
 	else
 	{
-		victim->velz = (1000 / victim->Mass) << FRACBITS;
+		victim->velz = ((1000 / victim->Mass) << FRACBITS) * velmul;
 	}
 	if (victim->player)
 	{
 		// Players handled automatically
 	}
-	else if (!dontdamage)
+	else if (!dontdamage && !(victim->flags7 & MF7_NOIMPACTDMG) && (velmul > 0))
 	{
 		victim->flags2 |= MF2_BLASTED;
 	}

--- a/src/g_strife/a_loremaster.cpp
+++ b/src/g_strife/a_loremaster.cpp
@@ -25,12 +25,13 @@ int ALoreShot::DoSpecialDamage (AActor *victim, int damage, FName damagetype)
 	
 	if (victim != NULL && target != NULL && !(victim->flags7 & MF7_DONTTHRUST))
 	{
+		fixed_t thrustmul = victim->GetThrustFactor(damagetype);
 		thrust.X = float(target->x - victim->x);
 		thrust.Y = float(target->y - victim->y);
 		thrust.Z = float(target->z - victim->z);
 	
 		thrust.MakeUnit();
-		thrust *= float((255*50*FRACUNIT) / (victim->Mass ? victim->Mass : 1));
+		thrust *= float(((255*50*FRACUNIT) / (victim->Mass ? victim->Mass : 1)) * thrustmul);
 	
 		victim->velx += fixed_t(thrust.X);
 		victim->vely += fixed_t(thrust.Y);

--- a/src/p_interaction.cpp
+++ b/src/p_interaction.cpp
@@ -1170,11 +1170,16 @@ int P_DamageMobj (AActor *target, AActor *inflictor, AActor *source, int damage,
 			// Calculate this as float to avoid overflows so that the
 			// clamping that had to be done here can be removed.
             double fltthrust;
+			double thrustmul = FIXED2DBL(target->GetThrustFactor(mod));
 
             fltthrust = mod == NAME_MDK ? 10 : 32;
             if (target->Mass > 0)
             {
-                fltthrust = clamp((damage * 0.125 * kickback) / target->Mass, 0., fltthrust);
+				bool thrustExists = target->CheckThrustType(mod);
+				if (thrustExists) //Use the raw damage instead, so modders can have finer control over it.
+					fltthrust = clamp(((rawdamage * 0.125 * kickback) / target->Mass) * thrustmul, 0., fltthrust);
+				else //...but only if it exists.
+					fltthrust = clamp(((damage * 0.125 * kickback) / target->Mass) * thrustmul, 0., fltthrust);
             }
 
 			thrust = FLOAT2FIXED(fltthrust);

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -4811,10 +4811,12 @@ void P_RadiusAttack(AActor *bombspot, AActor *bombsource, int bombdamage, int bo
 				double thrust;
 				int damage = abs((int)points);
 				int newdam = damage;
-
+				fixed_t thrustmul = thing->GetThrustFactor(bombmod);
 				if (!(flags & RADF_NODAMAGE))
 					newdam = P_DamageMobj(thing, bombspot, bombsource, damage, bombmod);
-				else if (thing->player == NULL && (!(flags & RADF_NOIMPACTDAMAGE) && !(thing->flags7 & MF7_DONTTHRUST)))
+				else if (thing->player == NULL 
+				&& (!(flags & RADF_NOIMPACTDAMAGE) && !(thing->flags7 & MF7_DONTTHRUST) && !(thing->flags7 & MF7_NOIMPACTDMG))
+				&& (thrustmul > 0))
 					thing->flags2 |= MF2_BLASTED;
 
 				if (!(thing->flags & MF_ICECORPSE))
@@ -4826,9 +4828,10 @@ void P_RadiusAttack(AActor *bombspot, AActor *bombsource, int bombdamage, int bo
 					{
 						if (bombsource == NULL || !(bombsource->flags2 & MF2_NODMGTHRUST))
 						{
-							if (!(thing->flags7 & MF7_DONTTHRUST))
+							if (!(thing->flags7 & MF7_DONTTHRUST) && (thrustmul > 0))
 							{
-							
+								
+								
 								thrust = points * 0.5f / (double)thing->Mass;
 								if (bombsource == thing)
 								{
@@ -4844,10 +4847,10 @@ void P_RadiusAttack(AActor *bombspot, AActor *bombsource, int bombdamage, int bo
 									velz *= 0.8f;
 								}
 								angle_t ang = R_PointToAngle2(bombspot->x, bombspot->y, thing->x, thing->y) >> ANGLETOFINESHIFT;
-								thing->velx += fixed_t(finecosine[ang] * thrust);
-								thing->vely += fixed_t(finesine[ang] * thrust);
+								thing->velx += fixed_t(finecosine[ang] * thrust) * thrustmul;
+								thing->vely += fixed_t(finesine[ang] * thrust) * thrustmul;
 								if (!(flags & RADF_NODAMAGE))
-									thing->velz += (fixed_t)velz;	// this really doesn't work well
+									thing->velz += (fixed_t)velz * thrustmul;	// this really doesn't work well
 							}
 						}
 					}

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -5823,3 +5823,34 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetRipMax)
 	ACTION_PARAM_INT(max, 0);
 	self->RipLevelMax = max;
 }
+
+//===========================================================================
+// A_SetThrustFactor(amount, damagetype, pointer)
+//
+// Sets the thrust factor of an actor('s pointer). Thrust Factor can be set
+// for damagetypes, so it allows the actor to take more/less of a thrust based
+// upon a certain damagetype that's hurting it. Itt multiplies the 
+// thrust amount after mass calculations, and doesn't rely upon damage
+// factored out. It uses the raw damage instead, if thrust by actual damage.
+//===========================================================================
+
+DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetThrustFactor)
+{
+	ACTION_PARAM_START(3);
+	ACTION_PARAM_FIXED(amount, 0);
+	ACTION_PARAM_NAME(dmgtype, 1);
+	ACTION_PARAM_INT(ptr, 2);
+
+	AActor *mobj = COPY_AAPTR(self, ptr);
+
+	if (!mobj)
+	{
+		ACTION_SET_RESULT(false);
+		return;
+	}
+
+	if (!dmgtype || dmgtype == NAME_None || !stricmp("none", dmgtype))
+		mobj->ThrustFactor = amount;
+	else
+		mobj->SetThrustFactor(dmgtype, amount);
+}

--- a/src/thingdef/thingdef_data.cpp
+++ b/src/thingdef/thingdef_data.cpp
@@ -259,6 +259,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF7, FORCEDECAL, AActor, flags7),
 
 	DEFINE_FLAG(MF7, LAXTELEFRAGDMG, AActor, flags7),
+	DEFINE_FLAG(MF7, NOIMPACTDMG, AActor, flags7),
 
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),

--- a/src/thingdef/thingdef_properties.cpp
+++ b/src/thingdef/thingdef_properties.cpp
@@ -1179,6 +1179,28 @@ DEFINE_PROPERTY(damagefactor, ZF, Actor)
 //==========================================================================
 //
 //==========================================================================
+DEFINE_PROPERTY(thrustfactor, ZF, Actor)
+{
+	PROP_STRING_PARM(str, 0);
+	PROP_FIXED_PARM(id, 1);
+
+	if (str == NULL)
+	{
+		defaults->ThrustFactor = id;
+	}
+	else
+	{
+		FName thrustType;
+		if (!stricmp(str, "Normal")) thrustType = NAME_None;
+		else thrustType = str;
+
+		defaults->SetThrustFactor(thrustType, id);
+	}
+}
+
+//==========================================================================
+//
+//==========================================================================
 DEFINE_PROPERTY(decal, S, Actor)
 {
 	PROP_STRING_PARM(str, 0);


### PR DESCRIPTION
- Works just like DamageFactor, except individual named factors take precedence over the undefined. Default is 1.0.
- Added A_SetThrustFactor (float amount, damagetype, pointer). Leaving damagetype as "none" will set the global actor valuable.
- Added +NOIMPACTDAMAGE which prevents the actor from being flagged as blasted when thrusted.