### PR TITLE
Sprite Jump Fix

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -1166,6 +1166,7 @@ public:
 	bool InStateSequence(FState * newstate, FState * basestate);
 	int GetTics(FState * newstate);
 	bool SetState (FState *newstate, bool nofunction=false);
+	void SetSpriteToNewState(FState *newstate);
 	virtual bool UpdateWaterLevel (fixed_t oldz, bool splash=true);
 	bool isFast();
 	bool isSlow();

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -604,8 +604,6 @@ bool AActor::SetState (FState *newstate, bool nofunction)
 
 void AActor::SetSpriteToNewState(FState *newstate)
 {
-	if (debugfile && player && (player->cheats & CF_PREDICTING))
-		fprintf(debugfile, "for pl %td: SetState while predicting!\n", player - players);
 	if (tics == 0)
 	{
 		if (newstate == NULL)

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -718,6 +718,7 @@ static void DoJump(AActor *self, AActor *stateowner, FState *callingstate, FStat
 		// call is waiting for us to return. We use the flag OF_StateChanged
 		// to cause it to bypass the normal next state mechanism and use
 		// the one we set here instead.
+		self->SetSpriteToNewState(jumpto);
 		self->state = jumpto;
 		self->ObjectFlags |= OF_StateChanged;
 	}


### PR DESCRIPTION
- Fixed: Actors did not acquire their new sprites when performing DECORATE action function jumps.