### PR TITLE
Compatibility fix for Whispers of Satan MAP29

### DIFF
--- a/wadsrc/static/compatibility.txt
+++ b/wadsrc/static/compatibility.txt
@@ -396,3 +396,8 @@ A53AE580A4AF2B5D0B0893F86914781E // TNT: Evilution map31
 {
 	setthingflags 470 2016
 }
+
+D0139194F7817BF06F3988DFC47DB38D // Whispers of Satan map29
+{
+	nopassover
+}


### PR DESCRIPTION
Insta-death pit (sector 1497) is now working as intended independently from compatibility settings
http://forum.zdoom.org/viewtopic.php?f=2&t=49488