### PR TITLE
-Fixed PCD_DROP affecting script result value.

### DIFF
--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -7274,9 +7274,9 @@ int DLevelScript::RunScript ()
 			sp--;
 			break;
 
-		case PCD_DROP:
 		case PCD_SETRESULTVALUE:
 			resultValue = STACK(1);
+		case PCD_DROP: //fall through.
 			sp--;
 			break;
 


### PR DESCRIPTION
IDK why this is like that currently, but that affects all scripts that rely on the assumption there is no way to change a script result value other than by calling SetResultvalue(). Especially if they don't call it with a value of 1, assuming it's already at it.