### PR TITLE
Fixed crash when clicking on back button in main menu

### DIFF
--- a/src/menu/listmenu.cpp
+++ b/src/menu/listmenu.cpp
@@ -491,7 +491,7 @@ bool FListMenuItemSelectable::MouseEvent(int type, int x, int y)
 {
 	if (type == DMenu::MOUSE_Release)
 	{
-		if (DMenu::CurrentMenu->MenuEvent(MKEY_Enter, true))
+		if (NULL != DMenu::CurrentMenu && DMenu::CurrentMenu->MenuEvent(MKEY_Enter, true))
 		{
 			return true;
 		}


### PR DESCRIPTION
If menu item selection overlaps back button in main menu, clicking on back button with mouse caused a crash
See http://forum.zdoom.org/viewtopic.php?t=49711