### PR TITLE
Shortcut to toggle fullscreen on OS X

### DIFF
--- a/src/posix/cocoa/i_common.h
+++ b/src/posix/cocoa/i_common.h
@@ -79,6 +79,7 @@ typedef float CGFloat;
 // From HIToolbox/Events.h
 enum
 {
+	kVK_ANSI_F        = 0x03,
 	kVK_Return        = 0x24,
 	kVK_Tab           = 0x30,
 	kVK_Space         = 0x31,

--- a/src/posix/cocoa/i_input.mm
+++ b/src/posix/cocoa/i_input.mm
@@ -57,6 +57,8 @@ CVAR(Bool, use_mouse,    true,  CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Bool, m_noprescale, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Bool, m_filter,     false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 
+CVAR(Bool, k_allowfullscreentoggle, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+
 CUSTOM_CVAR(Int, mouse_capturemode, 1, CVAR_GLOBALCONFIG | CVAR_ARCHIVE)
 {
 	if (self < 0)
@@ -539,6 +541,16 @@ void ProcessKeyboardEvent(NSEvent* theEvent)
 	if (keyCode >= KEY_COUNT)
 	{
 		assert(!"Unknown keycode");
+		return;
+	}
+
+	if (k_allowfullscreentoggle
+		&& (kVK_ANSI_F == keyCode)
+		&& (NSCommandKeyMask & [theEvent modifierFlags])
+		&& (NSKeyDown == [theEvent type])
+		&& ![theEvent isARepeat])
+	{
+		ToggleFullscreen = !ToggleFullscreen;
 		return;
 	}
 


### PR DESCRIPTION
Press Command+F to toggle fullscreen mode in native OS X backend
Set k_allowfullscreentoggle CVAR to false to disable the shortcut