### PR TITLE
<stdlib.h> has replaced <malloc.h> on FreeBSD as well

### DIFF
--- a/src/sound/fmodsound.cpp
+++ b/src/sound/fmodsound.cpp
@@ -44,7 +44,7 @@ extern HWND Window;
 #define FALSE 0
 #define TRUE 1
 #endif
-#ifdef __APPLE__
+#if defined(__FreeBSD__) || defined(__APPLE__)
 #include <stdlib.h>
 #elif __sun
 #include <alloca.h>


### PR DESCRIPTION
Fixes (?) compilation on FreeBSD 