### PR TITLE
Minor fixes from sanitize branch

### DIFF
--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -1791,8 +1791,14 @@ void G_ReadSnapshots (PNGHandle *png)
 		DWORD snapver;
 
 		arc << snapver;
-		arc << namelen;
-		arc.Read (mapname, namelen);
+		if (SaveVersion < 4508)
+		{
+			arc << namelen;
+			arc.Read(mapname, namelen);
+			mapname[namelen] = 0;
+			MapName = mapname;
+		}
+		else arc << MapName;
 		TheDefaultLevelInfo.snapshotVer = snapver;
 		TheDefaultLevelInfo.snapshot = new FCompressedMemFile;
 		TheDefaultLevelInfo.snapshot->Serialize (arc);

--- a/src/menu/joystickmenu.cpp
+++ b/src/menu/joystickmenu.cpp
@@ -345,8 +345,8 @@ void UpdateJoystickMenu(IJoystickConfig *selected)
 		for(unsigned i=0;i<opt->mItems.Size();i++)
 		{
 			delete opt->mItems[i];
-			opt->mItems.Clear();
 		}
+		opt->mItems.Clear();
 
 		int i;
 		int itemnum = -1;

--- a/src/p_interaction.cpp
+++ b/src/p_interaction.cpp
@@ -268,8 +268,6 @@ void ClientObituary (AActor *self, AActor *inflictor, AActor *attacker, int dmgf
 	{
 		if (friendly)
 		{
-			attacker->player->fragcount -= 2;
-			attacker->player->frags[attacker->player - players]++;
 			self = attacker;
 			gender = self->player->userinfo.GetGender();
 			mysnprintf (gendermessage, countof(gendermessage), "OB_FRIENDLY%c", '1' + (pr_obituary() & 3));
@@ -467,12 +465,21 @@ void AActor::Die (AActor *source, AActor *inflictor, int dmgflags)
 				if ((dmflags2 & DF2_YES_LOSEFRAG) && deathmatch)
 					player->fragcount--;
 
-				++source->player->fragcount;
-				++source->player->spreecount;
+				if (this->IsTeammate(source))
+				{
+					source->player->fragcount--;
+				}
+				else
+				{
+					++source->player->fragcount;
+					++source->player->spreecount;
+				}
+
 				if (source->player->morphTics)
 				{ // Make a super chicken
 					source->GiveInventoryType (RUNTIME_CLASS(APowerWeaponLevel2));
 				}
+
 				if (deathmatch && cl_showsprees)
 				{
 					const char *spreemsg;

--- a/src/p_interaction.cpp
+++ b/src/p_interaction.cpp
@@ -74,7 +74,6 @@ EXTERN_CVAR (Bool, show_obituaries)
 
 
 FName MeansOfDeath;
-bool FriendlyFire;
 
 //
 // GET STUFF
@@ -198,10 +197,8 @@ void ClientObituary (AActor *self, AActor *inflictor, AActor *attacker, int dmgf
 	if (inflictor && inflictor->player && inflictor->player->mo != inflictor)
 		MeansOfDeath = NAME_None;
 
-	if (multiplayer && !deathmatch)
-		FriendlyFire = true;
+	friendly = (self->player != attacker->player && self->IsTeammate(attacker));
 
-	friendly = FriendlyFire;
 	mod = MeansOfDeath;
 	message = NULL;
 	messagename = NULL;
@@ -1024,7 +1021,6 @@ int P_DamageMobj (AActor *target, AActor *inflictor, AActor *source, int damage,
 	}
 	
 	MeansOfDeath = mod;
-	FriendlyFire = false;
 	// [RH] Andy Baker's Stealth monsters
 	if (target->flags & MF_STEALTH)
 	{
@@ -1221,8 +1217,6 @@ int P_DamageMobj (AActor *target, AActor *inflictor, AActor *source, int damage,
 		((player && player != source->player) || (!player && target != source)) &&
 		target->IsTeammate (source))
 	{
-		if (player)
-			FriendlyFire = true;
 		if (rawdamage < TELEFRAG_DAMAGE) //Use the original damage to check for telefrag amount. Don't let the now-amplified damagetypes do it.
 		{ // Still allow telefragging :-(
 			damage = (int)((float)damage * level.teamdamage);

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -1013,15 +1013,15 @@ bool PIT_CheckThing(AActor *thing, FCheckPosition &tm)
 	bool 	solid;
 	int 	damage;
 
+	// don't clip against self
+	if (thing == tm.thing)
+		return true;
+
 	if (!((thing->flags & (MF_SOLID | MF_SPECIAL | MF_SHOOTABLE)) || thing->flags6 & MF6_TOUCHY))
 		return true;	// can't hit thing
 
 	fixed_t blockdist = thing->radius + tm.thing->radius;
 	if (abs(thing->x - tm.x) >= blockdist || abs(thing->y - tm.y) >= blockdist)
-		return true;
-
-	// don't clip against self
-	if (thing == tm.thing)
 		return true;
 
 	if ((thing->flags2 | tm.thing->flags2) & MF2_THRUACTORS)

--- a/src/win32/i_dijoy.cpp
+++ b/src/win32/i_dijoy.cpp
@@ -309,7 +309,7 @@ FDInputJoystick::~FDInputJoystick()
 	{
 		Joy_GenerateButtonEvents(Axes[0].ButtonValue, 0, 2, KEY_JOYAXIS1PLUS);
 	}
-	else
+	else if (Axes.Size() > 1)
 	{
 		Joy_GenerateButtonEvents(Axes[1].ButtonValue, 0, 4, KEY_JOYAXIS1PLUS);
 		for (i = 2; i < Axes.Size(); ++i)


### PR DESCRIPTION
Just a number of quick fixes and changes:
 - Shifted the self-clip checking to the top to make sure its done first, as self clipping is the most common operation.
 - Not a fix, but FriendlyFire was the most unnecessary global, only ever checked for obituaries, set by information that already existed on hand.
 - There was a synchronization issue for frag counts based on if the player had obits switched off/on.
 - The JoystickMenu would clear old lists before deleting them, causing a memory leak.
 - The direct input code had an issue deallocating controllers with no axes.
 - When mapnames were changed to an FString, the serialization for default maps wasn't updated, causing load corruption.