### PR TITLE
Disabled loading of SDL output plugin for FMOD Ex on OS X

### DIFF
--- a/src/sound/fmodsound.cpp
+++ b/src/sound/fmodsound.cpp
@@ -771,7 +771,7 @@ bool FMODSoundRenderer::Init()
 	}
 #endif
 
-#ifndef _WIN32
+#if !defined _WIN32 && !defined __APPLE__
 	// Try to load SDL output plugin
 	result = Sys->setPluginPath(progdir);	// Should we really look for it in the program directory?
 	result = Sys->loadPlugin("liboutput_sdl.so", &OutputPlugin);


### PR DESCRIPTION
Long path to executable file corrupts stack inside FMOD library
This plugin is not being built for OS X, output through CoreAudio works just fine