### PR TITLE
A_Chase Turn Flags - Pruned

### DIFF
--- a/src/p_enemy.h
+++ b/src/p_enemy.h
@@ -61,7 +61,6 @@ void A_Weave(AActor *self, int xyspeed, int zspeed, fixed_t xydist, fixed_t zdis
 void A_Unblock(AActor *self, bool drop);
 
 DECLARE_ACTION(A_Look)
-DECLARE_ACTION(A_Wander)
 DECLARE_ACTION(A_BossDeath)
 DECLARE_ACTION(A_Pain)
 DECLARE_ACTION(A_MonsterRail)
@@ -72,6 +71,7 @@ DECLARE_ACTION(A_FreezeDeathChunks)
 DECLARE_ACTION(A_BossDeath)
 
 void A_Chase(AActor *self);
+void A_Wander(AActor *self, int flags = 0);
 void A_FaceTarget(AActor *actor, angle_t max_turn = 0, angle_t max_pitch = ANGLE_270, angle_t ang_offset = 0, angle_t pitch_offset = 0, int flags = 0);
 void A_Face(AActor *self, AActor *other, angle_t max_turn = 0, angle_t max_pitch = ANGLE_270, angle_t ang_offset = 0, angle_t pitch_offset = 0, int flags = 0);
 

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -176,7 +176,7 @@ ACTOR Actor native //: Thinker
 	action native A_SkullPop(class<Actor> skulltype = "BloodySkull");
 	action native A_CheckPlayerDone();
 
-	action native A_Wander();
+	action native A_Wander(int flags = 0);
 	action native A_Look2();
 	action native A_TossGib();
 	action native A_SentinelBob();

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -84,6 +84,9 @@ const int CHF_NOPLAYACTIVE = 2;
 const int CHF_NIGHTMAREFAST = 4;
 const int CHF_RESURRECT = 8;
 const int CHF_DONTMOVE = 16;
+const int CHF_NORANDOMTURN = 32;
+const int CHF_DONTANGLE = 64;
+const int CHF_NOPOSTATTACKTURN = 128;
 
 // Flags for A_LookEx
 const int LOF_NOSIGHTCHECK = 1;

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -513,6 +513,13 @@ enum
 	CBF_SETONPTR		= 1 << 4,	//Sets the pointer change on the actor doing the checking instead of self.
 };
 
+// Wander Flags
+enum
+{
+	WF_NORANDOMTURN	=	1,
+	WF_DONTANGLE =		2,
+};
+
 // This is only here to provide one global variable for testing.
 native int testglobalvar;
 

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -79,14 +79,20 @@ const int SXF_ISMASTER				=	1 << 27;
 const int SXF_ISTRACER				=	1 << 28;
 
 // Flags for A_Chase
-const int CHF_FASTCHASE = 1;
-const int CHF_NOPLAYACTIVE = 2;
-const int CHF_NIGHTMAREFAST = 4;
-const int CHF_RESURRECT = 8;
-const int CHF_DONTMOVE = 16;
-const int CHF_NORANDOMTURN = 32;
-const int CHF_DONTANGLE = 64;
-const int CHF_NOPOSTATTACKTURN = 128;
+enum
+{
+	CHF_FASTCHASE =						1,
+	CHF_NOPLAYACTIVE =					2,
+	CHF_NIGHTMAREFAST =					4,
+	CHF_RESURRECT =						8,
+	CHF_DONTMOVE =						16,
+	CHF_NORANDOMTURN =					32,
+	CHF_DONTANGLE =						64,
+	CHF_NOPOSTATTACKTURN =				128,
+	CHF_STOPIFBLOCKED =					256,
+
+	CHF_DONTTURN = CHF_NORANDOMTURN|CHF_NOPOSTATTACKTURN|CHF_STOPIFBLOCKED,
+};
 
 // Flags for A_LookEx
 const int LOF_NOSIGHTCHECK = 1;


### PR DESCRIPTION
- Adds the following flags (CHF_):
- NORANDOMTURN: Actor will not randomly turn during chasing to pursue its target. It will only turn if it cannot keep moving forward.
- DONTANGLE: Actor does not adjust its angle to match the movement direction.
- NOPOSTATTACKTURN: Actor will not make its first turn after exiting its attacks.
- STOPIFBLOCKED: Actor will not change directions if it cannot move forward.