### PR TITLE
Fixed missing hit sound for Heretic weapon Dragon Claw

### DIFF
--- a/wadsrc/static/actors/heretic/hereticweaps.txt
+++ b/wadsrc/static/actors/heretic/hereticweaps.txt
@@ -802,6 +802,7 @@ ACTOR BlasterPuff
 	+NOGRAVITY
 	+PUFFONACTORS
 	RenderStyle Add
+	SeeSound "weapons/blasterhit"
 	States
 	{
 	Crash:


### PR DESCRIPTION
See http://forum.zdoom.org/viewtopic.php?f=2&t=49459