### PR TITLE
- Fixed alloc/dealloc mismatch in PClass code.

### DIFF
--- a/src/info.cpp
+++ b/src/info.cpp
@@ -321,7 +321,7 @@ void PClassActor::InitializeNativeDefaults()
 {
 	Symbols.SetParentTable(&ParentClass->Symbols);
 	assert(Defaults == NULL);
-	Defaults = new BYTE[Size];
+	Defaults = (BYTE *)M_Malloc(Size);
 	if (ParentClass->Defaults != NULL) 
 	{
 		memcpy(Defaults, ParentClass->Defaults, ParentClass->Size);


### PR DESCRIPTION
The function 'PClassActor::InitializeNativeDefault' is the only one which didn't allocate the 'Defaults' member variable with M_Malloc. Reported by the Address Sanitizer.