### PR TITLE
A_CheckLOF Pitch FIx

### DIFF
--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -3472,7 +3472,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_CheckLOF)
 		else return;
 
 		angle >>= ANGLETOFINESHIFT;
-		pitch = (0-pitch)>>ANGLETOFINESHIFT;
+		pitch >>= ANGLETOFINESHIFT;
 
 		vx = FixedMul (finecosine[pitch], finecosine[angle]);
 		vy = FixedMul (finecosine[pitch], finesine[angle]);


### PR DESCRIPTION
- Fixed: A_CheckLOF was doubling up on its pitch and reversing it when without a target.