### PR TITLE
Fixed possible issue with GCC/Clang

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -1408,7 +1408,7 @@ inline T *Spawn (fixed_t x, fixed_t y, fixed_t z, replace_t allowreplacement)
 template<class T>
 inline T *Spawn (const fixedvec3 &pos, replace_t allowreplacement)
 {
-	return static_cast<T *>(AActor::StaticSpawn (RUNTIME_CLASS(T), pos.x, pos.y, pos.z, allowreplacement));
+	return static_cast<T *>(AActor::StaticSpawn (RUNTIME_TEMPLATE_CLASS(T), pos.x, pos.y, pos.z, allowreplacement));
 }
 
 inline fixedvec2 Vec2Angle(fixed_t length, angle_t angle) 


### PR DESCRIPTION
Does RUNTIME_CLASS need to be RUNTIME_TEMPLATE_CLASS? I was told that Clang is failing to compile on this exact line and the lack of a typename seems to be why.