### PR TITLE
- Improve the TFlags code and fix the new errors.

### DIFF
--- a/src/d_dehacked.cpp
+++ b/src/d_dehacked.cpp
@@ -784,7 +784,7 @@ static int PatchThing (int thingy)
 	bool hadStyle = false;
 	FStateDefinitions statedef;
 	bool patchedStates = false;
-	int oldflags;
+	ActorFlags oldflags;
 	const PClass *type;
 	SWORD *ednum, dummyed;
 
@@ -1139,28 +1139,28 @@ static int PatchThing (int thingy)
 				}
 				if (vchanged[1])
 				{
-					info->flags2 = ActorFlags2::FromInt (value[1]);
-					if (info->flags2 & 0x00000004)	// old BOUNCE1
+					if (value[1] & 0x00000004)	// old BOUNCE1
 					{ 	
-						info->flags2 &= ActorFlags2::FromInt (~4);
+						value[1] &= ~0x00000004;
 						info->BounceFlags = BOUNCE_DoomCompat;
 					}
 					// Damage types that once were flags but now are not
-					if (info->flags2 & 0x20000000)
+					if (value[1] & 0x20000000)
 					{
 						info->DamageType = NAME_Ice;
-						info->flags2 &= ActorFlags2::FromInt (~0x20000000);
+						value[1] &= ~0x20000000;
 					}
-					if (info->flags2 & 0x10000)
+					if (value[1] & 0x10000000)
 					{
 						info->DamageType = NAME_Fire;
-						info->flags2 &= ActorFlags2::FromInt (~0x10000);
+						value[1] &= ~0x10000000;
 					}
-					if (info->flags2 & 1)
+					if (value[1] & 0x00000001)
 					{
 						info->gravity = FRACUNIT/4;
-						info->flags2 &= ActorFlags2::FromInt (~1);
+						value[1] &= ~0x00000001;
 					}
+					info->flags2 = ActorFlags2::FromInt (value[1]);
 				}
 				if (vchanged[2])
 				{

--- a/src/fragglescript/t_func.cpp
+++ b/src/fragglescript/t_func.cpp
@@ -1236,7 +1236,7 @@ void FParser::SF_ObjFlag(void)
 		t_return.type = svt_int;  
 		if (mo && flagnum<26)
 		{
-			t_return.value.i = !!(mo->flags & (1 << flagnum));
+			t_return.value.i = !!(mo->flags & ActorFlags::FromInt(1 << flagnum));
 		}
 		else t_return.value.i = 0;
 	}

--- a/src/g_hexen/a_clericstaff.cpp
+++ b/src/g_hexen/a_clericstaff.cpp
@@ -75,7 +75,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_CStaffCheck)
 			{
 				pmo->angle = R_PointToAngle2 (pmo->x, pmo->y, linetarget->x, linetarget->y);
 				if (((linetarget->player && (!linetarget->IsTeammate (pmo) || level.teamdamage != 0))|| linetarget->flags3&MF3_ISMONSTER)
-					&& (!(linetarget->flags2&(MF2_DORMANT+MF2_INVULNERABLE))))
+					&& (!(linetarget->flags2&(MF2_DORMANT|MF2_INVULNERABLE))))
 				{
 					newLife = player->health+(damage>>3);
 					newLife = newLife > max ? max : newLife;

--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -5761,9 +5761,9 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 					return 0;
 				}
 
-				DWORD actorMask = MF_SHOOTABLE;
+				ActorFlags actorMask = MF_SHOOTABLE;
 				if (argCount >= 6) {
-					actorMask = args[5];
+					actorMask = ActorFlags::FromInt(args[5]);
 				}
 
 				DWORD wallMask = ML_BLOCKEVERYTHING | ML_BLOCKHITSCAN;

--- a/src/p_local.h
+++ b/src/p_local.h
@@ -500,7 +500,7 @@ enum	// P_LineAttack flags
 
 AActor *P_LineAttack (AActor *t1, angle_t angle, fixed_t distance, int pitch, int damage, FName damageType, const PClass *pufftype, int flags = 0, AActor **victim = NULL, int *actualdamage = NULL);
 AActor *P_LineAttack (AActor *t1, angle_t angle, fixed_t distance, int pitch, int damage, FName damageType, FName pufftype, int flags = 0, AActor **victim = NULL, int *actualdamage = NULL);
-AActor *P_LinePickActor (AActor *t1, angle_t angle, fixed_t distance, int pitch, DWORD actorMask, DWORD wallMask);
+AActor *P_LinePickActor (AActor *t1, angle_t angle, fixed_t distance, int pitch, ActorFlags actorMask, DWORD wallMask);
 void	P_TraceBleed (int damage, fixed_t x, fixed_t y, fixed_t z, AActor *target, angle_t angle, int pitch);
 void	P_TraceBleed (int damage, AActor *target, angle_t angle, int pitch);
 void	P_TraceBleed (int damage, AActor *target, AActor *missile);		// missile version

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -3912,7 +3912,7 @@ AActor *P_LineAttack(AActor *t1, angle_t angle, fixed_t distance,
 //==========================================================================
 
 AActor *P_LinePickActor(AActor *t1, angle_t angle, fixed_t distance, int pitch,
-						DWORD actorMask, DWORD wallMask)
+						ActorFlags actorMask, DWORD wallMask)
 {
 	fixed_t vx, vy, vz, shootz;
 	

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -6467,25 +6467,25 @@ void PrintMiscActorInfo(AActor *query)
 
 		Printf("%s @ %p has the following flags:\n   flags: %x", query->GetTag(), query, query->flags.GetValue());
 		for (flagi = 0; flagi <= 31; flagi++)
-			if (query->flags & 1<<flagi) Printf(" %s", FLAG_NAME(1<<flagi, flags));
+			if (query->flags & ActorFlags::FromInt(1<<flagi)) Printf(" %s", FLAG_NAME(1<<flagi, flags));
 		Printf("\n   flags2: %x", query->flags2.GetValue());
 		for (flagi = 0; flagi <= 31; flagi++)
-			if (query->flags2 & 1<<flagi) Printf(" %s", FLAG_NAME(1<<flagi, flags2));
+			if (query->flags2 & ActorFlags2::FromInt(1<<flagi)) Printf(" %s", FLAG_NAME(1<<flagi, flags2));
 		Printf("\n   flags3: %x", query->flags3.GetValue());
 		for (flagi = 0; flagi <= 31; flagi++)
-			if (query->flags3 & 1<<flagi) Printf(" %s", FLAG_NAME(1<<flagi, flags3));
+			if (query->flags3 & ActorFlags3::FromInt(1<<flagi)) Printf(" %s", FLAG_NAME(1<<flagi, flags3));
 		Printf("\n   flags4: %x", query->flags4.GetValue());
 		for (flagi = 0; flagi <= 31; flagi++)
-			if (query->flags4 & 1<<flagi) Printf(" %s", FLAG_NAME(1<<flagi, flags4));
+			if (query->flags4 & ActorFlags4::FromInt(1<<flagi)) Printf(" %s", FLAG_NAME(1<<flagi, flags4));
 		Printf("\n   flags5: %x", query->flags5.GetValue());
 		for (flagi = 0; flagi <= 31; flagi++)
-			if (query->flags5 & 1<<flagi) Printf(" %s", FLAG_NAME(1<<flagi, flags5));
+			if (query->flags5 & ActorFlags5::FromInt(1<<flagi)) Printf(" %s", FLAG_NAME(1<<flagi, flags5));
 		Printf("\n   flags6: %x", query->flags6.GetValue());
 		for (flagi = 0; flagi <= 31; flagi++)
-			if (query->flags6 & 1<<flagi) Printf(" %s", FLAG_NAME(1<<flagi, flags6));
+			if (query->flags6 & ActorFlags6::FromInt(1<<flagi)) Printf(" %s", FLAG_NAME(1<<flagi, flags6));
 		Printf("\n   flags7: %x", query->flags7.GetValue());
 		for (flagi = 0; flagi <= 31; flagi++)
-			if (query->flags7 & 1<<flagi) Printf(" %s", FLAG_NAME(1<<flagi, flags7));
+			if (query->flags7 & ActorFlags7::FromInt(1<<flagi)) Printf(" %s", FLAG_NAME(1<<flagi, flags7));
 		Printf("\nBounce flags: %x\nBounce factors: f:%f, w:%f", 
 			query->BounceFlags.GetValue(), FIXED2FLOAT(query->bouncefactor),
 			FIXED2FLOAT(query->wallbouncefactor));

--- a/src/p_trace.cpp
+++ b/src/p_trace.cpp
@@ -42,7 +42,8 @@ struct FTraceInfo
 {
 	fixed_t StartX, StartY, StartZ;
 	fixed_t Vx, Vy, Vz;
-	DWORD ActorMask, WallMask;
+	ActorFlags ActorMask;
+	DWORD WallMask;
 	AActor *IgnoreThis;
 	FTraceResults *Results;
 	sector_t *CurSector;
@@ -70,7 +71,7 @@ static bool EditTraceResult (DWORD flags, FTraceResults &res);
 
 bool Trace (fixed_t x, fixed_t y, fixed_t z, sector_t *sector,
 			fixed_t vx, fixed_t vy, fixed_t vz, fixed_t maxDist,
-			DWORD actorMask, DWORD wallMask, AActor *ignore,
+			ActorFlags actorMask, DWORD wallMask, AActor *ignore,
 			FTraceResults &res,
 			DWORD flags, ETraceStatus (*callback)(FTraceResults &res, void *), void *callbackdata)
 {

--- a/src/p_trace.h
+++ b/src/p_trace.h
@@ -35,6 +35,7 @@
 #define __P_TRACE_H__
 
 #include <stddef.h>
+#include "actor.h"
 #include "textures/textures.h"
 
 struct sector_t;
@@ -96,7 +97,7 @@ enum ETraceStatus
 
 bool Trace (fixed_t x, fixed_t y, fixed_t z, sector_t *sector,
 			fixed_t vx, fixed_t vy, fixed_t vz, fixed_t maxDist,
-			DWORD ActorMask, DWORD WallMask, AActor *ignore,
+			ActorFlags ActorMask, DWORD WallMask, AActor *ignore,
 			FTraceResults &res,
 			DWORD traceFlags=0,
 			ETraceStatus (*callback)(FTraceResults &res, void *)=NULL, void *callbackdata=NULL);

--- a/src/tflags.h
+++ b/src/tflags.h
@@ -94,6 +94,10 @@ public:
 	static Self FromInt (TT value) { return Self (static_cast<T> (value)); }
 
 private:
+	template<typename X> Self operator| (X value) const { return Self::FromInt (Value | value); }
+	template<typename X> Self operator& (X value) const { return Self::FromInt (Value & value); }
+	template<typename X> Self operator^ (X value) const { return Self::FromInt (Value ^ value); }
+
 	TT Value;
 };
 

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -1014,7 +1014,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_CustomMissile)
                 	targ=owner;
                 	missile->target=owner;
 					// automatic handling of seeker missiles
-					if ((self->flags & MF_STEALTH) && (missile->flags2 & MF2_SEEKERMISSILE))
+					if (self->flags2 & missile->flags2 & MF2_SEEKERMISSILE)
 					{
 						missile->tracer=self->tracer;
 					}

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -1014,7 +1014,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_CustomMissile)
                 	targ=owner;
                 	missile->target=owner;
 					// automatic handling of seeker missiles
-					if (self->flags & missile->flags2 & MF2_SEEKERMISSILE)
+					if ((self->flags & MF_STEALTH) && (missile->flags2 & MF2_SEEKERMISSILE))
 					{
 						missile->tracer=self->tracer;
 					}
@@ -3414,7 +3414,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_CheckLOF)
 	lof_data.Flags = flags;
 	lof_data.BadActor = false;
 
-	Trace(x1, y1, z1, sec, vx, vy, vz, range, 0xFFFFFFFF, ML_BLOCKEVERYTHING, self, trace, 0,
+	Trace(x1, y1, z1, sec, vx, vy, vz, range, ActorFlags::FromInt(0xFFFFFFFF), ML_BLOCKEVERYTHING, self, trace, 0,
 		CheckLOFTraceFunc, &lof_data);
 
 	if (trace.HitType == TRACE_HitActor ||


### PR DESCRIPTION
The previous version didn't detect some real mistakes in code which used operator& with the wrong flagset (for now 'converted' to the correcly equivalent counterpart, waiting for the proper fix).

For a serious mistake, see ```if (self->flags & missile->flags2 & MF2_SEEKERMISSILE)```...

This needs a feedback from MSVC users, because I couldn't test the Windows platform.