### PR TITLE
Fixed: warp and warp2 texture effects now work for NPo2 textures.

### DIFF
--- a/src/textures/textures.h
+++ b/src/textures/textures.h
@@ -484,8 +484,11 @@ protected:
 	BYTE *Pixels;
 	Span **Spans;
 	float Speed;
+	int WidthOffsetMultipiler, HeightOffsetMultipiler;  // [mxd]
 
 	virtual void MakeTexture (DWORD time);
+	int NextPo2 (int v); // [mxd]
+	void SetupMultipliers (int width, int height); // [mxd]
 };
 
 // [GRB] Eternity-like warping


### PR DESCRIPTION
NOTE: does NextPo2() equivalent already exist, and if no, where should it be located?