### PR TITLE
Fixed division by zero in RNG

### DIFF
--- a/src/m_random.h
+++ b/src/m_random.h
@@ -57,7 +57,9 @@ public:
 	// Returns a random number in the range [0,mod)
 	int operator() (int mod)
 	{
-		return GenRand32() % mod;
+		return (0 == mod)
+			? 0
+			: (GenRand32() % mod);
 	}
 
 	// Returns rand# - rand#


### PR DESCRIPTION
Random number generator now returns zero for range [0, 0)