### PR TITLE
SkyExplode Compatibility

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -52,6 +52,7 @@
 #include "p_conversation.h"
 #include "r_data/r_translate.h"
 #include "g_level.h"
+#include "r_sky.h"
 
 CVAR(Bool, cl_bloodsplats, true, CVAR_ARCHIVE)
 CVAR(Int, sv_smartaim, 0, CVAR_ARCHIVE | CVAR_SERVERINFO)
@@ -4293,6 +4294,8 @@ void P_RailAttack(AActor *source, int damage, int offset_xy, fixed_t offset_z, i
 		if (puffclass != NULL && puffDefaults->flags3 & MF3_ALWAYSPUFF)
 		{
 			puff = P_SpawnPuff(source, puffclass, trace.X, trace.Y, trace.Z, (source->angle + angleoffset) - ANG90, 1, 0);
+			if (puff && (trace.Line->special == Line_Horizon) && !(puff->flags3 & MF3_SKYEXPLODE))
+				puff->Destroy();
 		}
 		if (puff != NULL && puffDefaults->flags7 & MF7_FORCEDECAL && puff->DecalGenerator)
 			SpawnShootDecal(puff, trace);
@@ -4306,6 +4309,12 @@ void P_RailAttack(AActor *source, int damage, int offset_xy, fixed_t offset_z, i
 		if (puffclass != NULL && puffDefaults->flags3 & MF3_ALWAYSPUFF)
 		{
 			puff = P_SpawnPuff(source, puffclass, trace.X, trace.Y, trace.Z, (source->angle + angleoffset) - ANG90, 1, 0);
+			if (puff && !(puff->flags3 & MF3_SKYEXPLODE) &&
+				(((trace.HitType == TRACE_HitFloor) && (puff->floorpic == skyflatnum)) ||
+				((trace.HitType == TRACE_HitCeiling) && (puff->ceilingpic == skyflatnum))))
+			{
+				puff->Destroy();
+			}
 		}
 	}
 	if (thepuff != NULL)

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -4294,7 +4294,7 @@ void P_RailAttack(AActor *source, int damage, int offset_xy, fixed_t offset_z, i
 		if (puffclass != NULL && puffDefaults->flags3 & MF3_ALWAYSPUFF)
 		{
 			puff = P_SpawnPuff(source, puffclass, trace.X, trace.Y, trace.Z, (source->angle + angleoffset) - ANG90, 1, 0);
-			if (puff && (trace.Line->special == Line_Horizon) && !(puff->flags3 & MF3_SKYEXPLODE))
+			if (puff && (trace.Line != NULL) && (trace.Line->special == Line_Horizon) && !(puff->flags3 & MF3_SKYEXPLODE))
 				puff->Destroy();
 		}
 		if (puff != NULL && puffDefaults->flags7 & MF7_FORCEDECAL && puff->DecalGenerator)


### PR DESCRIPTION
- Puffs should not spawn on floors or ceilings with sky flats without the SKYEXPLODE flag.
- Added line horizon check for puffs as well.