### PR TITLE
Fixed Iron Lich's Whirlwind attack

### DIFF
--- a/src/g_heretic/a_ironlich.cpp
+++ b/src/g_heretic/a_ironlich.cpp
@@ -19,10 +19,16 @@ class AWhirlwind : public AActor
 {
 	DECLARE_CLASS (AWhirlwind, AActor)
 public:
+	AWhirlwind();
 	int DoSpecialDamage (AActor *target, int damage, FName damagetype);
 };
 
 IMPLEMENT_CLASS(AWhirlwind)
+
+AWhirlwind::AWhirlwind()
+{
+	special1 = 60; // emulation of hack from original P_ExplodeMissile()
+}
 
 int AWhirlwind::DoSpecialDamage (AActor *target, int damage, FName damagetype)
 {
@@ -131,7 +137,6 @@ DEFINE_ACTION_FUNCTION(AActor, A_LichAttack)
 		{
 			mo->AddZ(-32*FRACUNIT, false);
 			mo->tracer = target;
-			mo->special1 = 60;
 			mo->special2 = 50; // Timer for active sound
 			mo->health = 20*TICRATE; // Duration
 			S_Sound (self, CHAN_BODY, "ironlich/attack3", 1, ATTN_NORM);


### PR DESCRIPTION
Emulate a hack from vanilla P_ExplodeMissile() to avoid whirlwind disappearing
Example: tornadoes were vanished because of low ceiling height in secret near the start of Heretic E2M2
See http://forum.zdoom.org/viewtopic.php?t=50751