### PR TITLE
Fixed intercept check in FPathTraverse

### DIFF
--- a/src/p_maputl.cpp
+++ b/src/p_maputl.cpp
@@ -985,7 +985,7 @@ void FPathTraverse::AddLineIntercepts(int bx, int by)
 		P_MakeDivline (ld, &dl);
 		frac = P_InterceptVector (&trace, &dl);
 
-		if (frac < 0 || frac > 1) continue;	// behind source or beyond end point
+		if (frac < 0 || frac > FRACUNIT) continue;	// behind source or beyond end point
 			
 		intercept_t newintercept;
 


### PR DESCRIPTION
Because frac variable has fixed_t type it must be compared with fixed one
Test case: try to break stained glass windows or open door at the beginning of Hexen's MAP01