### PR TITLE
Added visibility filter (by FDARI)

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -374,6 +374,7 @@ enum ActorFlag7
 	MF7_FORCEDECAL		= 0x00080000,	// [ZK] Forces puff's decal to override the weapon's.
 	MF7_LAXTELEFRAGDMG	= 0x00100000,	// [MC] Telefrag damage can be reduced.
 	MF7_ICESHATTER		= 0x00200000,	// [MC] Shatters ice corpses regardless of damagetype.
+	MF7_FILTERHIDES		= 0x00400000,	// Show the actor to anything not covered by the filter
 };
 
 // --- mobj.renderflags ---
@@ -1052,6 +1053,9 @@ public:
 
 	// [BB] If 0, everybody can see the actor, if > 0, only members of team (VisibleToTeam-1) can see it.
 	DWORD			VisibleToTeam;
+
+	// Inclusive filter (AAPTR_ bitmask) to tell who can see this actor; inverted by MF6_FILTERHIDES
+	int				VisibleFilter;
 
 	int				special1;		// Special info
 	int				special2;		// Special info

--- a/src/actorptrselect.cpp
+++ b/src/actorptrselect.cpp
@@ -184,3 +184,54 @@ void ASSIGN_AAPTR(AActor *toActor, int toSlot, AActor *ptr, int flags)
 			break;
 	}
 }
+
+//==========================================================================
+//
+// Search references from one actor (context)
+// to find another actor (target)
+// using references specified in aaptr_filter
+//
+// a null context will only match static filter specifications
+// a null target will only match AAPTR_NULL
+//
+// a null filter will match nothing (and it will check the bits one by one, so it is better to preempt the call)
+// null filter is not handled specifically here because specific handling is better handled by the calling code
+//
+// There is no filter for AAPTR_DEFAULT
+//
+//==========================================================================
+
+bool AAPTR_FILTER(AActor *context, AActor *target, int aaptr_filter)
+{
+	if (target)
+	{
+		// Because we're going through the lot, and returning on first match (or after processing all) order has no impact on logic, only performance
+		// For this reason, it seems viable to put target master and tracer rather high up, and rare/processing-intensive tests later
+		// Also note that since target is not null at this point, there is no need to re-verify that stuff is not equal to null; NULL != target
+		if (context)
+		{
+			if ((aaptr_filter & AAPTR_TARGET) && context->target == target) return true;
+			if ((aaptr_filter & AAPTR_MASTER) && context->master == target) return true;
+			if ((aaptr_filter & AAPTR_TRACER) && context->tracer == target) return true;
+			if ((aaptr_filter & AAPTR_FRIENDPLAYER) && context->FriendPlayer && AAPTR_RESOLVE_PLAYERNUM(context->FriendPlayer - 1) == target) return true;
+			if (context->player)
+			{
+				if ((aaptr_filter & AAPTR_PLAYER_GETCONVERSATION) && context->player->ConversationNPC == target) return true;
+				if (aaptr_filter & AAPTR_PLAYER_GETTARGET)
+				{
+					AActor *gettarget = NULL;
+					P_BulletSlope(context, &gettarget);
+					if (gettarget == target) return true;
+				}
+			}
+		}
+
+		for (int p = 0; p < MAXPLAYERS; p++)
+		{
+			if ((aaptr_filter & (AAPTR_PLAYER1 << p)) && AAPTR_RESOLVE_PLAYERNUM(p) == target)
+				return true;
+		}
+		return false;
+	}
+	return !!(aaptr_filter & AAPTR_NULL);
+}

--- a/src/actorptrselect.h
+++ b/src/actorptrselect.h
@@ -95,5 +95,5 @@ enum PTROP
 
 void VerifyTargetChain(AActor *self, bool preciseMissileCheck=true);
 void VerifyMasterChain(AActor *self);
-void ASSIGN_AAPTR(AActor *toActor, int toSlot, AActor *ptr, int flags) ;
-
+void ASSIGN_AAPTR(AActor *toActor, int toSlot, AActor *ptr, int flags);
+bool AAPTR_FILTER(AActor *context, AActor *target, int aaptr_filter);

--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -3693,6 +3693,8 @@ enum
 	APROP_StencilColor	= 41,
 	APROP_Friction		= 42,
 	APROP_DamageMultiplier=43,
+	APROP_VisibleFilter	= 44,
+	APROP_FilterHides	= 45,
 };
 
 // These are needed for ACS's APROP_RenderStyle
@@ -3772,7 +3774,7 @@ void DLevelScript::DoSetActorProperty (AActor *actor, int property, int value)
 		break;
 
 	case APROP_RenderStyle:
-		for(int i=0; LegacyRenderStyleIndices[i] >= 0; i++)
+		for (int i = 0; LegacyRenderStyleIndices[i] >= 0; i++)
 		{
 			if (LegacyRenderStyleIndices[i] == value)
 			{
@@ -3803,7 +3805,7 @@ void DLevelScript::DoSetActorProperty (AActor *actor, int property, int value)
 		break;
 
 	case APROP_JumpZ:
-		if (actor->IsKindOf (RUNTIME_CLASS (APlayerPawn)))
+		if (actor->IsKindOf(RUNTIME_CLASS(APlayerPawn)))
 			static_cast<APlayerPawn *>(actor)->JumpZ = value;
 		break; 	// [GRB]
 
@@ -3836,7 +3838,7 @@ void DLevelScript::DoSetActorProperty (AActor *actor, int property, int value)
 
 
 	case APROP_SpawnHealth:
-		if (actor->IsKindOf (RUNTIME_CLASS (APlayerPawn)))
+		if (actor->IsKindOf(RUNTIME_CLASS(APlayerPawn)))
 		{
 			static_cast<APlayerPawn *>(actor)->MaxHealth = value;
 		}
@@ -3888,8 +3890,8 @@ void DLevelScript::DoSetActorProperty (AActor *actor, int property, int value)
 
 	case APROP_MasterTID:
 		AActor *other;
-		other = SingleActorFromTID (value, NULL);
-		DoSetMaster (actor, other);
+		other = SingleActorFromTID(value, NULL);
+		DoSetMaster(actor, other);
 		break;
 
 	case APROP_ScaleX:
@@ -3921,7 +3923,7 @@ void DLevelScript::DoSetActorProperty (AActor *actor, int property, int value)
 		break;
 
 	case APROP_ViewHeight:
-		if (actor->IsKindOf (RUNTIME_CLASS (APlayerPawn)))
+		if (actor->IsKindOf(RUNTIME_CLASS(APlayerPawn)))
 		{
 			static_cast<APlayerPawn *>(actor)->ViewHeight = value;
 			if (actor->player != NULL)
@@ -3932,7 +3934,7 @@ void DLevelScript::DoSetActorProperty (AActor *actor, int property, int value)
 		break;
 
 	case APROP_AttackZOffset:
-		if (actor->IsKindOf (RUNTIME_CLASS (APlayerPawn)))
+		if (actor->IsKindOf(RUNTIME_CLASS(APlayerPawn)))
 			static_cast<APlayerPawn *>(actor)->AttackZOffset = value;
 		break;
 
@@ -3942,6 +3944,18 @@ void DLevelScript::DoSetActorProperty (AActor *actor, int property, int value)
 
 	case APROP_Friction:
 		actor->Friction = value;
+		break;
+
+	case APROP_VisibleFilter:
+		actor->VisibleFilter = value;
+		break;
+
+	case APROP_FilterHides:
+		if (value)
+			actor->flags7 |= MF7_FILTERHIDES;
+		else
+			actor->flags7 &= ~MF7_FILTERHIDES;
+		break;
 
 	default:
 		// do nothing.
@@ -4043,6 +4057,8 @@ int DLevelScript::GetActorProperty (int tid, int property, const SDWORD *stack, 
 	case APROP_NameTag:		return GlobalACSStrings.AddString(actor->GetTag(), stack, stackdepth);
 	case APROP_StencilColor:return actor->fillcolor;
 	case APROP_Friction:	return actor->Friction;
+	case APROP_VisibleFilter:return actor->VisibleFilter;
+	case APROP_FilterHides:	return !!(actor->flags7 & MF7_FILTERHIDES);
 
 	default:				return 0;
 	}
@@ -4090,6 +4106,7 @@ int DLevelScript::CheckActorProperty (int tid, int property, int value)
 		case APROP_ViewHeight:
 		case APROP_AttackZOffset:
 		case APROP_StencilColor:
+		case APROP_VisibleFilter:
 			return (GetActorProperty(tid, property, NULL, 0) == value);
 
 		// Boolean values need to compare to a binary version of value
@@ -4102,6 +4119,7 @@ int DLevelScript::CheckActorProperty (int tid, int property, int value)
 		case APROP_Notarget:
 		case APROP_Notrigger:
 		case APROP_Dormant:
+		case APROP_FilterHides:
 			return (GetActorProperty(tid, property, NULL, 0) == (!!value));
 
 		// Strings are covered by GetActorProperty, but they're fairly

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -66,6 +66,7 @@
 #include "farchive.h"
 #include "r_data/colormaps.h"
 #include "r_renderer.h"
+#include "actorptrselect.h"
 
 // MACROS ------------------------------------------------------------------
 
@@ -300,14 +301,18 @@ void AActor::Serialize (FArchive &arc)
 		<< PainType
 		<< DeathType;
 	}
-	arc	<< gravity
+	arc << gravity
 		<< FastChaseStrafeCount
 		<< master
 		<< smokecounter
 		<< BlockingMobj
 		<< BlockingLine
-		<< VisibleToTeam // [BB]
-		<< pushfactor
+		<< VisibleToTeam; // [BB]
+	if (SaveVersion >= 4532) // [zombie]
+	{
+		arc << VisibleFilter; // [fdari]
+	}
+	arc	<< pushfactor
 		<< Species
 		<< Score;
 	if (SaveVersion >= 3113)
@@ -1030,6 +1035,13 @@ bool AActor::IsVisibleToPlayer() const
 		}
 		if(!visible)
 			return false;
+	}
+
+	// [FDARI] Passed all checks but the filter
+	if (VisibleFilter)
+	{
+		bool visible = AAPTR_FILTER(const_cast<AActor *>(this), pPlayer->mo, VisibleFilter);
+		return (flags7 & MF7_FILTERHIDES) ? !visible : visible;
 	}
 
 	// [BB] Passed all checks.

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -6137,3 +6137,15 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_CheckBlock)
 		ACTION_JUMP(block);
 	}
 }
+
+//==========================================================================
+//
+// A_FilterVisibility
+//
+//==========================================================================
+DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FilterVisibility)
+{
+	ACTION_PARAM_START(1);
+	ACTION_PARAM_INT(visiblefilter, 0);
+	self->VisibleFilter = visiblefilter;
+}

--- a/src/thingdef/thingdef_data.cpp
+++ b/src/thingdef/thingdef_data.cpp
@@ -257,7 +257,8 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF7, FORCEDECAL, AActor, flags7),
 	DEFINE_FLAG(MF7, LAXTELEFRAGDMG, AActor, flags7),
 	DEFINE_FLAG(MF7, ICESHATTER, AActor, flags7),
-
+	DEFINE_FLAG(MF7, FILTERHIDES, AActor, flags7),
+		
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),
 	DEFINE_FLAG2(FX_ROCKET, ROCKETTRAIL, AActor, effects),

--- a/src/thingdef/thingdef_properties.cpp
+++ b/src/thingdef/thingdef_properties.cpp
@@ -1462,6 +1462,15 @@ DEFINE_PROPERTY(riplevelmax, I, Actor)
 }
 
 //==========================================================================
+// [FDARI]
+//==========================================================================
+DEFINE_PROPERTY(visiblefilter, I, Actor)
+{
+	PROP_INT_PARM(i, 0);
+	defaults->VisibleFilter = i;
+}
+
+//==========================================================================
 //
 // Special inventory properties
 //

--- a/src/version.h
+++ b/src/version.h
@@ -76,7 +76,7 @@ const char *GetVersionString();
 
 // Use 4500 as the base git save version, since it's higher than the
 // SVN revision ever got.
-#define SAVEVER 4531
+#define SAVEVER 4532
 
 #define SAVEVERSTRINGIFY2(x) #x
 #define SAVEVERSTRINGIFY(x) SAVEVERSTRINGIFY2(x)

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -346,6 +346,7 @@ ACTOR Actor native //: Thinker
 	action native A_RearrangePointers(int newtarget, int newmaster = AAPTR_DEFAULT, int newtracer = AAPTR_DEFAULT, int flags=0);
 	action native A_TransferPointer(int ptr_source, int ptr_recepient, int sourcefield, int recepientfield=AAPTR_DEFAULT, int flags=0);
 	action native A_CopyFriendliness(int ptr_source = AAPTR_MASTER);
+	action native A_FilterVisibility(int ptr_bitmask);
 
 	action native ACS_NamedExecute(string script, int mapnum=0, int arg1=0, int arg2=0, int arg3=0);
 	action native ACS_NamedSuspend(string script, int mapnum=0);


### PR DESCRIPTION
Same as the earlier visibility filter pull request (https://github.com/rheit/zdoom/pull/474), although this time I've added proper savegame handling. Not sure what I should do about any recalculation stuff, and whether I should make any of the other visibility checks do that too if I end up adding such a thing.

The check only happens if the actor has a visibility filter applied to it anyway, so any noticeable performance impact (if any) would only take effect if one is applied.