### PR TITLE
Backported fgsfds's +ROLLSPRITE.

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -406,6 +406,7 @@ enum ActorRenderFlag
 
 	RF_FORCEYBILLBOARD		= 0x10000,	// [BB] OpenGL only: draw with y axis billboard, i.e. anchored to the floor (overrides gl_billboard_mode setting)
 	RF_FORCEXYBILLBOARD		= 0x20000,	// [BB] OpenGL only: draw with xy axis billboard, i.e. unanchored (overrides gl_billboard_mode setting)
+	RF_ROLLSPRITE			= 0x40000,	// [marrub] OpenGL only: roll the sprite billboard
 };
 
 #define TRANSLUC25			(FRACUNIT/4)

--- a/src/thingdef/thingdef_data.cpp
+++ b/src/thingdef/thingdef_data.cpp
@@ -267,6 +267,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(RF, INVISIBLE, AActor, renderflags),
 	DEFINE_FLAG(RF, FORCEYBILLBOARD, AActor, renderflags),
 	DEFINE_FLAG(RF, FORCEXYBILLBOARD, AActor, renderflags),
+	DEFINE_FLAG(RF, ROLLSPRITE, AActor, renderflags),
 
 	// Bounce flags
 	DEFINE_FLAG2(BOUNCE_Walls, BOUNCEONWALLS, AActor, BounceFlags),


### PR DESCRIPTION
GZDoom only. This is just the compatibility patch for ZDoom so it can still run. Here's the full pull request for GZDoom:

https://github.com/coelckers/gzdoom/pull/27