### PR TITLE
A_SeekerMissile Fix

### DIFF
--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -1684,7 +1684,7 @@ bool P_SeekerMissile (AActor *actor, angle_t thresh, angle_t turnMax, bool preci
 		angle_t pitch = 0;
 		if (!(actor->flags3 & (MF3_FLOORHUGGER|MF3_CEILINGHUGGER)))
 		{ // Need to seek vertically
-			double dist = MAX(1.0, FVector2(actor->Vec2To(target)).Length());
+			double dist = MAX(1.0, FVector2(target->X() - actor->X(), target->Y() - actor->Y()).Length());
 			// Aim at a player's eyes and at the middle of the actor for everything else.
 			fixed_t aimheight = target->height/2;
 			if (target->IsKindOf(RUNTIME_CLASS(APlayerPawn)))


### PR DESCRIPTION
- Fixed: FVector2 did not play nicely with Vec2To when it comes to seeker missiles. (I am fully aware this may not be the most ideal and possibly 'not a fix' but it at least pinpoints to something being wrong with the two aforementioned things conflicting with one another.)