### PR TITLE
Fixed cmf_aimdirection doubling up the spawn Z

### DIFF
--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -953,7 +953,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_CustomMissile)
 				break;
 
 			case 2:
-				self->SetXYZ(self->Vec3Offset(x, y, self->Z()));
+				self->SetXYZ(self->Vec3Offset(x, y, 0));
 				missile = P_SpawnMissileAngleZSpeed(self, self->Z() + self->GetBobOffset() + spawnheight, ti, self->angle, 0, GetDefaultByType(ti)->Speed, self, false);
 				self->SetXYZ(pos);
 


### PR DESCRIPTION
The old code only offset the x/y, so the relative Z here would be 0, not its own Z height.