### PR TITLE
- Fixed Clang errors/warnings on wildMIDI code.

### DIFF
--- a/src/sound/music_wildmidi_mididevice.cpp
+++ b/src/sound/music_wildmidi_mididevice.cpp
@@ -193,7 +193,7 @@ void WildMIDIDevice::HandleEvent(int status, int parm1, int parm2)
 
 void WildMIDIDevice::HandleLongEvent(const BYTE *data, int len)
 {
-	Renderer->LongEvent((const char *)data, len);
+	Renderer->LongEvent(data, len);
 }
 
 //==========================================================================

--- a/src/wildmidi/wildmidi_lib.cpp
+++ b/src/wildmidi/wildmidi_lib.cpp
@@ -162,7 +162,7 @@ struct _mdi {
 		patch_count = 0;
 		amp = 0;
 		mix_buffer = NULL;
-		mix_buffer_size = NULL;
+		mix_buffer_size = 0;
 		reverb = NULL;
 	}
 
@@ -2926,7 +2926,7 @@ void WildMidi_Renderer::ShortEvent(int status, int parm1, int parm2)
 	}
 }
 
-void WildMidi_Renderer::LongEvent(const char *data, int len)
+void WildMidi_Renderer::LongEvent(const unsigned char *data, int len)
 {
 	// Check for Roland SysEx
 	if (len >= 11 &&			// Must be at least 11 bytes
@@ -2949,7 +2949,7 @@ void WildMidi_Renderer::LongEvent(const char *data, int len)
 		{ // Check destination address
 			if (((data[6] & 0xF0) == 0x10) && data[7] == 0x15)
 			{ // Roland drum track setting
-				int sysex_ch = data[6] & 0x0F;
+				unsigned char sysex_ch = data[6] & 0x0F;
 				if (sysex_ch == 0)
 				{
 					sysex_ch = 9;
@@ -2958,7 +2958,7 @@ void WildMidi_Renderer::LongEvent(const char *data, int len)
 				{
 					sysex_ch -= 1;
 				}
-				_event_data ev = { sysex_ch, data[8] };
+				_event_data ev = { sysex_ch, static_cast<unsigned long>(data[8]) };
 				do_sysex_roland_drum_track((_mdi *)handle, &ev);
 			}
 			else if (data[6] == 0x00 && data[7] == 0x7F && data[8] == 0x00)

--- a/src/wildmidi/wildmidi_lib.h
+++ b/src/wildmidi/wildmidi_lib.h
@@ -74,7 +74,7 @@ public:
 	~WildMidi_Renderer();
 
 	void ShortEvent(int status, int parm1, int parm2);
-	void LongEvent(const char *data, int len);
+	void LongEvent(const unsigned char *data, int len);
 	void ComputeOutput(float *buffer, int len);
 	void LoadInstrument(int bank, int percussion, int instr);
 	int GetVoiceCount();


### PR DESCRIPTION
Fixes the following clang warnings/errors:

```
/home/edward-san/zdoom/trunk/src/wildmidi/wildmidi_lib.cpp:165:21: warning: 
      implicit conversion of NULL constant to 'unsigned long'
      [-Wnull-conversion]
                mix_buffer_size = NULL;
                                ~ ^~~~
                                  0
/home/edward-san/zdoom/trunk/src/wildmidi/wildmidi_lib.cpp:2951:24: error: 
      non-constant-expression cannot be narrowed from type 'int' to
      'unsigned char' in initializer list [-Wc++11-narrowing]
                                _event_data ev = { sysex_ch, data[8] };
                                                   ^~~~~~~~
/home/edward-san/zdoom/trunk/src/wildmidi/wildmidi_lib.cpp:2951:24: note: 
      insert an explicit cast to silence this issue
                                _event_data ev = { sysex_ch, data[8] };
                                                   ^~~~~~~~
                                                   static_cast<unsigned char>( )
/home/edward-san/zdoom/trunk/src/wildmidi/wildmidi_lib.cpp:2951:34: error: 
      non-constant-expression cannot be narrowed from type 'char' to
      'unsigned long' in initializer list [-Wc++11-narrowing]
                                _event_data ev = { sysex_ch, data[8] };
                                                             ^~~~~~~
/home/edward-san/zdoom/trunk/src/wildmidi/wildmidi_lib.cpp:2951:34: note: 
      insert an explicit cast to silence this issue
  ..._event_data ev = { sysex_ch, data[8] };
                                  ^~~~~~~
                                  static_cast<unsigned long>( )
/home/edward-san/zdoom/trunk/src/wildmidi/wildmidi_lib.cpp:2923:15: warning: 
      comparison of constant 247 with expression of type 'const char' is always
      false [-Wtautological-constant-out-of-range-compare]
                data[len-1] == 0xF7 &&  // SysEx end
                ~~~~~~~~~~~ ^  ~~~~
/home/edward-san/zdoom/trunk/src/wildmidi/wildmidi_lib.cpp:2924:11: warning: 
      comparison of constant 240 with expression of type 'const char' is always
      false [-Wtautological-constant-out-of-range-compare]
                data[0] == 0xF0 &&              // SysEx
                ~~~~~~~ ^  ~~~~
3 warnings and 2 errors generated.
```