### PR TITLE
- Fixed lemon trying to free non-allocated memory.

### DIFF
--- a/tools/lemon/lemon.c
+++ b/tools/lemon/lemon.c
@@ -3061,6 +3061,7 @@ struct lemon *lemp;
   FILE *in;
   char *tpltname;
   char *cp;
+  Boolean tpltnameinbuf;
 
   cp = strrchr(lemp->filename,'.');
   if( cp ){
@@ -3070,10 +3071,13 @@ struct lemon *lemp;
   }
   if( access(buf,004)==0 ){
     tpltname = buf;
+    tpltnameinbuf = LEMON_TRUE;
   }else if( access(templatename,004)==0 ){
     tpltname = templatename;
+    tpltnameinbuf = LEMON_TRUE;
   }else{
     tpltname = pathsearch(lemp->argv0,templatename,0);
+    tpltnameinbuf = LEMON_FALSE;
   }
   if( tpltname==0 ){
     fprintf(stderr,"Can't find the parser driver template file \"%s\".\n",
@@ -3084,11 +3088,11 @@ struct lemon *lemp;
   in = fopen(tpltname,"rb");
   if( in==0 ){
     fprintf(stderr,"Can't open the template file \"%s\".\n",templatename);
-    free(tpltname);
+    if (tpltnameinbuf == LEMON_FALSE) free(tpltname);
     lemp->errorcnt++;
     return 0;
   }
-  free(tpltname);
+  if (tpltnameinbuf == LEMON_FALSE) free(tpltname);
   return in;
 }
 


### PR DESCRIPTION
This is a regression from commit 24a096fb27eb0959366c605499c7819352cc501c . It happened only if the input files were present in the same directory as the executable.

This was reported as a comment in the mentioned commit.