### PR TITLE
Added sv_action_limit CVar, to customize the ACS action limit

### DIFF
--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -5978,6 +5978,9 @@ static bool CharArrayParms(int &capacity, int &offset, int &a, int *Stack, int &
 	return true;
 }
 
+// [zombie] custom action limit
+CVAR(Int, sv_action_limit, 2000000, CVAR_ARCHIVE);
+
 int DLevelScript::RunScript ()
 {
 	DACSThinker *controller = DACSThinker::ActiveThinker;
@@ -6068,7 +6071,8 @@ int DLevelScript::RunScript ()
 
 	while (state == SCRIPT_Running)
 	{
-		if (++runaway > 2000000)
+		// [zombie] custom action limit
+		if (++runaway > sv_action_limit && sv_action_limit != -1)
 		{
 			Printf ("Runaway %s terminated\n", ScriptPresentation(script).GetChars());
 			state = SCRIPT_PleaseRemove;

--- a/src/p_acs.h
+++ b/src/p_acs.h
@@ -976,4 +976,7 @@ struct acsdefered_t
 
 FArchive &operator<< (FArchive &arc, acsdefered_t *&defer);
 
+// [zombie] custom action limit
+EXTERN_CVAR(Int, sv_action_limit);
+
 #endif //__P_ACS_H__


### PR DESCRIPTION
Incredibly useful (near-mandatory) when using something such as Lua through GDCC.
If the CVar is set to -1, then the action limit is ignored, the default remains 2000000, just as it was before this addition.