### PR TITLE
Added "support" for PCD_CONSOLECOMMAND in ACS

### DIFF
--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -75,6 +75,7 @@
 #include "actorptrselect.h"
 #include "farchive.h"
 #include "decallib.h"
+#include "version.h"
 
 #include "g_shared/a_pickups.h"
 
@@ -9357,6 +9358,10 @@ scriptwait:
 			}
 			break;
 
+		case PCD_CONSOLECOMMAND:
+			Printf (TEXTCOLOR_RED GAMENAME " doesn't support execution of console commands from scripts\n");
+			sp -= 3;
+			break;
  		}
  	}
 


### PR DESCRIPTION
Now attempt to execute a console command from a script will not terminate its execution
An error message will be issued in the console on every such attempt