### PR TITLE
Fade fix

### DIFF
--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -2439,7 +2439,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FadeIn)
 		if (flags & FTF_CLAMP)
 			self->alpha = (FRACUNIT * 1);
 		if (flags & FTF_REMOVE)
-			self->Destroy();
+			P_RemoveThing(self);
 	}
 }
 
@@ -2467,7 +2467,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FadeOut)
 		if (flags & FTF_CLAMP)
 			self->alpha = 0;
 		if (flags & FTF_REMOVE)
-			self->Destroy();
+			P_RemoveThing(self);
 	}
 }
 
@@ -2515,7 +2515,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FadeTo)
 	}
 	if (self->alpha == target && (flags & FTF_REMOVE))
 	{
-		self->Destroy();
+		P_RemoveThing(self);
 	}
 }
 


### PR DESCRIPTION
- Fixed: A_Fade* could destroy live player bodies because it was calling the Destroy() function directly instead of going through P_RemoveThing.