### PR TITLE
I missed one last spot where a FreeBSD compilation should follow the …

### DIFF
--- a/src/posix/sdl/crashcatcher.c
+++ b/src/posix/sdl/crashcatcher.c
@@ -15,7 +15,7 @@
 #ifndef PR_SET_PTRACER
 #define PR_SET_PTRACER 0x59616d61
 #endif
-#elif defined (__APPLE__)
+#elif defined (__APPLE__) || defined (__FreeBSD__)
 #include <signal.h>
 #endif
 


### PR DESCRIPTION
…path of OS X -- <signal.h> needs to be pulled in for signal functions