### PR TITLE
A_BFGSpray enhancements + fixes

### DIFF
--- a/src/g_doom/a_doomweaps.cpp
+++ b/src/g_doom/a_doomweaps.cpp
@@ -629,7 +629,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_BFGSpray)
 				if (spray->flags7 & MF7_HITTARGET)	spray->target = linetarget; //Overridden by PUFFGETSOWNER.
 				if (spray->flags7 & MF7_HITMASTER)	spray->master = linetarget;
 				if (spray->flags7 & MF7_HITTRACER)	spray->tracer = linetarget;
-				if (spray->flags5 & MF5_PUFFGETSOWNER) spray->target = self;
+				if (spray->flags5 & MF5_PUFFGETSOWNER) spray->target = self->target;
 				if (spray->flags3 & MF3_FOILINVUL) dmgFlags |= DMG_FOILINVUL;
 				if (spray->flags7 & MF7_FOILBUDDHA) dmgFlags |= DMG_FOILBUDDHA;
 				dmgType = spray->DamageType;

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -76,7 +76,7 @@ ACTOR Actor native //: Thinker
 	// End of MBF redundant functions.
 
 	action native A_MonsterRail();
-	action native A_BFGSpray(class<Actor> spraytype = "BFGExtra", int numrays = 40, int damagecount = 15, float angle = 90, float distance = 16*64, float vrange = 32, int damage = 0);
+	action native A_BFGSpray(class<Actor> spraytype = "BFGExtra", int numrays = 40, int damagecount = 15, float angle = 90, float distance = 16*64, float vrange = 32, int damage = 0, bool sprayinflictor = false);
 	action native A_Pain();
 	action native A_NoBlocking();
 	action native A_XScream();


### PR DESCRIPTION
- Added THRUSPECIES support for A_BFGSpray. Checks the spray's species against the linetarget's species.
- Added HIT<TARGET/MASTER/TRACER> support to sprays. The sprays set the actor to damage as the indicated flag pointer.
- Added SprayInflictor boolean parameter to A_BFGSpray. By using this, it allows the spray to utilize things like pain/extreme death flags and more.