### PR TITLE
Fixes for missing menu textures

### DIFF
--- a/src/menu/listmenu.cpp
+++ b/src/menu/listmenu.cpp
@@ -385,6 +385,11 @@ FListMenuItemStaticPatch::FListMenuItemStaticPatch(int x, int y, FTextureID patc
 	
 void FListMenuItemStaticPatch::Drawer(bool selected)
 {
+	if (!mTexture.Exists())
+	{
+		return;
+	}
+
 	int x = mXpos;
 	FTexture *tex = TexMan(mTexture);
 	if (mYpos >= 0)

--- a/src/menu/menudef.cpp
+++ b/src/menu/menudef.cpp
@@ -95,6 +95,18 @@ static void DeinitMenus()
 	ClearSaveGames();
 }
 
+static FTextureID GetMenuTexture(const char* const name)
+{
+	const FTextureID texture = TexMan.CheckForTexture(name, FTexture::TEX_MiscPatch);
+
+	if (!texture.Exists())
+	{
+		Printf("Missing menu texture: \"%s\"\n", name);
+	}
+
+	return texture;
+}
+
 //=============================================================================
 //
 //
@@ -235,7 +247,7 @@ static void ParseListMenuBody(FScanner &sc, FListMenuDescriptor *desc)
 		else if (sc.Compare("Selector"))
 		{
 			sc.MustGetString();
-			desc->mSelector = TexMan.CheckForTexture(sc.String, FTexture::TEX_MiscPatch);
+			desc->mSelector = GetMenuTexture(sc.String);
 			sc.MustGetStringName(",");
 			sc.MustGetNumber();
 			desc->mSelectOfsX = sc.Number;
@@ -278,7 +290,7 @@ static void ParseListMenuBody(FScanner &sc, FListMenuDescriptor *desc)
 			int y = sc.Number;
 			sc.MustGetStringName(",");
 			sc.MustGetString();
-			FTextureID tex = TexMan.CheckForTexture(sc.String, FTexture::TEX_MiscPatch);
+			FTextureID tex = GetMenuTexture(sc.String);
 
 			FListMenuItem *it = new FListMenuItemStaticPatch(x, y, tex, centered);
 			desc->mItems.Push(it);
@@ -299,7 +311,7 @@ static void ParseListMenuBody(FScanner &sc, FListMenuDescriptor *desc)
 		else if (sc.Compare("PatchItem"))
 		{
 			sc.MustGetString();
-			FTextureID tex = TexMan.CheckForTexture(sc.String, FTexture::TEX_MiscPatch);
+			FTextureID tex = GetMenuTexture(sc.String);
 			sc.MustGetStringName(",");
 			sc.MustGetString();
 			int hotkey = sc.String[0];
@@ -1045,7 +1057,7 @@ static void BuildEpisodeMenu()
 					FListMenuItem *it;
 					if (AllEpisodes[i].mPicName.IsNotEmpty())
 					{
-						FTextureID tex = TexMan.CheckForTexture(AllEpisodes[i].mPicName, FTexture::TEX_MiscPatch);
+						FTextureID tex = GetMenuTexture(AllEpisodes[i].mPicName);
 						it = new FListMenuItemPatch(ld->mXpos, posy, ld->mLinespacing, AllEpisodes[i].mShortcut, 
 							tex, NAME_Skillmenu, i);
 					}
@@ -1442,7 +1454,7 @@ void M_StartupSkillMenu(FGameStartup *gs)
 
 				if (skill.PicName.Len() != 0 && pItemText == NULL)
 				{
-					FTextureID tex = TexMan.CheckForTexture(skill.PicName, FTexture::TEX_MiscPatch);
+					FTextureID tex = GetMenuTexture(skill.PicName);
 					li = new FListMenuItemPatch(ld->mXpos, y, ld->mLinespacing, skill.Shortcut, tex, action, i);
 				}
 				else


### PR DESCRIPTION
Fixed crash when menu item uses non-existent texture
Print warning to console if unknown texture found in menu definition
