### PR TITLE
Fixed "Detailed save messages" option's value

### DIFF
--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1123,7 +1123,7 @@ OptionMenu MessageOptions
 	Option "$MSGMNU_CENTEREDMESSAGES",			"msgmidcolor", "TextColors"
 	StaticText " "
 	Option "$MSGMNU_SCREENSHOTMESSAGES",		"screenshot_quiet",	"OffOn"
-	Option "$MSGMNU_LONGSAVEMESSAGES",	"		longsavemessages",	"OnOff"
+	Option "$MSGMNU_LONGSAVEMESSAGES",			"longsavemessages",	"OnOff"
 }
 
 //-------------------------------------------------------------------------------------------


### PR DESCRIPTION
The value for that option was displayed as "Unknown", instead of "On" or
"Off".