### PR TITLE
Added FDARI's advanced visibility filtering

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -374,6 +374,7 @@ enum ActorFlag7
 	MF7_FORCEDECAL		= 0x00080000,	// [ZK] Forces puff's decal to override the weapon's.
 	MF7_LAXTELEFRAGDMG	= 0x00100000,	// [MC] Telefrag damage can be reduced.
 	MF7_ICESHATTER		= 0x00200000,	// [MC] Shatters ice corpses regardless of damagetype.
+	MF7_FILTERHIDES		= 0x00400000,	// Show the actor to anything not covered by the filter
 };
 
 // --- mobj.renderflags ---
@@ -972,6 +973,9 @@ public:
 
 	// [BB] If 0, everybody can see the actor, if > 0, only members of team (VisibleToTeam-1) can see it.
 	DWORD			VisibleToTeam;
+
+	// Inclusive filter (AAPTR_ bitmask) to tell who can see this actor; inverted by MF6_FILTERHIDES
+	int				VisibleFilter;
 
 	int				special1;		// Special info
 	int				special2;		// Special info

--- a/src/actorptrselect.cpp
+++ b/src/actorptrselect.cpp
@@ -232,14 +232,12 @@ bool AAPTR_FILTER(AActor *context, AActor *target, int aaptr_filter)
 			}
 		}
 
-		if ((aaptr_filter & AAPTR_PLAYER1) && AAPTR_RESOLVE_PLAYERNUM(0) == target) return true;
-		if ((aaptr_filter & AAPTR_PLAYER2) && AAPTR_RESOLVE_PLAYERNUM(1) == target) return true;
-		if ((aaptr_filter & AAPTR_PLAYER3) && AAPTR_RESOLVE_PLAYERNUM(2) == target) return true;
-		if ((aaptr_filter & AAPTR_PLAYER4) && AAPTR_RESOLVE_PLAYERNUM(3) == target) return true;
-		if ((aaptr_filter & AAPTR_PLAYER5) && AAPTR_RESOLVE_PLAYERNUM(4) == target) return true;
-		if ((aaptr_filter & AAPTR_PLAYER6) && AAPTR_RESOLVE_PLAYERNUM(5) == target) return true;
-		if ((aaptr_filter & AAPTR_PLAYER7) && AAPTR_RESOLVE_PLAYERNUM(6) == target) return true;
-		if ((aaptr_filter & AAPTR_PLAYER8) && AAPTR_RESOLVE_PLAYERNUM(7) == target) return true;
+		// [zombie] support any amount of players
+		for (int i = 0; i < MAXPLAYERS; i++)
+		{
+			if ((aaptr_filter & (AAPTR_PLAYER1 << i)) && AAPTR_RESOLVE_PLAYERNUM(i) == target)
+				return true;
+		}
 
 		return false;
 	}

--- a/src/actorptrselect.cpp
+++ b/src/actorptrselect.cpp
@@ -184,3 +184,64 @@ void ASSIGN_AAPTR(AActor *toActor, int toSlot, AActor *ptr, int flags)
 			break;
 	}
 }
+
+/*
+
+AAPTR_FILTER
+
+Search references from one actor (context)
+to find another actor (target)
+using references specified in aaptr_filter
+
+a null context will only match static filter specifications
+a null target will only match AAPTR_NULL
+
+a null filter will match nothing (and it will check the bits one by one, so it is better to preempt the call)
+null filter is not handled specifically here because specific handling is better handled by the calling code
+
+There is no filter for AAPTR_DEFAULT
+*/
+
+bool AAPTR_FILTER(AActor *context, AActor *target, int aaptr_filter)
+{
+	if (target)
+	{
+		/*
+		Because we're going through the lot, and returning on first match (or after processing all) order has no impact on logic, only performance
+		For this reason, it seems viable to put target master and tracer rather high up, and rare/processing-intensive tests later
+		*/
+
+		// Also note that since target is not null at this point, there is no need to re-verify that stuff is not equal to null; NULL != target
+
+		if (context)
+		{
+			if ((aaptr_filter & AAPTR_TARGET) && context->target == target) return true;
+			if ((aaptr_filter & AAPTR_MASTER) && context->master == target) return true;
+			if ((aaptr_filter & AAPTR_TRACER) && context->tracer == target) return true;
+			if ((aaptr_filter & AAPTR_FRIENDPLAYER) && context->FriendPlayer && AAPTR_RESOLVE_PLAYERNUM(context->FriendPlayer - 1) == target) return true;
+
+			if (context->player)
+			{
+				if ((aaptr_filter & AAPTR_PLAYER_GETCONVERSATION) && context->player->ConversationNPC == target) return true;
+				if (aaptr_filter & AAPTR_PLAYER_GETTARGET)
+				{
+					AActor *gettarget = NULL;
+					P_BulletSlope(context, &gettarget);
+					if (gettarget == target) return true;
+				}
+			}
+		}
+
+		if ((aaptr_filter & AAPTR_PLAYER1) && AAPTR_RESOLVE_PLAYERNUM(0) == target) return true;
+		if ((aaptr_filter & AAPTR_PLAYER2) && AAPTR_RESOLVE_PLAYERNUM(1) == target) return true;
+		if ((aaptr_filter & AAPTR_PLAYER3) && AAPTR_RESOLVE_PLAYERNUM(2) == target) return true;
+		if ((aaptr_filter & AAPTR_PLAYER4) && AAPTR_RESOLVE_PLAYERNUM(3) == target) return true;
+		if ((aaptr_filter & AAPTR_PLAYER5) && AAPTR_RESOLVE_PLAYERNUM(4) == target) return true;
+		if ((aaptr_filter & AAPTR_PLAYER6) && AAPTR_RESOLVE_PLAYERNUM(5) == target) return true;
+		if ((aaptr_filter & AAPTR_PLAYER7) && AAPTR_RESOLVE_PLAYERNUM(6) == target) return true;
+		if ((aaptr_filter & AAPTR_PLAYER8) && AAPTR_RESOLVE_PLAYERNUM(7) == target) return true;
+
+		return false;
+	}
+	return !!(aaptr_filter & AAPTR_NULL);
+}

--- a/src/actorptrselect.h
+++ b/src/actorptrselect.h
@@ -95,5 +95,5 @@ enum PTROP
 
 void VerifyTargetChain(AActor *self, bool preciseMissileCheck=true);
 void VerifyMasterChain(AActor *self);
-void ASSIGN_AAPTR(AActor *toActor, int toSlot, AActor *ptr, int flags) ;
-
+void ASSIGN_AAPTR(AActor *toActor, int toSlot, AActor *ptr, int flags);
+bool AAPTR_FILTER(AActor *origin, AActor *locate, int aaptr_filter);

--- a/src/dobject.h
+++ b/src/dobject.h
@@ -297,6 +297,16 @@ namespace GC
 		return obj = NULL;
 	}
 
+	// Handles a read barrier when assigning to obj is not permitted
+	template<class T> inline T *ReadBarrier(T * const &obj)
+	{
+		if (obj == NULL || !(obj->ObjectFlags & OF_EuthanizeMe))
+		{
+			return obj;
+		}
+		return NULL;
+	}
+
 	// Check if it's time to collect, and do a collection step if it is.
 	static inline void CheckGC()
 	{
@@ -366,6 +376,10 @@ public:
 		// The caller must now perform a write barrier.
 	}
 	operator T*() throw()
+	{
+		return GC::ReadBarrier(p);
+	}
+	operator T*() const throw()
 	{
 		return GC::ReadBarrier(p);
 	}

--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -3689,6 +3689,8 @@ enum
 	APROP_StencilColor	= 41,
 	APROP_Friction		= 42,
 	APROP_DamageMultiplier=43,
+	APROP_VisibleFilter	= 44,
+	APROP_FilterHides	= 45,
 };
 
 // These are needed for ACS's APROP_RenderStyle
@@ -3938,6 +3940,22 @@ void DLevelScript::DoSetActorProperty (AActor *actor, int property, int value)
 
 	case APROP_Friction:
 		actor->Friction = value;
+		break;
+
+	case APROP_VisibleFilter:
+		actor->VisibleFilter = value;
+		break;
+
+	case APROP_FilterHides:
+		if (value)
+		{
+			actor->flags7 |= MF7_FILTERHIDES;
+		}
+		else
+		{
+			actor->flags7 &= ~MF7_FILTERHIDES;
+		}
+		break;
 
 	default:
 		// do nothing.
@@ -4039,6 +4057,8 @@ int DLevelScript::GetActorProperty (int tid, int property, const SDWORD *stack, 
 	case APROP_NameTag:		return GlobalACSStrings.AddString(actor->GetTag(), stack, stackdepth);
 	case APROP_StencilColor:return actor->fillcolor;
 	case APROP_Friction:	return actor->Friction;
+	case APROP_VisibleFilter:return actor->VisibleFilter;
+	case APROP_FilterHides:	return !!(actor->flags7 & MF7_FILTERHIDES);
 
 	default:				return 0;
 	}
@@ -4086,6 +4106,7 @@ int DLevelScript::CheckActorProperty (int tid, int property, int value)
 		case APROP_ViewHeight:
 		case APROP_AttackZOffset:
 		case APROP_StencilColor:
+		case APROP_VisibleFilter:
 			return (GetActorProperty(tid, property, NULL, 0) == value);
 
 		// Boolean values need to compare to a binary version of value
@@ -4098,6 +4119,7 @@ int DLevelScript::CheckActorProperty (int tid, int property, int value)
 		case APROP_Notarget:
 		case APROP_Notrigger:
 		case APROP_Dormant:
+		case APROP_FilterHides:
 			return (GetActorProperty(tid, property, NULL, 0) == (!!value));
 
 		// Strings are covered by GetActorProperty, but they're fairly

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -66,6 +66,7 @@
 #include "farchive.h"
 #include "r_data/colormaps.h"
 #include "r_renderer.h"
+#include "actorptrselect.h"
 
 // MACROS ------------------------------------------------------------------
 
@@ -307,6 +308,7 @@ void AActor::Serialize (FArchive &arc)
 		<< BlockingMobj
 		<< BlockingLine
 		<< VisibleToTeam // [BB]
+		<< VisibleFilter // [fdari]
 		<< pushfactor
 		<< Species
 		<< Score;
@@ -1030,6 +1032,14 @@ bool AActor::IsVisibleToPlayer() const
 		}
 		if(!visible)
 			return false;
+	}
+
+	// [FDARI] Passed all checks but the filter
+	if (VisibleFilter)
+	{
+		if (AAPTR_FILTER((AActor *)this, pPlayer->mo, VisibleFilter))
+			return !(pPlayer->mo->flags7 & MF7_FILTERHIDES);
+		return !!(pPlayer->mo->flags7 & MF7_FILTERHIDES);
 	}
 
 	// [BB] Passed all checks.

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -1037,9 +1037,8 @@ bool AActor::IsVisibleToPlayer() const
 	// [FDARI] Passed all checks but the filter
 	if (VisibleFilter)
 	{
-		if (AAPTR_FILTER((AActor *)this, pPlayer->mo, VisibleFilter))
-			return !(pPlayer->mo->flags7 & MF7_FILTERHIDES);
-		return !!(pPlayer->mo->flags7 & MF7_FILTERHIDES);
+		bool visible = AAPTR_FILTER((AActor *)this, pPlayer->mo, VisibleFilter);
+		return (flags7 & MF7_FILTERHIDES) ? !visible : visible;
 	}
 
 	// [BB] Passed all checks.

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -6029,3 +6029,15 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_CheckBlock)
 		ACTION_JUMP(block);
 	}
 }
+
+//===========================================================================
+//
+// A_FilterVisibility
+//
+//===========================================================================
+DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FilterVisibility)
+{
+	ACTION_PARAM_START(1);
+	ACTION_PARAM_INT(visibleFilter, 0);
+	self->VisibleFilter = visibleFilter;
+}

--- a/src/thingdef/thingdef_data.cpp
+++ b/src/thingdef/thingdef_data.cpp
@@ -257,6 +257,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF7, FORCEDECAL, AActor, flags7),
 	DEFINE_FLAG(MF7, LAXTELEFRAGDMG, AActor, flags7),
 	DEFINE_FLAG(MF7, ICESHATTER, AActor, flags7),
+	DEFINE_FLAG(MF7, FILTERHIDES, AActor, flags7),
 
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),

--- a/src/thingdef/thingdef_properties.cpp
+++ b/src/thingdef/thingdef_properties.cpp
@@ -1462,6 +1462,15 @@ DEFINE_PROPERTY(riplevelmax, I, Actor)
 }
 
 //==========================================================================
+// [FDARI]
+//==========================================================================
+DEFINE_PROPERTY(visibleFilter, I, Actor)
+{
+	PROP_INT_PARM(i, 0);
+	defaults->VisibleFilter = i;
+}
+
+//==========================================================================
 //
 // Special inventory properties
 //

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -345,6 +345,7 @@ ACTOR Actor native //: Thinker
 	action native A_RearrangePointers(int newtarget, int newmaster = AAPTR_DEFAULT, int newtracer = AAPTR_DEFAULT, int flags=0);
 	action native A_TransferPointer(int ptr_source, int ptr_recepient, int sourcefield, int recepientfield=AAPTR_DEFAULT, int flags=0);
 	action native A_CopyFriendliness(int ptr_source = AAPTR_MASTER);
+	action native A_FilterVisibility(int ptr_bitmask);
 
 	action native ACS_NamedExecute(string script, int mapnum=0, int arg1=0, int arg2=0, int arg3=0);
 	action native ACS_NamedSuspend(string script, int mapnum=0);


### PR DESCRIPTION
Pull request version of: http://forum.zdoom.org/viewtopic.php?f=34&t=31497
With some minor changes here and there

ACC changes here: https://github.com/rheit/acc/pull/36

Note that due to constants not being usable in decorate properties (can be remedied if this is added: http://forum.zdoom.org/viewtopic.php?f=34&t=31516 ), the VisibilityFilter property must take the raw values of the pointer constants. For example, "VisibilityFilter 0" instead of "VisibilityFilter AAPTR_DEFAULT"