### PR TITLE
- Added Warp properties RadiusOffset and Pitch.

### DIFF
--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -5864,6 +5864,8 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 			const char *statename = argCount > 6 ? FBehavior::StaticLookupString(args[6]) : "";
 			bool exact = argCount > 7 ? !!args[7] : false;
 			fixed_t heightoffset = argCount > 8 ? args[8] : 0;
+			fixed_t radiusoffset = argCount > 9 ? args[9] : 0;
+			fixed_t pitch = argCount > 10 ? args[10] : 0;
 
 			FState *state = argCount > 6 ? activator->GetClass()->ActorInfo->FindStateByString(statename, exact) : 0;
 
@@ -5881,7 +5883,7 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 			if (!reference)
 				return false;
 
-			if (P_Thing_Warp(activator, reference, xofs, yofs, zofs, angle, flags, heightoffset))
+			if (P_Thing_Warp(activator, reference, xofs, yofs, zofs, angle, flags, heightoffset, radiusoffset, pitch))
 			{
 				if (state && argCount > 6)
 				{

--- a/src/p_local.h
+++ b/src/p_local.h
@@ -176,7 +176,7 @@ bool P_Thing_Raise(AActor *thing, AActor *raiser);
 bool P_Thing_CanRaise(AActor *thing);
 const PClass *P_GetSpawnableType(int spawnnum);
 void InitSpawnablesFromMapinfo();
-int P_Thing_Warp(AActor *caller, AActor *reference, fixed_t xofs, fixed_t yofs, fixed_t zofs, angle_t angle, int flags, fixed_t heightoffset);
+int P_Thing_Warp(AActor *caller, AActor *reference, fixed_t xofs, fixed_t yofs, fixed_t zofs, angle_t angle, int flags, fixed_t heightoffset, fixed_t radiusoffset, angle_t pitch);
 
 enum WARPF
 {
@@ -198,6 +198,8 @@ enum WARPF
 	WARPF_MOVEPTR          = 0x1000,
 	WARPF_USEPTR           = 0x2000,
 	WARPF_USETID           = 0x2000,
+	WARPF_COPYVELOCITY		= 0x4000,
+	WARPF_COPYPITCH			= 0x8000,
 };
 
 

--- a/src/p_things.cpp
+++ b/src/p_things.cpp
@@ -695,7 +695,7 @@ int P_Thing_Warp(AActor *caller, AActor *reference, fixed_t xofs, fixed_t yofs, 
 	zofs += FixedMul(reference->height, heightoffset);
 	
 	const fixed_t rad = FixedMul(radiusoffset, reference->radius);
-	
+	const angle_t fineangle = angle >> ANGLETOFINESHIFT;
 
 	if (!(flags & WARPF_ABSOLUTEANGLE))
 	{
@@ -706,7 +706,7 @@ int P_Thing_Warp(AActor *caller, AActor *reference, fixed_t xofs, fixed_t yofs, 
 	{
 		if (!(flags & WARPF_ABSOLUTEOFFSET))
 		{
-			const angle_t fineangle = angle >> ANGLETOFINESHIFT;
+			
 			fixed_t xofs1 = xofs;			
 			// (borrowed from A_SpawnItemEx, assumed workable)
 			// in relative mode negative y values mean 'left' and positive ones mean 'right'

--- a/src/p_things.cpp
+++ b/src/p_things.cpp
@@ -695,18 +695,19 @@ int P_Thing_Warp(AActor *caller, AActor *reference, fixed_t xofs, fixed_t yofs, 
 	zofs += FixedMul(reference->height, heightoffset);
 	
 	const fixed_t rad = FixedMul(radiusoffset, reference->radius);
-	const angle_t fineangle = angle >> ANGLETOFINESHIFT;
+	
 
 	if (!(flags & WARPF_ABSOLUTEANGLE))
 	{
+		
 		angle += (flags & WARPF_USECALLERANGLE) ? caller->angle : reference->angle;
 	}
 	if (!(flags & WARPF_ABSOLUTEPOSITION))
 	{
 		if (!(flags & WARPF_ABSOLUTEOFFSET))
 		{
-			fixed_t xofs1 = xofs;
-
+			const angle_t fineangle = angle >> ANGLETOFINESHIFT;
+			fixed_t xofs1 = xofs;			
 			// (borrowed from A_SpawnItemEx, assumed workable)
 			// in relative mode negative y values mean 'left' and positive ones mean 'right'
 			// This is the inverse orientation of the absolute mode!

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -4673,7 +4673,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_WolfAttack)
 
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_Warp)
 {
-	ACTION_PARAM_START(8);
+	ACTION_PARAM_START(10);
 
 	ACTION_PARAM_INT(destination_selector, 0);
 	ACTION_PARAM_FIXED(xofs, 1);
@@ -4682,7 +4682,9 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_Warp)
 	ACTION_PARAM_ANGLE(angle, 4);
 	ACTION_PARAM_INT(flags, 5);
 	ACTION_PARAM_STATE(success_state, 6);
-	ACTION_PARAM_FIXED(heightoffset,7)
+	ACTION_PARAM_FIXED(heightoffset, 7);
+	ACTION_PARAM_FIXED(radiusoffset, 8);
+	ACTION_PARAM_ANGLE(pitch, 9);
 	
 	AActor *reference;
 	
@@ -4702,7 +4704,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_Warp)
 		return;
 	}
 
-	if (P_Thing_Warp(self, reference, xofs, yofs, zofs, angle, flags, heightoffset))
+	if (P_Thing_Warp(self, reference, xofs, yofs, zofs, angle, flags, heightoffset, radiusoffset, pitch))
 	{
 		if (success_state)
 		{

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -249,7 +249,7 @@ ACTOR Actor native //: Thinker
 	action native A_PlayerSkinCheck(state label);
 	action native A_BasicAttack(int meleedamage, sound meleesound, class<actor> missiletype, float missileheight);
 	action native A_Teleport(state teleportstate = "", class<SpecialSpot> targettype = "BossSpot", class<Actor> fogtype = "TeleportFog", int flags = 0, float mindist = 0, float maxdist = 0, int ptr = AAPTR_DEFAULT);
-	action native A_Warp(int ptr_destination, float xofs = 0, float yofs = 0, float zofs = 0, float angle = 0, int flags = 0, state success_state = "", float heightoffset = 0);
+	action native A_Warp(int ptr_destination, float xofs = 0, float yofs = 0, float zofs = 0, float angle = 0, int flags = 0, state success_state = "", float heightoffset = 0, float radiusoffset = 0, float pitch = 0);
 	action native A_ThrowGrenade(class<Actor> itemtype, float zheight = 0, float xyvel = 0, float zvel = 0, bool useammo = true);
 	action native A_Weave(int xspeed, int yspeed, float xdist, float ydist);
 

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -362,6 +362,8 @@ Const Int WARPF_ABSOLUTEPOSITION = 0x400;
 Const Int WARPF_BOB = 0x800;
 Const Int WARPF_MOVEPTR = 0x1000;
 Const Int WARPF_USETID = 0x2000;
+Const Int WARPF_COPYVELOCITY = 0x4000;
+Const Int WARPF_COPYPITCH = 0x8000;
 
 // flags for A_SetPitch/SetAngle/SetRoll
 const int SPF_FORCECLAMP = 1;


### PR DESCRIPTION
- RadiusOffset is a multiplier of the target actor's radius added onto the offsets x and y.
- Pitch is added to the warping actor's current pitch, provided WARPF_USEPITCH is supplied.
- WARPF_COPYVELOCITY copies the target's velocities for the warping actor's self.
- Fixed WARPF_TOFLOOR not working as intended.