### PR TITLE
A_CheckProximity Expansion - Pruned

### DIFF
--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -497,6 +497,14 @@ enum
 	CPXF_COUNTDEAD			= 1 << 3,
 	CPXF_DEADONLY			= 1 << 4,
 	CPXF_EXACT				= 1 << 5,
+	CPXF_SETTARGET =		1 << 6,
+	CPXF_SETMASTER =		1 << 7,
+	CPXF_SETTRACER =		1 << 8,
+	CPXF_FARTHEST =			1 << 9,
+	CPXF_CLOSEST =			1 << 10,
+	CPXF_SETONPTR =			1 << 11,
+	CPXF_NODISTANCE =		1 << 12,
+	CPXF_CHECKSIGHT =		1 << 13,
 };
 
 // Flags for A_CheckBlock


### PR DESCRIPTION
- Added the following flags, all affixed with CPXF_:
- NODISTANCE: Disables distance checking.
- CHECKSIGHT: The qualifying actor must be in sight in order to count.
- SET<TARGET/MASTER/TRACER>: Gets the first qualifying actor and sets the calling actor's specified pointer to it.
- SETONPTR: If the function is being aimed at another actor other than the caller, sets that actor's pointers instead. Requires a SET* flag to work.
- FARTHEST: The actor farthest from the checking actor is set as the pointer. Requires a SET* flag to work.
- CLOSEST: The closest qualifying actor is set as the pointer. Requires a SET* flag to work.