### PR TITLE
Restored damage value for instant death sector special

### DIFF
--- a/src/p_spec.cpp
+++ b/src/p_spec.cpp
@@ -1244,7 +1244,8 @@ void P_InitSectorSpecial(sector_t *sector, int special, bool nothinkers)
 
 	case Damage_InstantDeath:
 		// Strife's instant death sector
-		P_SetupSectorDamage(sector, TELEFRAG_DAMAGE, 1, 256, NAME_InstantDeath, 0);
+		// Damage value is truncated to short for compatibility reason
+		P_SetupSectorDamage(sector, (short)TELEFRAG_DAMAGE, 1, 256, NAME_InstantDeath, 0);
 		break;
 
 	case sDamage_SuperHellslime:


### PR DESCRIPTION
Damage value should be 16960 but not 1000000, i.e. TELEFRAG_DAMAGE should be truncated to short integer
Invulnerability cheats are working correctly