### PR TITLE
A_Face* Fixes

### DIFF
--- a/src/p_enemy.cpp
+++ b/src/p_enemy.cpp
@@ -2724,9 +2724,9 @@ enum FAF_Flags
 	FAF_BOTTOM = 1,
 	FAF_MIDDLE = 2,
 	FAF_TOP = 4,
-	FAF_NODISTFACTOR = 8,
+	FAF_MULTIPLY = 8,
 };
-void A_Face (AActor *self, AActor *other, angle_t max_turn, angle_t max_pitch, angle_t ang_offset, angle_t pitch_offset, int flags)
+void A_Face (AActor *self, AActor *other, angle_t max_turn, angle_t max_pitch, angle_t ang_offset, angle_t pitch_offset, int flags, fixed_t pitch_add)
 {
 	if (!other)
 		return;
@@ -2799,8 +2799,8 @@ void A_Face (AActor *self, AActor *other, angle_t max_turn, angle_t max_pitch, a
 			target_z = other->Z() + (other->height / 2) + other->GetBobOffset();
 		if (flags & FAF_TOP)
 			target_z = other->Z() + (other->height) + other->GetBobOffset();
-		if (!(flags & FAF_NODISTFACTOR))
-			target_z += pitch_offset;
+
+		target_z = (flags & FAF_MULTIPLY) ? target_z + FixedMul(pitch_add, other->height) : target_z + pitch_add;
 
 		double dist_z = target_z - source_z;
 		double ddist = sqrt(dist.X*dist.X + dist.Y*dist.Y + dist_z*dist_z);
@@ -2823,8 +2823,7 @@ void A_Face (AActor *self, AActor *other, angle_t max_turn, angle_t max_pitch, a
 		{
 			self->pitch = other_pitch;
 		}
-		if (flags & FAF_NODISTFACTOR)
-			self->pitch += pitch_offset;
+		self->pitch += pitch_offset;
 	}
 	
 
@@ -2836,55 +2835,58 @@ void A_Face (AActor *self, AActor *other, angle_t max_turn, angle_t max_pitch, a
     }
 }
 
-void A_FaceTarget(AActor *self, angle_t max_turn, angle_t max_pitch, angle_t ang_offset, angle_t pitch_offset, int flags)
+void A_FaceTarget(AActor *self, angle_t max_turn, angle_t max_pitch, angle_t ang_offset, angle_t pitch_offset, int flags, fixed_t pitch_add)
 {
-	A_Face(self, self->target, max_turn, max_pitch, ang_offset, pitch_offset, flags);
+	A_Face(self, self->target, max_turn, max_pitch, ang_offset, pitch_offset, flags, pitch_add);
 }
 
-void A_FaceMaster(AActor *self, angle_t max_turn, angle_t max_pitch, angle_t ang_offset, angle_t pitch_offset, int flags)
+void A_FaceMaster(AActor *self, angle_t max_turn, angle_t max_pitch, angle_t ang_offset, angle_t pitch_offset, int flags, fixed_t pitch_add)
 {
-	A_Face(self, self->master, max_turn, max_pitch, ang_offset, pitch_offset, flags);
+	A_Face(self, self->master, max_turn, max_pitch, ang_offset, pitch_offset, flags, pitch_add);
 }
 
-void A_FaceTracer(AActor *self, angle_t max_turn, angle_t max_pitch, angle_t ang_offset, angle_t pitch_offset, int flags)
+void A_FaceTracer(AActor *self, angle_t max_turn, angle_t max_pitch, angle_t ang_offset, angle_t pitch_offset, int flags, fixed_t pitch_add)
 {
-	A_Face(self, self->tracer, max_turn, max_pitch, ang_offset, pitch_offset, flags);
+	A_Face(self, self->tracer, max_turn, max_pitch, ang_offset, pitch_offset, flags, pitch_add);
 }
 
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FaceTarget)
 {
-	ACTION_PARAM_START(5);
+	ACTION_PARAM_START(6);
 	ACTION_PARAM_ANGLE(max_turn, 0);
 	ACTION_PARAM_ANGLE(max_pitch, 1);
 	ACTION_PARAM_ANGLE(ang_offset, 2);
 	ACTION_PARAM_ANGLE(pitch_offset, 3);
 	ACTION_PARAM_INT(flags, 4);
+	ACTION_PARAM_FIXED(pitch_add, 5);
 
-	A_FaceTarget(self, max_turn, max_pitch, ang_offset, pitch_offset, flags);
+	A_FaceTarget(self, max_turn, max_pitch, ang_offset, pitch_offset, flags, pitch_add);
 }
 
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FaceMaster)
 {
-	ACTION_PARAM_START(5);
+	ACTION_PARAM_START(6);
 	ACTION_PARAM_ANGLE(max_turn, 0);
 	ACTION_PARAM_ANGLE(max_pitch, 1);
 	ACTION_PARAM_ANGLE(ang_offset, 2);
 	ACTION_PARAM_ANGLE(pitch_offset, 3);
 	ACTION_PARAM_INT(flags, 4);
+	ACTION_PARAM_FIXED(pitch_add, 5);
 
-	A_FaceMaster(self, max_turn, max_pitch, ang_offset, pitch_offset, flags);
+	A_FaceMaster(self, max_turn, max_pitch, ang_offset, pitch_offset, flags, pitch_add);
 }
 
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FaceTracer)
 {
-	ACTION_PARAM_START(5);
+	ACTION_PARAM_START(6);
 	ACTION_PARAM_ANGLE(max_turn, 0);
 	ACTION_PARAM_ANGLE(max_pitch, 1);
 	ACTION_PARAM_ANGLE(ang_offset, 2);
 	ACTION_PARAM_ANGLE(pitch_offset, 3);
 	ACTION_PARAM_INT(flags, 4);
+	ACTION_PARAM_FIXED(pitch_add, 5);
 
-	A_FaceTracer(self, max_turn, max_pitch, ang_offset, pitch_offset, flags);
+	A_FaceTracer(self, max_turn, max_pitch, ang_offset, pitch_offset, flags, pitch_add);
 }
 
 //===========================================================================

--- a/src/p_enemy.h
+++ b/src/p_enemy.h
@@ -72,8 +72,8 @@ DECLARE_ACTION(A_FreezeDeathChunks)
 DECLARE_ACTION(A_BossDeath)
 
 void A_Chase(AActor *self);
-void A_FaceTarget(AActor *actor, angle_t max_turn = 0, angle_t max_pitch = ANGLE_270, angle_t ang_offset = 0, angle_t pitch_offset = 0, int flags = 0);
-void A_Face(AActor *self, AActor *other, angle_t max_turn = 0, angle_t max_pitch = ANGLE_270, angle_t ang_offset = 0, angle_t pitch_offset = 0, int flags = 0);
+void A_FaceTarget(AActor *actor, angle_t max_turn = 0, angle_t max_pitch = ANGLE_270, angle_t ang_offset = 0, angle_t pitch_offset = 0, int flags = 0, fixed_t pitch_add = 0);
+void A_Face(AActor *self, AActor *other, angle_t max_turn = 0, angle_t max_pitch = ANGLE_270, angle_t ang_offset = 0, angle_t pitch_offset = 0, int flags = 0, fixed_t pitch_add = 0);
 
 bool A_RaiseMobj (AActor *, fixed_t speed);
 bool A_SinkMobj (AActor *, fixed_t speed);

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -82,9 +82,9 @@ ACTOR Actor native //: Thinker
 	action native A_XScream();
 	action native A_Look();
 	action native A_Chase(state melee = "*", state missile = "none", int flags = 0);
-	action native A_FaceTarget(float max_turn = 0, float max_pitch = 270, float ang_offset = 0, float pitch_offset = 0, int flags = 0);
-	action native A_FaceTracer(float max_turn = 0, float max_pitch = 270, float ang_offset = 0, float pitch_offset = 0, int flags = 0);
-	action native A_FaceMaster(float max_turn = 0, float max_pitch = 270, float ang_offset = 0, float pitch_offset = 0, int flags = 0);
+	action native A_FaceTarget(float max_turn = 0, float max_pitch = 270, float ang_offset = 0, float pitch_offset = 0, int flags = 0, float pitch_add = 0);
+	action native A_FaceTracer(float max_turn = 0, float max_pitch = 270, float ang_offset = 0, float pitch_offset = 0, int flags = 0, float pitch_add = 0);
+	action native A_FaceMaster(float max_turn = 0, float max_pitch = 270, float ang_offset = 0, float pitch_offset = 0, int flags = 0, float pitch_add = 0);
 	action native A_PosAttack();
 	action native A_Scream();
 	action native A_SPosAttack();

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -472,10 +472,11 @@ enum
 // Flags for A_Face*
 enum
 {
+	FAF_NODISTFACTOR = 0, //For compatibility as this flag's been around a while.
 	FAF_BOTTOM = 1,
 	FAF_MIDDLE = 2,
 	FAF_TOP = 4,
-	FAF_NODISTFACTOR = 8,
+	FAF_MULTIPLY = 8,
 };
 
 // Flags for A_QuakeEx


### PR DESCRIPTION
- New parameter added, pitch_add. Adds an offset to the target's position when aiming with pitch, and fixes the issue of pitch_offset being broken.
- New flag, FAF_MULTIPLY replaces FAF_NODISTFACTOR: adds a multiplier of the actor's height as an offset to the target's position with pitch.
- Deprecated FAF_NODISTFACTOR.