### PR TITLE
A_CheckBlock Fix

### DIFF
--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -6219,7 +6219,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_CheckBlock)
 	}
 
 	//Nothing to block it so skip the rest.
-	if (P_TestMobjLocation(mobj)) return;
+	if (P_CheckMove(mobj,mobj->X(),mobj->Y())) return;
 
 	if (mobj->BlockingMobj)
 	{


### PR DESCRIPTION
- Changed A_CheckBlock to use P_CheckMove instead of P_TestMobjLocation.
- This function not only covers P_TestMobjLocation, it also allows detection of tall dropoffs.