### PR TITLE
Fixed MSVC warning in a_randomspawner.cpp

### DIFF
--- a/src/g_shared/a_randomspawner.cpp
+++ b/src/g_shared/a_randomspawner.cpp
@@ -29,7 +29,7 @@ static bool IsMonster(const FDropItem *di)
 		return false;
 	}
 
-	return GetDefaultByType(pclass)->flags3 & MF3_ISMONSTER;
+	return 0 != (GetDefaultByType(pclass)->flags3 & MF3_ISMONSTER);
 }
 
 class ARandomSpawner : public AActor


### PR DESCRIPTION
...\src\g_shared\a_randomspawner.cpp(32): warning C4800: 'DWORD' : forcing value to bool 'true' or 'false' (performance warning)
See http://forum.zdoom.org/viewtopic.php?t=49737