### PR TITLE
Make CheckActor*Texture also consider swimmable 3D floors

### DIFF
--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -4154,7 +4154,7 @@ bool DLevelScript::DoCheckActorTexture(int tid, AActor *activator, int string, b
 			{ // This is the highest solid floor beneath our feet
 				secpic = *ff->top.texture;
 			}
-			else if (ff->flags & FF_SWIMMABLE &&
+			else if (!(ff->flags & FF_SOLID) &&
 				tex == TexMan[*ff->top.texture] &&
 				z <= ff->top.plane->ZatPoint(actor->x, actor->y) &&
 				z >= ff->bottom.plane->ZatPoint(actor->x, actor->y))
@@ -4184,7 +4184,7 @@ bool DLevelScript::DoCheckActorTexture(int tid, AActor *activator, int string, b
 			{ // This is the lowest solid ceiling above our eyes
 				secpic = *ff->top.texture;
 			}
-			else if (ff->flags & FF_SWIMMABLE &&
+			else if (!(ff->flags & FF_SOLID) &&
 				tex == TexMan[*ff->bottom.texture] &&
 				z <= ff->top.plane->ZatPoint(actor->X(), actor->Y()) &&
 				z >= ff->bottom.plane->ZatPoint(actor->X(), actor->Y()))

--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -4140,16 +4140,26 @@ bool DLevelScript::DoCheckActorTexture(int tid, AActor *activator, int string, b
 
 	if (floor)
 	{
+		fixed_t z = actor->z;
 		// Looking through planes from top to bottom
 		for (i = 0; i < numff; ++i)
 		{
 			F3DFloor *ff = sec->e->XFloor.ffloors[i];
+			if (!(ff->flags & FF_EXISTS))
+				continue;
 
-			if ((ff->flags & (FF_EXISTS | FF_SOLID)) == (FF_EXISTS | FF_SOLID) &&
-				actor->Z() >= ff->top.plane->ZatPoint(actor))
-			{ // This floor is beneath our feet.
+			if (ff->flags & FF_SOLID &&
+				secpic.isNull() &&
+				z >= ff->top.plane->ZatPoint(actor->X(), actor->Y()))
+			{ // This is the highest solid floor beneath our feet
 				secpic = *ff->top.texture;
-				break;
+			}
+			else if (ff->flags & FF_SWIMMABLE &&
+				tex == TexMan[*ff->top.texture] &&
+				z <= ff->top.plane->ZatPoint(actor->x, actor->y) &&
+				z >= ff->bottom.plane->ZatPoint(actor->x, actor->y))
+			{ // Having your feet within a liquid count as being "on" it
+				return true;
 			}
 		}
 		if (i == numff)
@@ -4165,11 +4175,21 @@ bool DLevelScript::DoCheckActorTexture(int tid, AActor *activator, int string, b
 		{
 			F3DFloor *ff = sec->e->XFloor.ffloors[i];
 
-			if ((ff->flags & (FF_EXISTS | FF_SOLID)) == (FF_EXISTS | FF_SOLID) &&
-				z <= ff->bottom.plane->ZatPoint(actor))
-			{ // This floor is above our eyes.
-				secpic = *ff->bottom.texture;
-				break;
+			if (!(ff->flags & FF_EXISTS))
+				continue;
+
+			if (ff->flags & FF_SOLID &&
+				secpic.isNull() &&
+				z <= ff->bottom.plane->ZatPoint(actor->X(), actor->Y()))
+			{ // This is the lowest solid ceiling above our eyes
+				secpic = *ff->top.texture;
+			}
+			else if (ff->flags & FF_SWIMMABLE &&
+				tex == TexMan[*ff->bottom.texture] &&
+				z <= ff->top.plane->ZatPoint(actor->X(), actor->Y()) &&
+				z >= ff->bottom.plane->ZatPoint(actor->X(), actor->Y()))
+			{ // Having your eyes within a liquid count as being "under" it
+				return true;
 			}
 		}
 		if (i < 0)

--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -4158,7 +4158,7 @@ bool DLevelScript::DoCheckActorTexture(int tid, AActor *activator, int string, b
 				tex == TexMan[*ff->top.texture] &&
 				z <= ff->top.plane->ZatPoint(actor->x, actor->y) &&
 				z >= ff->bottom.plane->ZatPoint(actor->x, actor->y))
-			{ // Having your feet within a liquid count as being "on" it
+			{ // Having your feet within a liquid counts as being "on" it
 				return true;
 			}
 		}
@@ -4188,7 +4188,7 @@ bool DLevelScript::DoCheckActorTexture(int tid, AActor *activator, int string, b
 				tex == TexMan[*ff->bottom.texture] &&
 				z <= ff->top.plane->ZatPoint(actor->X(), actor->Y()) &&
 				z >= ff->bottom.plane->ZatPoint(actor->X(), actor->Y()))
-			{ // Having your eyes within a liquid count as being "under" it
+			{ // Having your eyes within a liquid counts as being "under" it
 				return true;
 			}
 		}

--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -4140,7 +4140,7 @@ bool DLevelScript::DoCheckActorTexture(int tid, AActor *activator, int string, b
 
 	if (floor)
 	{
-		fixed_t z = actor->z;
+		fixed_t z = actor->Z();
 		// Looking through planes from top to bottom
 		for (i = 0; i < numff; ++i)
 		{
@@ -4156,8 +4156,8 @@ bool DLevelScript::DoCheckActorTexture(int tid, AActor *activator, int string, b
 			}
 			else if (!(ff->flags & FF_SOLID) &&
 				tex == TexMan[*ff->top.texture] &&
-				z <= ff->top.plane->ZatPoint(actor->x, actor->y) &&
-				z >= ff->bottom.plane->ZatPoint(actor->x, actor->y))
+				z <= ff->top.plane->ZatPoint(actor->X(), actor->Y()) &&
+				z >= ff->bottom.plane->ZatPoint(actor->X(), actor->Y()))
 			{ // Having your feet within a liquid counts as being "on" it
 				return true;
 			}

--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -4150,14 +4150,14 @@ bool DLevelScript::DoCheckActorTexture(int tid, AActor *activator, int string, b
 
 			if (ff->flags & FF_SOLID &&
 				secpic.isNull() &&
-				z >= ff->top.plane->ZatPoint(actor->X(), actor->Y()))
+				z >= ff->top.plane->ZatPoint(actor))
 			{ // This is the highest solid floor beneath our feet
 				secpic = *ff->top.texture;
 			}
 			else if (!(ff->flags & FF_SOLID) &&
 				tex == TexMan[*ff->top.texture] &&
-				z <= ff->top.plane->ZatPoint(actor->X(), actor->Y()) &&
-				z >= ff->bottom.plane->ZatPoint(actor->X(), actor->Y()))
+				z <= ff->top.plane->ZatPoint(actor) &&
+				z >= ff->bottom.plane->ZatPoint(actor))
 			{ // Having your feet within a liquid counts as being "on" it
 				return true;
 			}
@@ -4180,14 +4180,14 @@ bool DLevelScript::DoCheckActorTexture(int tid, AActor *activator, int string, b
 
 			if (ff->flags & FF_SOLID &&
 				secpic.isNull() &&
-				z <= ff->bottom.plane->ZatPoint(actor->X(), actor->Y()))
+				z <= ff->bottom.plane->ZatPoint(actor))
 			{ // This is the lowest solid ceiling above our eyes
 				secpic = *ff->top.texture;
 			}
 			else if (!(ff->flags & FF_SOLID) &&
 				tex == TexMan[*ff->bottom.texture] &&
-				z <= ff->top.plane->ZatPoint(actor->X(), actor->Y()) &&
-				z >= ff->bottom.plane->ZatPoint(actor->X(), actor->Y()))
+				z <= ff->top.plane->ZatPoint(actor) &&
+				z >= ff->bottom.plane->ZatPoint(actor))
 			{ // Having your eyes within a liquid counts as being "under" it
 				return true;
 			}


### PR DESCRIPTION
An actor standing within a swimmable floor whose ceiling texture is X and on a solid floor whose texture is Y will now be reported as standing on both.

This seems inconsistent at a glance: if you're in the air, `CheckActorFloorTexture` will test against the nearest solid floor below you, but only against non-solid 3D floors that your feet are _inside_.  But it's consistent with the concept of a "swimmable" floor and my changes to make TERRAIN apply within a swimmable floor.

Seems unlikely to break existing maps; this is an obscure function, and anywhere it returned true before will still do so now.  An author who explicitly wants the old behavior can check waterlevel with `GetActorProperty`.

Test map and more words: http://forum.zdoom.org/viewtopic.php?f=34&t=49946