### PR TITLE
<malloc.h> -> <stdlib.h> on __FreeBSD__ and __APPLE__ systems

### DIFF
--- a/src/thingdef/thingdef_expression.cpp
+++ b/src/thingdef/thingdef_expression.cpp
@@ -37,7 +37,11 @@
 **
 */
 
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 #include <malloc.h>
+#else
+#include <stdlib.h>
+#endif
 #include "actor.h"
 #include "sc_man.h"
 #include "tarray.h"


### PR DESCRIPTION
-- seems to be the only FreeBSD- (and APPLE-) incompatible change brought over from the scripting branch