### PR TITLE
Backport RETURNTID and FORCETID flags for PickActor from GLOOME. 

### DIFF
--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -133,6 +133,16 @@ enum
 	ARMORINFO_ACTUALSAVEAMOUNT,
 };
 
+// PickActor
+// [JP] I've renamed these flags to something else to avoid confusion with the other PAF_ flags
+enum
+{
+//	PAF_FORCETID,
+//	PAF_RETURNTID
+	PICKAF_FORCETID = 1,
+	PICKAF_RETURNTID = 2,
+};
+
 struct CallReturn
 {
 	CallReturn(int pc, ScriptFunction *func, FBehavior *module, SDWORD *locals, ACSLocalArrays *arrays, bool discard, unsigned int runaway)
@@ -5779,11 +5789,10 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 					wallMask = args[6];
 				}
 
-				bool forceTID = 0;
+				int flags = 0;
 				if (argCount >= 8)
 				{
-					if (args[7] != 0)
-						forceTID = 1;
+					flags = args[7];
 				}
 
 				AActor* pickedActor = P_LinePickActor(actor, args[1] << 16, args[3], args[2] << 16, actorMask, wallMask);
@@ -5791,14 +5800,18 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 					return 0;
 				}
 
-				if (!(forceTID) && (args[4] == 0) && (pickedActor->tid == 0))
+				if (!(flags & PICKAF_FORCETID) && (args[4] == 0) && (pickedActor->tid == 0))
 					return 0;
 
-				if ((pickedActor->tid == 0) || (forceTID))
+				if ((pickedActor->tid == 0) || (flags & PICKAF_FORCETID))
 				{
 					pickedActor->RemoveFromHash();
 					pickedActor->tid = args[4];
 					pickedActor->AddToHash();
+				}
+				if (flags & PICKAF_RETURNTID)
+				{
+					return pickedActor->tid;
 				}
 				return 1;
 			}


### PR DESCRIPTION
Backport RETURNTID and FORCETID flags for PickActor from [GLOOME](https://github.com/marrub--/GLOOME ). Renamed prefix to avoid confusion with Pain Attack flags. Fixed broken enum.

I already made a [pull request](https://github.com/marrub--/GLOOME/pull/19) on GLOOME's repository, but there hasn't been any activity there in almost a month.

Relevant ACC pull request: https://github.com/rheit/acc/pull/31