### PR TITLE
- Fixed Linux compiler errors and snd_mididevice.

### DIFF
--- a/src/sound/music_midi_base.cpp
+++ b/src/sound/music_midi_base.cpp
@@ -198,8 +198,8 @@ CCMD (snd_listmididevices)
 
 CUSTOM_CVAR(Int, snd_mididevice, -1, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 {
-	if (self < -5)
-		self = -5;
+	if (self < -6)
+		self = -6;
 	else if (self > -1)
 		self = -1;
 	else

--- a/src/wildmidi/file_io.cpp
+++ b/src/wildmidi/file_io.cpp
@@ -33,6 +33,8 @@
 **
 */
 
+#include <errno.h>
+
 #include "../files.h"
 #include "wm_error.h"
 #include "file_io.h"

--- a/src/wildmidi/lock.cpp
+++ b/src/wildmidi/lock.cpp
@@ -29,7 +29,6 @@
 #ifdef _WIN32
 #include <windows.h>
 #else
-#define _GNU_SOURCE
 #include <unistd.h>
 #endif
 

--- a/src/wildmidi/wildmidi_lib.cpp
+++ b/src/wildmidi/wildmidi_lib.cpp
@@ -47,11 +47,11 @@
 #ifdef _WIN32
 #include <windows.h>
 #include <tchar.h>
-*/
 #undef strcasecmp
 #define strcasecmp _stricmp
 #undef strncasecmp
 #define strncasecmp _strnicmp
+*/
 
 
 
@@ -699,7 +699,7 @@ static int WM_LoadConfig(const char *config_file) {
 			if (config_ptr != line_start_ptr) {
 				line_tokens = WM_LC_Tokenize_Line(&config_buffer[line_start_ptr]);
 				if (line_tokens) {
-					if (strcasecmp(line_tokens[0], "dir") == 0) {
+					if (stricmp(line_tokens[0], "dir") == 0) {
 						free(config_dir);
 						if (!line_tokens[1]) {
 							_WM_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG,
@@ -724,7 +724,7 @@ static int WM_LoadConfig(const char *config_file) {
 							config_dir[strlen(config_dir) + 1] = '\0';
 							config_dir[strlen(config_dir)] = '/';
 						}
-					} else if (strcasecmp(line_tokens[0], "source") == 0) {
+					} else if (stricmp(line_tokens[0], "source") == 0) {
 						char *new_config = NULL;
 						if (!line_tokens[1]) {
 							_WM_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG,
@@ -772,7 +772,7 @@ static int WM_LoadConfig(const char *config_file) {
 							return -1;
 						}
 						free(new_config);
-					} else if (strcasecmp(line_tokens[0], "bank") == 0) {
+					} else if (stricmp(line_tokens[0], "bank") == 0) {
 						if (!line_tokens[1] || !wm_isdigit(line_tokens[1][0])) {
 							_WM_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG,
 									"(syntax error in bank line)", 0);
@@ -785,7 +785,7 @@ static int WM_LoadConfig(const char *config_file) {
 							return -1;
 						}
 						patchid = (atoi(line_tokens[1]) & 0xFF) << 8;
-					} else if (strcasecmp(line_tokens[0], "drumset") == 0) {
+					} else if (stricmp(line_tokens[0], "drumset") == 0) {
 						if (!line_tokens[1] || !wm_isdigit(line_tokens[1][0])) {
 							_WM_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG,
 									"(syntax error in drumset line)", 0);
@@ -798,7 +798,7 @@ static int WM_LoadConfig(const char *config_file) {
 							return -1;
 						}
 						patchid = ((atoi(line_tokens[1]) & 0xFF) << 8) | 0x80;
-					} else if (strcasecmp(line_tokens[0], "reverb_room_width") == 0) {
+					} else if (stricmp(line_tokens[0], "reverb_room_width") == 0) {
 						if (!line_tokens[1] || !wm_isdigit(line_tokens[1][0])) {
 							_WM_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG,
 									"(syntax error in reverb_room_width line)",
@@ -823,7 +823,7 @@ static int WM_LoadConfig(const char *config_file) {
 									0);
 							reverb_room_width = 100.0f;
 						}
-					} else if (strcasecmp(line_tokens[0], "reverb_room_length") == 0) {
+					} else if (stricmp(line_tokens[0], "reverb_room_length") == 0) {
 						if (!line_tokens[1] || !wm_isdigit(line_tokens[1][0])) {
 							_WM_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG,
 									"(syntax error in reverb_room_length line)",
@@ -848,7 +848,7 @@ static int WM_LoadConfig(const char *config_file) {
 									0);
 							reverb_room_length = 100.0f;
 						}
-					} else if (strcasecmp(line_tokens[0], "reverb_listener_posx") == 0) {
+					} else if (stricmp(line_tokens[0], "reverb_listener_posx") == 0) {
 						if (!line_tokens[1] || !wm_isdigit(line_tokens[1][0])) {
 							_WM_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG,
 									"(syntax error in reverb_listen_posx line)",
@@ -869,7 +869,7 @@ static int WM_LoadConfig(const char *config_file) {
 									0);
 							reverb_listen_posx = reverb_room_width / 2.0f;
 						}
-					} else if (strcasecmp(line_tokens[0],
+					} else if (stricmp(line_tokens[0],
 							"reverb_listener_posy") == 0) {
 						if (!line_tokens[1] || !wm_isdigit(line_tokens[1][0])) {
 							_WM_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG,
@@ -891,13 +891,13 @@ static int WM_LoadConfig(const char *config_file) {
 									0);
 							reverb_listen_posy = reverb_room_length * 0.75f;
 						}
-					} else if (strcasecmp(line_tokens[0],
+					} else if (stricmp(line_tokens[0],
 							"guspat_editor_author_cant_read_so_fix_release_time_for_me")
 							== 0) {
 						fix_release = 1;
-					} else if (strcasecmp(line_tokens[0], "auto_amp") == 0) {
+					} else if (stricmp(line_tokens[0], "auto_amp") == 0) {
 						auto_amp = 1;
-					} else if (strcasecmp(line_tokens[0], "auto_amp_with_amp")
+					} else if (stricmp(line_tokens[0], "auto_amp_with_amp")
 							== 0) {
 						auto_amp = 1;
 						auto_amp_with_amp = 1;
@@ -1038,7 +1038,7 @@ static int WM_LoadConfig(const char *config_file) {
 								return -1;
 							}
 						}
-						if (strncasecmp(
+						if (strnicmp(
 								&tmp_patch->filename[strlen(tmp_patch->filename)
 										- 4], ".pat", 4) != 0) {
 							strcat(tmp_patch->filename, ".pat");
@@ -1054,7 +1054,7 @@ static int WM_LoadConfig(const char *config_file) {
 
 						token_count = 0;
 						while (line_tokens[token_count]) {
-							if (strncasecmp(line_tokens[token_count], "amp=", 4)
+							if (strnicmp(line_tokens[token_count], "amp=", 4)
 									== 0) {
 								if (!wm_isdigit(line_tokens[token_count][4])) {
 									_WM_ERROR(__FUNCTION__, __LINE__,
@@ -1065,7 +1065,7 @@ static int WM_LoadConfig(const char *config_file) {
 											&line_tokens[token_count][4]) << 10)
 											/ 100;
 								}
-							} else if (strncasecmp(line_tokens[token_count],
+							} else if (strnicmp(line_tokens[token_count],
 									"note=", 5) == 0) {
 								if (!wm_isdigit(line_tokens[token_count][5])) {
 									_WM_ERROR(__FUNCTION__, __LINE__,
@@ -1075,7 +1075,7 @@ static int WM_LoadConfig(const char *config_file) {
 									tmp_patch->note = atoi(
 											&line_tokens[token_count][5]);
 								}
-							} else if (strncasecmp(line_tokens[token_count],
+							} else if (strnicmp(line_tokens[token_count],
 									"env_time", 8) == 0) {
 								if ((!wm_isdigit(line_tokens[token_count][8]))
 										|| (!wm_isdigit(
@@ -1110,7 +1110,7 @@ static int WM_LoadConfig(const char *config_file) {
 										}
 									}
 								}
-							} else if (strncasecmp(line_tokens[token_count],
+							} else if (strnicmp(line_tokens[token_count],
 									"env_level", 9) == 0) {
 								if ((!wm_isdigit(line_tokens[token_count][9]))
 										|| (!wm_isdigit(
@@ -1144,16 +1144,16 @@ static int WM_LoadConfig(const char *config_file) {
 										}
 									}
 								}
-							} else if (strcasecmp(line_tokens[token_count],
+							} else if (stricmp(line_tokens[token_count],
 									"keep=loop") == 0) {
 								tmp_patch->keep |= SAMPLE_LOOP;
-							} else if (strcasecmp(line_tokens[token_count],
+							} else if (stricmp(line_tokens[token_count],
 									"keep=env") == 0) {
 								tmp_patch->keep |= SAMPLE_ENVELOPE;
-							} else if (strcasecmp(line_tokens[token_count],
+							} else if (stricmp(line_tokens[token_count],
 									"remove=sustain") == 0) {
 								tmp_patch->remove |= SAMPLE_SUSTAIN;
-							} else if (strcasecmp(line_tokens[token_count],
+							} else if (stricmp(line_tokens[token_count],
 									"remove=clamped") == 0) {
 								tmp_patch->remove |= SAMPLE_CLAMPED;
 							}
@@ -1695,7 +1695,7 @@ static void do_control_channel_balance(struct _mdi *mdi,
 static void do_control_channel_pan(struct _mdi *mdi, struct _event_data *data) {
 	unsigned char ch = data->channel;
 
-	mdi->channel[ch].pan = signed char(data->data - 64);
+	mdi->channel[ch].pan = (signed char)(data->data - 64);
 	do_pan_adjust(mdi, ch);
 }
 


### PR DESCRIPTION
-- errno.h is required for 'errno';
-- don't use str(n)casecmp and rely on ZDoom CMake handling;
-- add a missing parenthesis around a 'signed char' cast;
-- remove an unneeded GNU_SOURCE redefinition;
-- the non-MSVC side of snd_mididevice was not adapted to the new code, making wildmidi unavailable through the menu.