### PR TITLE
- Fixed uninitialized variable in level info code.

### DIFF
--- a/src/g_mapinfo.cpp
+++ b/src/g_mapinfo.cpp
@@ -240,6 +240,7 @@ void level_info_t::Reset()
 		flags2 = 0;
 	else
 		flags2 = LEVEL2_LAXMONSTERACTIVATION;
+	flags3 = 0;
 	Music = "";
 	LevelName = "";
 	FadeTable = "COLORMAP";


### PR DESCRIPTION
Found with Valgrind.

Detail of the error:
```
==10171== Conditional jump or move depends on uninitialised value(s)
==10171==    at 0x6A9CE8: side_t::GetLightLevel(bool, int, bool, int*) const (p_sectors.cpp:1039)
==10171==    by 0x710B6D: R_NewWall(bool) (r_segs.cpp:2279)
==10171==    by 0x710E93: R_StoreWallRange(int, int) (r_segs.cpp:2353)
==10171==    by 0x6F665A: R_ClipWallSegment(int, int, bool) (r_bsp.cpp:179)
==10171==    by 0x6F811B: R_AddLine(seg_t*) (r_bsp.cpp:738)
==10171==    by 0x6FA644: R_Subsector(subsector_t*) (r_bsp.cpp:1355)
==10171==    by 0x6FA762: R_RenderBSPNode(void*) (r_bsp.cpp:1395)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==  Uninitialised value was created by a stack allocation
==10171==    at 0x5E0FB3: G_ParseMapInfo(FString) (g_mapinfo.cpp:1961)
==10171==
==10171== Conditional jump or move depends on uninitialised value(s)
==10171==    at 0x6A9CE8: side_t::GetLightLevel(bool, int, bool, int*) const (p_sectors.cpp:1039)
==10171==    by 0x711B43: R_StoreWallRange(int, int) (r_segs.cpp:2533)
==10171==    by 0x6F665A: R_ClipWallSegment(int, int, bool) (r_bsp.cpp:179)
==10171==    by 0x6F811B: R_AddLine(seg_t*) (r_bsp.cpp:738)
==10171==    by 0x6FA644: R_Subsector(subsector_t*) (r_bsp.cpp:1355)
==10171==    by 0x6FA762: R_RenderBSPNode(void*) (r_bsp.cpp:1395)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==  Uninitialised value was created by a stack allocation
==10171==    at 0x5E0FB3: G_ParseMapInfo(FString) (g_mapinfo.cpp:1961)
==10171==
==10171== Conditional jump or move depends on uninitialised value(s)
==10171==    at 0x6A9CE8: side_t::GetLightLevel(bool, int, bool, int*) const (p_sectors.cpp:1039)
==10171==    by 0x710B6D: R_NewWall(bool) (r_segs.cpp:2279)
==10171==    by 0x710E93: R_StoreWallRange(int, int) (r_segs.cpp:2353)
==10171==    by 0x6F67AB: R_ClipWallSegment(int, int, bool) (r_bsp.cpp:238)
==10171==    by 0x6F811B: R_AddLine(seg_t*) (r_bsp.cpp:738)
==10171==    by 0x6FA644: R_Subsector(subsector_t*) (r_bsp.cpp:1355)
==10171==    by 0x6FA762: R_RenderBSPNode(void*) (r_bsp.cpp:1395)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==  Uninitialised value was created by a stack allocation
==10171==    at 0x5E0FB3: G_ParseMapInfo(FString) (g_mapinfo.cpp:1961)
==10171==
==10171== Conditional jump or move depends on uninitialised value(s)
==10171==    at 0x6A9CE8: side_t::GetLightLevel(bool, int, bool, int*) const (p_sectors.cpp:1039)
==10171==    by 0x711B43: R_StoreWallRange(int, int) (r_segs.cpp:2533)
==10171==    by 0x6F67AB: R_ClipWallSegment(int, int, bool) (r_bsp.cpp:238)
==10171==    by 0x6F811B: R_AddLine(seg_t*) (r_bsp.cpp:738)
==10171==    by 0x6FA644: R_Subsector(subsector_t*) (r_bsp.cpp:1355)
==10171==    by 0x6FA762: R_RenderBSPNode(void*) (r_bsp.cpp:1395)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==  Uninitialised value was created by a stack allocation
==10171==    at 0x5E0FB3: G_ParseMapInfo(FString) (g_mapinfo.cpp:1961)
==10171==
==10171== Conditional jump or move depends on uninitialised value(s)
==10171==    at 0x6A9CE8: side_t::GetLightLevel(bool, int, bool, int*) const (p_sectors.cpp:1039)
==10171==    by 0x710B6D: R_NewWall(bool) (r_segs.cpp:2279)
==10171==    by 0x710E93: R_StoreWallRange(int, int) (r_segs.cpp:2353)
==10171==    by 0x6F6775: R_ClipWallSegment(int, int, bool) (r_bsp.cpp:226)
==10171==    by 0x6F811B: R_AddLine(seg_t*) (r_bsp.cpp:738)
==10171==    by 0x6FA644: R_Subsector(subsector_t*) (r_bsp.cpp:1355)
==10171==    by 0x6FA762: R_RenderBSPNode(void*) (r_bsp.cpp:1395)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==  Uninitialised value was created by a stack allocation
==10171==    at 0x5E0FB3: G_ParseMapInfo(FString) (g_mapinfo.cpp:1961)
==10171==
==10171== Conditional jump or move depends on uninitialised value(s)
==10171==    at 0x6A9CE8: side_t::GetLightLevel(bool, int, bool, int*) const (p_sectors.cpp:1039)
==10171==    by 0x711B43: R_StoreWallRange(int, int) (r_segs.cpp:2533)
==10171==    by 0x6F6775: R_ClipWallSegment(int, int, bool) (r_bsp.cpp:226)
==10171==    by 0x6F811B: R_AddLine(seg_t*) (r_bsp.cpp:738)
==10171==    by 0x6FA644: R_Subsector(subsector_t*) (r_bsp.cpp:1355)
==10171==    by 0x6FA762: R_RenderBSPNode(void*) (r_bsp.cpp:1395)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==    by 0x6FA70C: R_RenderBSPNode(void*) (r_bsp.cpp:1386)
==10171==  Uninitialised value was created by a stack allocation
==10171==    at 0x5E0FB3: G_ParseMapInfo(FString) (g_mapinfo.cpp:1961)
```

See http://forum.zdoom.org/viewtopic.php?f=2&t=50620#p881127 .