### PR TITLE
A_QuakeEx Falloff + High Point

### DIFF
--- a/src/g_shared/a_quake.cpp
+++ b/src/g_shared/a_quake.cpp
@@ -281,26 +281,21 @@ fixed_t DEarthquake::GetModIntensity(fixed_t intensity) const
 
 fixed_t DEarthquake::GetFalloff(fixed_t dist) const
 {
-	double falloff;
-	double tremorradius = FIXED2DBL(m_TremorRadius);
-	double fall = FIXED2DBL(m_Falloff);
-	double dis = FIXED2DBL(dist);
 	if ((dist < m_Falloff) || (m_Falloff >= m_TremorRadius) || (m_Falloff <= 0) || (m_TremorRadius - m_Falloff <= 0))
 	{ //Player inside the minimum falloff range, or safety check kicked in.
-		falloff = 1.f;
+		return FRACUNIT;
 	}
 	else if ((dist > m_Falloff) && (dist < m_TremorRadius))
 	{ //Player inside the radius, and outside the min distance for falloff.
-		double tremorsize = tremorradius - fall;
-		double tremordist = dis - fall;
+		fixed_t tremorsize = m_TremorRadius - m_Falloff;
+		fixed_t tremordist = dist - m_Falloff;
 		assert(tremorsize > 0);
-		falloff = (1.f - (1.f * tremordist) / tremorsize);
+		return (FRACUNIT - FixedMul(FRACUNIT,tremordist) / tremorsize);
 	}
 	else 
 	{ //Shouldn't happen.
-		falloff = 1.f;
+		return FRACUNIT;
 	}
-	return FLOAT2FIXED(falloff);
 }
 
 //==========================================================================

--- a/src/g_shared/a_quake.cpp
+++ b/src/g_shared/a_quake.cpp
@@ -98,21 +98,13 @@ void DEarthquake::Serialize (FArchive &arc)
 	{
 		arc << m_WaveSpeedX << m_WaveSpeedY << m_WaveSpeedZ;
 	}
-	if (SaveVersion < 4525)
+	if (SaveVersion < 4528)
 	{
-		m_Falloff <<= FRACBITS;
+		m_Falloff = m_Highpoint = m_MiniCount = 0;
 	}
 	else
 	{
-		arc << m_Falloff;
-	}
-	if (SaveVersion < 4526)
-	{
-		m_Highpoint = m_MiniCount = 0;
-	}
-	else
-	{
-		arc << m_Highpoint << m_MiniCount;
+		arc << m_Falloff << m_Highpoint << m_MiniCount;
 	}
 }
 

--- a/src/g_shared/a_sharedglobal.h
+++ b/src/g_shared/a_sharedglobal.h
@@ -157,7 +157,7 @@ class DEarthquake : public DThinker
 public:
 	DEarthquake(AActor *center, int intensityX, int intensityY, int intensityZ, int duration,
 		int damrad, int tremrad, FSoundID quakesfx, int flags, 
-		double waveSpeedX, double waveSpeedY, double waveSpeedZ, int falloff);
+		double waveSpeedX, double waveSpeedY, double waveSpeedZ, int falloff, int highpoint);
 
 	void Serialize (FArchive &arc);
 	void Tick ();
@@ -170,6 +170,7 @@ public:
 	fixed_t m_IntensityX, m_IntensityY, m_IntensityZ;
 	float m_WaveSpeedX, m_WaveSpeedY, m_WaveSpeedZ;
 	fixed_t m_Falloff;
+	int m_Highpoint, m_MiniCount;
 
 	fixed_t GetModIntensity(int intensity) const;
 	fixed_t GetModWave(double waveMultiplier) const;

--- a/src/g_shared/a_sharedglobal.h
+++ b/src/g_shared/a_sharedglobal.h
@@ -147,6 +147,7 @@ struct FQuakeJiggers
 	int RelIntensityX, RelIntensityY, RelIntensityZ;
 	int OffsetX, OffsetY, OffsetZ;
 	int RelOffsetX, RelOffsetY, RelOffsetZ;
+	int Falloff, WFalloff;
 };
 
 class DEarthquake : public DThinker
@@ -156,7 +157,7 @@ class DEarthquake : public DThinker
 public:
 	DEarthquake(AActor *center, int intensityX, int intensityY, int intensityZ, int duration,
 		int damrad, int tremrad, FSoundID quakesfx, int flags, 
-		double waveSpeedX, double waveSpeedY, double waveSpeedZ);
+		double waveSpeedX, double waveSpeedY, double waveSpeedZ, int falloff);
 
 	void Serialize (FArchive &arc);
 	void Tick ();
@@ -168,9 +169,11 @@ public:
 	int m_Flags;
 	fixed_t m_IntensityX, m_IntensityY, m_IntensityZ;
 	float m_WaveSpeedX, m_WaveSpeedY, m_WaveSpeedZ;
+	fixed_t m_Falloff;
 
 	fixed_t GetModIntensity(int intensity) const;
 	fixed_t GetModWave(double waveMultiplier) const;
+	fixed_t GetFalloff(fixed_t dist) const;
 
 	static int StaticGetQuakeIntensities(AActor *viewer, FQuakeJiggers &jiggers);
 

--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -5719,7 +5719,8 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 				argCount > 9 ? FIXED2DBL(args[9]) : 1.0, 
 				argCount > 10 ? FIXED2DBL(args[10]) : 1.0, 
 				argCount > 11 ? FIXED2DBL(args[11]) : 1.0, 
-				argCount > 12 ? args[12] : 0);
+				argCount > 12 ? args[12] : 0,
+				argCount > 13 ? args[13] : 0);
 		}
 
 		case ACSF_SetLineActivation:

--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -5718,7 +5718,8 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 				argCount > 8 ? args[8] : 0,
 				argCount > 9 ? FIXED2DBL(args[9]) : 1.0, 
 				argCount > 10 ? FIXED2DBL(args[10]) : 1.0, 
-				argCount > 11 ? FIXED2DBL(args[11]) : 1.0 );
+				argCount > 11 ? FIXED2DBL(args[11]) : 1.0, 
+				argCount > 12 ? args[12] : 0);
 		}
 
 		case ACSF_SetLineActivation:

--- a/src/p_spec.h
+++ b/src/p_spec.h
@@ -927,7 +927,7 @@ void P_DoDeferedScripts (void);
 //
 // [RH] p_quake.c
 //
-bool P_StartQuakeXYZ(AActor *activator, int tid, int intensityX, int intensityY, int intensityZ, int duration, int damrad, int tremrad, FSoundID quakesfx, int flags, double waveSpeedX, double waveSpeedY, double waveSpeedZ, int falloff);
+bool P_StartQuakeXYZ(AActor *activator, int tid, int intensityX, int intensityY, int intensityZ, int duration, int damrad, int tremrad, FSoundID quakesfx, int flags, double waveSpeedX, double waveSpeedY, double waveSpeedZ, int falloff, int highpoint);
 bool P_StartQuake(AActor *activator, int tid, int intensity, int duration, int damrad, int tremrad, FSoundID quakesfx);
 
 #endif

--- a/src/p_spec.h
+++ b/src/p_spec.h
@@ -927,7 +927,7 @@ void P_DoDeferedScripts (void);
 //
 // [RH] p_quake.c
 //
-bool P_StartQuakeXYZ(AActor *activator, int tid, int intensityX, int intensityY, int intensityZ, int duration, int damrad, int tremrad, FSoundID quakesfx, int flags, double waveSpeedX, double waveSpeedY, double waveSpeedZ);
+bool P_StartQuakeXYZ(AActor *activator, int tid, int intensityX, int intensityY, int intensityZ, int duration, int damrad, int tremrad, FSoundID quakesfx, int flags, double waveSpeedX, double waveSpeedY, double waveSpeedZ, int falloff);
 bool P_StartQuake(AActor *activator, int tid, int intensity, int duration, int damrad, int tremrad, FSoundID quakesfx);
 
 #endif

--- a/src/r_utility.cpp
+++ b/src/r_utility.cpp
@@ -770,7 +770,6 @@ bool R_GetViewInterpolationStatus()
 static fixed_t QuakePower(fixed_t factor, fixed_t intensity, fixed_t offset, fixed_t falloff, fixed_t wfalloff)
 { 
 	fixed_t randumb;
-	int divisor = 1;
 	if (intensity == 0)
 	{
 		randumb = 0;
@@ -779,7 +778,6 @@ static fixed_t QuakePower(fixed_t factor, fixed_t intensity, fixed_t offset, fix
 	{
 		randumb = pr_torchflicker(intensity * 2) - intensity;
 	}
-	fixed_t rn1 = FixedMul(offset + randumb, factor);
 	fixed_t rn2 = (FixedMul(wfalloff,offset) + FixedMul(falloff, randumb));
 	return FixedMul(factor, rn2);
 }

--- a/src/r_utility.cpp
+++ b/src/r_utility.cpp
@@ -767,10 +767,10 @@ bool R_GetViewInterpolationStatus()
 //
 //==========================================================================
 
-static fixed_t QuakePower(fixed_t factor, fixed_t intensity, fixed_t offset)
+static fixed_t QuakePower(fixed_t factor, fixed_t intensity, fixed_t offset, fixed_t falloff, fixed_t wfalloff)
 { 
 	fixed_t randumb;
-
+	int divisor = 1;
 	if (intensity == 0)
 	{
 		randumb = 0;
@@ -779,7 +779,9 @@ static fixed_t QuakePower(fixed_t factor, fixed_t intensity, fixed_t offset)
 	{
 		randumb = pr_torchflicker(intensity * 2) - intensity;
 	}
-	return FixedMul(factor, randumb + offset);
+	fixed_t rn1 = FixedMul(offset + randumb, factor);
+	fixed_t rn2 = (FixedMul(wfalloff,offset) + FixedMul(falloff, randumb));
+	return FixedMul(factor, rn2);
 }
 
 //==========================================================================
@@ -901,34 +903,33 @@ void R_SetupFrame (AActor *actor)
 			if ((jiggers.RelIntensityX | jiggers.RelOffsetX) != 0)
 			{
 				int ang = (camera->angle) >> ANGLETOFINESHIFT;
-				fixed_t power = QuakePower(quakefactor, jiggers.RelIntensityX, jiggers.RelOffsetX);
+				fixed_t power = QuakePower(quakefactor, jiggers.RelIntensityX, jiggers.RelOffsetX, jiggers.Falloff, jiggers.WFalloff);
 				viewx += FixedMul(finecosine[ang], power);
 				viewy += FixedMul(finesine[ang], power);
 			}
 			if ((jiggers.RelIntensityY | jiggers.RelOffsetY) != 0)
 			{
 				int ang = (camera->angle + ANG90) >> ANGLETOFINESHIFT;
-				fixed_t power = QuakePower(quakefactor, jiggers.RelIntensityY, jiggers.RelOffsetY);
+				fixed_t power = QuakePower(quakefactor, jiggers.RelIntensityY, jiggers.RelOffsetY, jiggers.Falloff, jiggers.WFalloff);
 				viewx += FixedMul(finecosine[ang], power);
 				viewy += FixedMul(finesine[ang], power);
 			}
 			// FIXME: Relative Z is not relative
-			// [MC]On it! Will be introducing pitch after QF_WAVE.
 			if ((jiggers.RelIntensityZ | jiggers.RelOffsetZ) != 0)
 			{
-				viewz += QuakePower(quakefactor, jiggers.RelIntensityZ, jiggers.RelOffsetZ);
+				viewz += QuakePower(quakefactor, jiggers.RelIntensityZ, jiggers.RelOffsetZ, jiggers.Falloff, jiggers.WFalloff);
 			}
 			if ((jiggers.IntensityX | jiggers.OffsetX) != 0)
 			{
-				viewx += QuakePower(quakefactor, jiggers.IntensityX, jiggers.OffsetX);
+				viewx += QuakePower(quakefactor, jiggers.IntensityX, jiggers.OffsetX, jiggers.Falloff, jiggers.WFalloff);
 			}
 			if ((jiggers.IntensityY | jiggers.OffsetY) != 0)
 			{
-				viewy += QuakePower(quakefactor, jiggers.IntensityY, jiggers.OffsetY);
+				viewy += QuakePower(quakefactor, jiggers.IntensityY, jiggers.OffsetY, jiggers.Falloff, jiggers.WFalloff);
 			}
 			if ((jiggers.IntensityZ | jiggers.OffsetZ) != 0)
 			{
-				viewz += QuakePower(quakefactor, jiggers.IntensityZ, jiggers.OffsetZ);
+				viewz += QuakePower(quakefactor, jiggers.IntensityZ, jiggers.OffsetZ, jiggers.Falloff, jiggers.WFalloff);
 			}
 		}
 	}

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -4446,7 +4446,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_Quake)
 
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_QuakeEx)
 {
-	ACTION_PARAM_START(12);
+	ACTION_PARAM_START(13);
 	ACTION_PARAM_INT(intensityX, 0);
 	ACTION_PARAM_INT(intensityY, 1);
 	ACTION_PARAM_INT(intensityZ, 2);
@@ -4459,7 +4459,8 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_QuakeEx)
 	ACTION_PARAM_DOUBLE(mulWaveY, 9);
 	ACTION_PARAM_DOUBLE(mulWaveZ, 10);
 	ACTION_PARAM_INT(falloff, 11);
-	P_StartQuakeXYZ(self, 0, intensityX, intensityY, intensityZ, duration, damrad, tremrad, sound, flags, mulWaveX, mulWaveY, mulWaveZ, falloff);
+	ACTION_PARAM_INT(highpoint, 12);
+	P_StartQuakeXYZ(self, 0, intensityX, intensityY, intensityZ, duration, damrad, tremrad, sound, flags, mulWaveX, mulWaveY, mulWaveZ, falloff, highpoint);
 }
 
 //===========================================================================

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -4441,12 +4441,12 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_Quake)
 // A_QuakeEx
 //
 // Extended version of A_Quake. Takes individual axis into account and can
-// take a flag.
+// take flags.
 //===========================================================================
 
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_QuakeEx)
 {
-	ACTION_PARAM_START(11);
+	ACTION_PARAM_START(12);
 	ACTION_PARAM_INT(intensityX, 0);
 	ACTION_PARAM_INT(intensityY, 1);
 	ACTION_PARAM_INT(intensityZ, 2);
@@ -4458,7 +4458,8 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_QuakeEx)
 	ACTION_PARAM_DOUBLE(mulWaveX, 8);
 	ACTION_PARAM_DOUBLE(mulWaveY, 9);
 	ACTION_PARAM_DOUBLE(mulWaveZ, 10);
-	P_StartQuakeXYZ(self, 0, intensityX, intensityY, intensityZ, duration, damrad, tremrad, sound, flags, mulWaveX, mulWaveY, mulWaveZ);
+	ACTION_PARAM_INT(falloff, 11);
+	P_StartQuakeXYZ(self, 0, intensityX, intensityY, intensityZ, duration, damrad, tremrad, sound, flags, mulWaveX, mulWaveY, mulWaveZ, falloff);
 }
 
 //===========================================================================

--- a/src/version.h
+++ b/src/version.h
@@ -76,7 +76,7 @@ const char *GetVersionString();
 
 // Use 4500 as the base git save version, since it's higher than the
 // SVN revision ever got.
-#define SAVEVER 4527
+#define SAVEVER 4528
 
 #define SAVEVERSTRINGIFY2(x) #x
 #define SAVEVERSTRINGIFY(x) SAVEVERSTRINGIFY2(x)

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -299,7 +299,7 @@ ACTOR Actor native //: Thinker
 	action native A_SetUserArray(name varname, int index, int value);
 	action native A_SetSpecial(int spec, int arg0 = 0, int arg1 = 0, int arg2 = 0, int arg3 = 0, int arg4 = 0);
 	action native A_Quake(int intensity, int duration, int damrad, int tremrad, sound sfx = "world/quake");
-	action native A_QuakeEx(int intensityX, int intensityY, int intensityZ, int duration, int damrad, int tremrad, sound sfx = "world/quake", int flags = 0, float mulWaveX = 1, float mulWaveY = 1, float mulWaveZ = 1);
+	action native A_QuakeEx(int intensityX, int intensityY, int intensityZ, int duration, int damrad, int tremrad, sound sfx = "world/quake", int flags = 0, float mulWaveX = 1, float mulWaveY = 1, float mulWaveZ = 1, int falloff = 0);
 	action native A_SetTics(int tics);
 	action native A_SetDamageType(name damagetype);
 	action native A_DropItem(class<Actor> item, int dropamount = -1, int chance = 256);

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -299,7 +299,7 @@ ACTOR Actor native //: Thinker
 	action native A_SetUserArray(name varname, int index, int value);
 	action native A_SetSpecial(int spec, int arg0 = 0, int arg1 = 0, int arg2 = 0, int arg3 = 0, int arg4 = 0);
 	action native A_Quake(int intensity, int duration, int damrad, int tremrad, sound sfx = "world/quake");
-	action native A_QuakeEx(int intensityX, int intensityY, int intensityZ, int duration, int damrad, int tremrad, sound sfx = "world/quake", int flags = 0, float mulWaveX = 1, float mulWaveY = 1, float mulWaveZ = 1, int falloff = 0);
+	action native A_QuakeEx(int intensityX, int intensityY, int intensityZ, int duration, int damrad, int tremrad, sound sfx = "world/quake", int flags = 0, float mulWaveX = 1, float mulWaveY = 1, float mulWaveZ = 1, int falloff = 0, int highpoint = 0);
 	action native A_SetTics(int tics);
 	action native A_SetDamageType(name damagetype);
 	action native A_DropItem(class<Actor> item, int dropamount = -1, int chance = 256);


### PR DESCRIPTION
- Added Falloff + HighPoint parameters to A_QuakeEx.
- Falloff works just like A_Explode's Full Radius Damage parameter. The farther a player is from that point, the more subtle the quake becomes. Default is 0, meaning no falloff is made.
- HighPoint determines when the quake will reach its peak, specified in tics.