### PR TITLE
Fixed crash when accessing undefined user variable

### DIFF
--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -4564,13 +4564,13 @@ bool GetVarAddrType(AActor *self, FName varname, int index, void *&addr, PType *
 {
 	PField *var = dyn_cast<PField>(self->GetClass()->Symbols.FindSymbol(varname, true));
 	PArray *arraytype;
-	BYTE *baddr = reinterpret_cast<BYTE *>(self) + var->Offset;
 
 	if (var == NULL || (var->Flags & VARF_Native))
 	{
 		return false;
 	}
 	type = var->Type;
+	BYTE *baddr = reinterpret_cast<BYTE *>(self) + var->Offset;
 	arraytype = dyn_cast<PArray>(type);
 	if (arraytype != NULL)
 	{


### PR DESCRIPTION
Presence of DECORATE user variable was not checked before attempting to read or write its value from ACS