### PR TITLE
A_CheckChildCount

### DIFF
--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -306,6 +306,7 @@ ACTOR Actor native //: Thinker
 	action native A_SetSpeed(float speed, int ptr = AAPTR_DEFAULT);
 	action native A_SetFloatSpeed(float speed, int ptr = AAPTR_DEFAULT);
 	action native A_SetPainThreshold(int threshold, int ptr = AAPTR_DEFAULT);
+	action native A_CheckChildCount(state jump, class<Actor> entity = "None", int numchild = 1, int flags = 0);
 	action native A_DamageSelf(int amount, name damagetype = "none", int flags = 0, class<Actor> filter = "None", name species = "None");
 	action native A_DamageTarget(int amount, name damagetype = "none", int flags = 0, class<Actor> filter = "None", name species = "None");
 	action native A_DamageMaster(int amount, name damagetype = "none", int flags = 0, class<Actor> filter = "None", name species = "None");

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -495,6 +495,15 @@ enum
 	CBF_SETONPTR		= 1 << 4,	//Sets the pointer change on the actor doing the checking instead of self.
 };
 
+// Flags for A_CheckChildCount
+enum
+{
+	CCCF_LESSOREQUAL =		1,
+	CCCF_EXACT =			1 << 1,
+	CCCF_ALIVEONLY =		1 << 2,
+	CCCF_DEADONLY =			1 << 3,
+};
+
 // This is only here to provide one global variable for testing.
 native int testglobalvar;
 


### PR DESCRIPTION
- Added A_CheckChildCount(state jump, actor entity, int numchild, int flags).
- Performs a jump if a master has 'numchild' amount of children, (un)specified by 'entity' actor name. All flags appended by CCCF:
- LESSOREQUAL inverses the greater-or-equal functionality to less-or-equal. EXACT will only jump if precisely that number of children are found based on entity name, and overrides LESSOREQUAL.
- By default, the function searches both dead and live actors. ALIVEONLY and DEADONLY are mutually exclusive, and the function does nothing if both are used at once.