### PR TITLE
A_CheckProximity Fixes

### DIFF
--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -6419,8 +6419,8 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_CheckProximity)
 	PARAM_CLASS(classname, AActor);
 	PARAM_FIXED(distance);
 	PARAM_INT_OPT(count) { count = 1; }
-	PARAM_INT(flags) { flags = 0; }
-	PARAM_INT(ptr) { ptr = AAPTR_DEFAULT; }
+	PARAM_INT_OPT(flags) { flags = 0; }
+	PARAM_INT_OPT(ptr) { ptr = AAPTR_DEFAULT; }
 
 	ACTION_SET_RESULT(false); //No inventory chain results please.
 
@@ -6455,7 +6455,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_CheckProximity)
 		//Check inheritance for the classname. Taken partly from CheckClass DECORATE function.
 		if (flags & CPXF_ANCESTOR)
 		{
-			if (!(mo->GetClass()->IsAncestorOf(classname)))
+			if (!(mo->IsKindOf(classname)))
 				continue;
 		}
 		//Otherwise, just check for the regular class name.


### PR DESCRIPTION
- Fixed: A_CheckProximity could trigger an assert because the flags and ptr were not flagged as optional.
- Fixed: CPXF_ANCESTOR no longer worked for some reason because apparently the IsAncestorOf() functionality has changed. Use IsKindOf instead.