### PR TITLE
Fixed potential crash in ACS engine

### DIFF
--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -6032,6 +6032,7 @@ int DLevelScript::RunScript ()
 	int sp = 0;
 	int *pc = this->pc;
 	ACSFormat fmt = activeBehavior->GetFormat();
+	FBehavior* const savedActiveBehavior = activeBehavior;
 	unsigned int runaway = 0;	// used to prevent infinite loops
 	int pcd;
 	FString work;
@@ -6065,6 +6066,7 @@ int DLevelScript::RunScript ()
 		{
 		default:
 			Printf ("Unknown P-Code %d in %s\n", pcd, ScriptPresentation(script).GetChars());
+			activeBehavior = savedActiveBehavior;
 			// fall through
 		case PCD_TERMINATE:
 			DPrintf ("%s finished\n", ScriptPresentation(script).GetChars());


### PR DESCRIPTION
Unknown p-code in compiled script may lead to a crash if the current module was changed during script execution, e.g. by function call
See http://forum.zdoom.org/viewtopic.php?f=2&t=48524