### PR TITLE
A_CheckProximity Expansion

### DIFF
--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -5951,7 +5951,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_CheckProximity)
 	TThinkerIterator<AActor> it;
 	AActor *mo, *classtarget = NULL, *nonclasstarget = NULL, *dist = NULL;
 	const double distsquared = double(distance) * double(distance);
-	double closer = distsquared, farther = 0, current = 0;
+	double closer = 0, farther = 0, current = 0;
 
 	//[MC] Process of elimination, I think, will get through this as quickly and 
 	//efficiently as possible. 

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -337,7 +337,7 @@ ACTOR Actor native //: Thinker
 	action native A_SetRipperLevel(int level);
 	action native A_SetRipMin(int min);
 	action native A_SetRipMax(int max);
-	action native A_CheckProximity(state jump, class<Actor> classname, float distance, int count = 1, int flags = 0, int ptr = AAPTR_DEFAULT);
+	action native A_CheckProximity(state jump, class<Actor> classname, float distance = 0, int count = 1, int flags = 0, int ptr = AAPTR_DEFAULT);
 	action native A_CheckBlock(state block, int flags = 0, int ptr = AAPTR_DEFAULT);
 	action native A_CheckSightOrRange(float distance, state label, bool two_dimension = false);
 	action native A_CheckRange(float distance, state label, bool two_dimension = false);

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -504,7 +504,8 @@ enum
 	CPXF_MISSILES =		1 << 14,
 	CPXF_OBJECTS =		1 << 15,
 	CPXF_CORPSES =		1 << 16,
-	CPXF_CHECKSIGHT =	1 << 17
+	CPXF_CHECKSIGHT =	1 << 17,
+	CPXF_NOCOUNTMASK =	1 << 18,
 };
 
 // Flags for A_CheckBlock

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -487,12 +487,24 @@ enum
 // A_CheckProximity flags
 enum
 {
-	CPXF_ANCESTOR			= 1,
-	CPXF_LESSOREQUAL		= 1 << 1,
-	CPXF_NOZ				= 1 << 2,
-	CPXF_COUNTDEAD			= 1 << 3,
-	CPXF_DEADONLY			= 1 << 4,
-	CPXF_EXACT				= 1 << 5,
+	CPXF_ANCESTOR =		1,
+	CPXF_LESSOREQUAL =	1 << 1,
+	CPXF_NOZ =			1 << 2,
+	CPXF_COUNTDEAD =	1 << 3,
+	CPXF_DEADONLY =		1 << 4,
+	CPXF_EXACT =		1 << 5,
+	CPXF_SETTARGET =	1 << 6,
+	CPXF_SETMASTER =	1 << 7,
+	CPXF_SETTRACER =	1 << 8,
+	CPXF_FARTHEST =		1 << 9,
+	CPXF_CLOSEST =		1 << 10,
+	CPXF_SETONPTR =		1 << 11,
+	CPXF_NODISTANCE =	1 << 12,
+	CPXF_MONSTERS =		1 << 13,
+	CPXF_MISSILES =		1 << 14,
+	CPXF_OBJECTS =		1 << 15,
+	CPXF_CORPSES =		1 << 16,
+	CPXF_CHECKSIGHT =	1 << 17
 };
 
 // Flags for A_CheckBlock


### PR DESCRIPTION
- New flags:
- SET [TARGET/MASTER/TRACER] - The first qualifying actor becomes the caller's designated pointer.
- SETONPTR: The targeted pointer's pointers will change instead of the calling actor's. Requires one of the three to work.
- FARTHEST: The farthest qualifying actor in range will be set, regardless of success or not.
- CLOSEST: The closest qualifying actor in range will be set, regardless of success or not.
- CHECKSIGHT: Only counts actors that can be seen between itself and the counting actors.
- NODISTANCE: Disables distance qualifying check, in short unlimited radius.

- Masking flags added in the form of CPXF_MONSTERS, OBJECTS, MISSILES and CORPSES as secondary targets to search in case of no primary targets, and are overridden regardless of flag by the specified classname, no matter what flag is used. (I.e. if a masked/secondary target is closer than the primary and the CLOSEST flag is used, the primary will targeted even if it's actually further, but the flag will be respected if more than one primary target is in range.)
- NOCOUNTMASK: Do not count masked actors, only the primary specified classname. Only useful if one of the masking flags is used.