### PR TITLE
GetDistance Non-Action

### DIFF
--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -219,6 +219,39 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, IsPointerEqual)
 
 //==========================================================================
 //
+// GetDistance
+//
+// NON-ACTION function to get the distance in double.
+//
+//==========================================================================
+DEFINE_ACTION_FUNCTION_PARAMS(AActor, GetDistance)
+{
+	if (numret > 0)
+	{
+		assert(ret != NULL);
+		PARAM_PROLOGUE;
+		PARAM_OBJECT(self, AActor);
+		PARAM_BOOL(checkz);
+		PARAM_INT_OPT(ptr) { ptr = AAPTR_TARGET; }
+
+		AActor *target = COPY_AAPTR(self, ptr);
+
+		if (!target || target == self)
+		{
+			ret->SetFloat(false);
+		}
+		else
+		{
+			fixed_t dist = (checkz) ? self->AproxDistance3D(target) : self->AproxDistance(target);
+			ret->SetFloat(FIXED2DBL(dist));
+		}
+		return 1;
+	}
+	return 0;
+}
+
+//==========================================================================
+//
 // A_RearrangePointers
 //
 // Allow an actor to change its relationship to other actors by

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -35,6 +35,7 @@ ACTOR Actor native //: Thinker
 	// Functions
 	native bool CheckClass(class<Actor> checkclass, int ptr_select = AAPTR_DEFAULT, bool match_superclass = false);
 	native bool IsPointerEqual(int ptr_select1, int ptr_select2);
+	native float GetDistance(bool checkz, int ptr = AAPTR_DEFAULT);
 
 	// Action functions
 


### PR DESCRIPTION
- Added GetDistance(bool checkz, ptr = aaptr_target).
- Returns the distance of an actor. Must be target, master or tracer.