### PR TITLE
NoCollideActor/Group Properties

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -376,7 +376,7 @@ enum ActorFlag7
 	MF7_FORCEDECAL		= 0x00080000,	// [ZK] Forces puff's decal to override the weapon's.
 	MF7_LAXTELEFRAGDMG	= 0x00100000,	// [MC] Telefrag damage can be reduced.
 	MF7_ICESHATTER		= 0x00200000,	// [MC] Shatters ice corpses regardless of damagetype.
-	MF7_NOCOLLIDECHILD	= 0x00400000,	// NoCollideActor includes any children inheriting from this actor.
+	MF7_NOCOLLIDESUBCLASS	= 0x00400000,	// NoCollideActor includes any children inheriting from this actor.
 };
 
 // --- mobj.renderflags ---

--- a/src/actor.h
+++ b/src/actor.h
@@ -1035,6 +1035,8 @@ public:
 	int				skillrespawncount;
 	int				TIDtoHate;			// TID of things to hate (0 if none)
 	FNameNoInit		Species;		// For monster families
+	FNameNoInit		NoCollideGroup;
+	PClassActor	*	NoCollideActor;	// [MC]Like species but without subjugation to infighting or missile checks of ANY KIND. A strict one way system.
 	TObjPtr<AActor>	tracer;			// Thing being chased/attacked for tracers
 	TObjPtr<AActor>	master;			// Thing which spawned this one (prevents mutual attacks)
 	fixed_t			floorclip;		// value to use for floor clipping

--- a/src/actor.h
+++ b/src/actor.h
@@ -376,6 +376,7 @@ enum ActorFlag7
 	MF7_FORCEDECAL		= 0x00080000,	// [ZK] Forces puff's decal to override the weapon's.
 	MF7_LAXTELEFRAGDMG	= 0x00100000,	// [MC] Telefrag damage can be reduced.
 	MF7_ICESHATTER		= 0x00200000,	// [MC] Shatters ice corpses regardless of damagetype.
+	MF7_NOCOLLIDECHILD	= 0x00400000,	// NoCollideActor includes any children inheriting from this actor.
 };
 
 // --- mobj.renderflags ---

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -555,6 +555,7 @@ void PClassActor::ReplaceClassRef(PClass *oldclass, PClass *newclass)
 	{
 		if (def->TeleFogSourceType == oldclass) def->TeleFogSourceType = static_cast<PClassActor *>(newclass);
 		if (def->TeleFogDestType == oldclass) def->TeleFogDestType = static_cast<PClassActor *>(newclass);
+		if (def->NoCollideActor == oldclass) def->NoCollideActor = static_cast<PClassActor *>(newclass);
 	}
 }
 

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -965,8 +965,21 @@ static bool CheckCollisionGroups(AActor *t1, AActor *t2)
 	if (t1->NoCollideActor == NULL && t2->NoCollideActor == NULL)
 		return false;
 
-	//Either they didn't have a shared collision name, or neither of them did.
-	//So check for collision actor exclusions. This works two-way.
+	//Check for inheriting actors of NoCollideChild.
+	if ((t1->flags7 & MF7_NOCOLLIDECHILD) && (t1->NoCollideActor != NULL))
+	{
+		if (t2->IsKindOf(t1->NoCollideActor))
+			return true;
+	}
+
+	//Check the inverse just to make sure.
+	if ((t2->flags7 & MF7_NOCOLLIDECHILD) && (t2->NoCollideActor != NULL))
+	{
+		if (t1->IsKindOf(t2->NoCollideActor))
+			return true;
+	}
+
+	//Check for collision actor exclusions. This works two-way.
 	if (((t1->NoCollideActor != NULL) && (t1->NoCollideActor == t2->GetClass())) ||
 		((t2->NoCollideActor != NULL) && (t2->NoCollideActor == t1->GetClass())))
 	{

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -965,15 +965,15 @@ static bool CheckCollisionGroups(AActor *t1, AActor *t2)
 	if (t1->NoCollideActor == NULL && t2->NoCollideActor == NULL)
 		return false;
 
-	//Check for inheriting actors of NoCollideChild.
-	if ((t1->flags7 & MF7_NOCOLLIDECHILD) && (t1->NoCollideActor != NULL))
+	//Check for inheriting actors of NOCOLLIDESUBCLASS.
+	if ((t1->flags7 & MF7_NOCOLLIDESUBCLASS) && (t1->NoCollideActor != NULL))
 	{
 		if (t2->IsKindOf(t1->NoCollideActor))
 			return true;
 	}
 
 	//Check the inverse just to make sure.
-	if ((t2->flags7 & MF7_NOCOLLIDECHILD) && (t2->NoCollideActor != NULL))
+	if ((t2->flags7 & MF7_NOCOLLIDESUBCLASS) && (t2->NoCollideActor != NULL))
 	{
 		if (t1->IsKindOf(t2->NoCollideActor))
 			return true;

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -437,6 +437,11 @@ void AActor::Serialize (FArchive &arc)
 	{
 		arc << DefThreshold;
 	}
+	if (SaveVersion >= 4534)
+	{
+		arc << NoCollideActor
+			<< NoCollideGroup;
+	}
 
 	{
 		FString tagstr;

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -6791,3 +6791,56 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FaceMovementDirection)
 	}
 	return numret;
 }
+
+//===========================================================================
+//
+// A_SetNoColideActor
+//
+// Sets the specific actor to not collide with anymore.
+// 
+//===========================================================================
+
+DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetNoCollideActor)
+{
+	PARAM_ACTION_PROLOGUE;
+	PARAM_CLASS(ncclass, AActor);
+	PARAM_INT_OPT(ptr) { ptr = AAPTR_DEFAULT; }
+
+	AActor *mobj = COPY_AAPTR(self, ptr);
+
+	//Need an actor.
+	if (!mobj)
+	{
+		ACTION_SET_RESULT(false);
+		return 0;
+	}
+
+	mobj->NoCollideActor = ncclass;
+	return 0;
+}
+
+//===========================================================================
+//
+// A_SetNoCollideGroup
+//
+// Sets the calling actor (pointer)'s NoCollideGroup. Any actor sharing the
+// same group cannot collide with one another and can move independantly
+// through everyone else of the same group name.
+//
+//===========================================================================
+DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetNoCollideGroup)
+{
+	PARAM_ACTION_PROLOGUE;
+	PARAM_NAME(ncgroup);
+	PARAM_INT_OPT(ptr)	{ ptr = AAPTR_DEFAULT; }
+
+	AActor *mobj = COPY_AAPTR(self, ptr);
+	if (!mobj)
+	{
+		ACTION_SET_RESULT(false);
+		return 0;
+	}
+
+	mobj->NoCollideGroup = ncgroup;
+	return 0;
+}

--- a/src/thingdef/thingdef_data.cpp
+++ b/src/thingdef/thingdef_data.cpp
@@ -256,6 +256,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF7, FORCEDECAL, AActor, flags7),
 	DEFINE_FLAG(MF7, LAXTELEFRAGDMG, AActor, flags7),
 	DEFINE_FLAG(MF7, ICESHATTER, AActor, flags7),
+	DEFINE_FLAG(MF7, NOCOLLIDECHILD, AActor, flags7),
 
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),

--- a/src/thingdef/thingdef_data.cpp
+++ b/src/thingdef/thingdef_data.cpp
@@ -256,7 +256,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF7, FORCEDECAL, AActor, flags7),
 	DEFINE_FLAG(MF7, LAXTELEFRAGDMG, AActor, flags7),
 	DEFINE_FLAG(MF7, ICESHATTER, AActor, flags7),
-	DEFINE_FLAG(MF7, NOCOLLIDECHILD, AActor, flags7),
+	DEFINE_FLAG(MF7, NOCOLLIDESUBCLASS, AActor, flags7),
 
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),

--- a/src/thingdef/thingdef_properties.cpp
+++ b/src/thingdef/thingdef_properties.cpp
@@ -1368,6 +1368,24 @@ DEFINE_PROPERTY(species, S, Actor)
 //==========================================================================
 //
 //==========================================================================
+DEFINE_PROPERTY(nocollisiongroup, S, Actor)
+{
+	PROP_STRING_PARM(n, 0);
+	defaults->NoCollideGroup = n;
+}
+
+//==========================================================================
+//
+//==========================================================================
+DEFINE_PROPERTY(nocollisionactor, S, Actor)
+{
+	PROP_STRING_PARM(str, 0);
+	defaults->NoCollideActor = FindClassTentative(str, RUNTIME_CLASS(AActor));
+}
+
+//==========================================================================
+//
+//==========================================================================
 DEFINE_PROPERTY(clearflags, 0, Actor)
 {
 	defaults->flags = 0;

--- a/src/version.h
+++ b/src/version.h
@@ -76,7 +76,7 @@ const char *GetVersionString();
 
 // Use 4500 as the base git save version, since it's higher than the
 // SVN revision ever got.
-#define SAVEVER 4533
+#define SAVEVER 4534
 
 #define SAVEVERSTRINGIFY2(x) #x
 #define SAVEVERSTRINGIFY(x) SAVEVERSTRINGIFY2(x)

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -35,6 +35,7 @@ ACTOR Actor native //: Thinker
 	BloodType "Blood", "BloodSplatter", "AxeBlood"
 	ExplosionDamage 128
 	MissileHeight 32
+	NoCollisionActor "None"
 	
 
 	// Functions
@@ -319,6 +320,8 @@ ACTOR Actor native //: Thinker
 	action native A_CheckSightOrRange(float distance, state label, bool two_dimension = false);
 	action native A_CheckRange(float distance, state label, bool two_dimension = false);
 	action native A_FaceMovementDirection(float offset = 0, float anglelimit = 0, float pitchlimit = 0, int flags = 0, int ptr = AAPTR_DEFAULT);
+	action native A_SetNoCollideActor(class<Actor> ncclass, int ptr = AAPTR_DEFAULT);
+	action native A_SetNoCollideGroup(name ncgroup, int ptr = AAPTR_DEFAULT);
 
 	action native A_RearrangePointers(int newtarget, int newmaster = AAPTR_DEFAULT, int newtracer = AAPTR_DEFAULT, int flags=0);
 	action native A_TransferPointer(int ptr_source, int ptr_recepient, int sourcefield, int recepientfield=AAPTR_DEFAULT, int flags=0);


### PR DESCRIPTION
Added NoCollideActor and NoCollideGroup.
- NoCollideActor is one specific actor to disable all forms of collision with.
- NoCollideGroup is like species, but always goes through actors of the same group name.
- A_SetNoCollideActor/Group (name, int ptr = AAPTR_DEFAULT) can change both properties.
