### PR TITLE
[OSX] Fixed mouse cursor centering in fullscreen mode

### DIFF
--- a/src/posix/cocoa/i_video.mm
+++ b/src/posix/cocoa/i_video.mm
@@ -625,7 +625,7 @@ void CocoaVideo::SetFullscreenMode(const int width, const int height)
 		[m_window setHidesOnDeactivate:YES];
 	}
 
-	[m_window setFrame:displayRect display:YES];
+	[m_window setFrame:screenFrame display:YES];
 	[m_window setFrameOrigin:NSMakePoint(0.0f, 0.0f)];
 }
 
@@ -1231,10 +1231,7 @@ NSSize I_GetContentViewSize(const NSWindow* const window)
 	const NSView* const view = [window contentView];
 	const NSSize frameSize   = [view frame].size;
 
-	// TODO: figure out why [NSView frame] returns different values in "fullscreen" and in window
-	// In "fullscreen" the result is multiplied by [NSScreen backingScaleFactor], but not in window
-
-	return (vid_hidpi && !fullscreen)
+	return (vid_hidpi)
 		? [view convertSizeToBacking:frameSize]
 		: frameSize;
 }


### PR DESCRIPTION
Native OS X backed didn't center mouse cursor in fullscreen mode with Retina/HiDPI support enabled
Incorrect size of content view led to placement of cursor in upper right corner of the screen upon releasing of mouse capture
When some action is assigned to this corner using system Hot Corners feature, the given action was triggered on acquiring mouse capture