### PR TITLE
C++11 transition fixes for OS X

### DIFF
--- a/src/posix/cocoa/i_system.mm
+++ b/src/posix/cocoa/i_system.mm
@@ -208,12 +208,12 @@ void I_PrintStr(const char* const message)
 		else if (0x1d == *srcp || 0x1f == *srcp) // Opening and closing bar character
 		{
 			*dstp++ = '-';
-			*srcp++;
+			++srcp;
 		}
 		else if (0x1e == *srcp) // Middle bar character
 		{
 			*dstp++ = '=';
-			*srcp++;
+			++srcp;
 		}
 		else
 		{

--- a/src/posix/cocoa/st_console.mm
+++ b/src/posix/cocoa/st_console.mm
@@ -213,7 +213,7 @@ void FConsoleWindow::AddText(const char* message)
 		if (TEXTCOLOR_ESCAPE == *message)
 		{
 			const BYTE* colorID = reinterpret_cast<const BYTE*>(message) + 1;
-			if ('\0' == colorID)
+			if ('\0' == *colorID)
 			{
 				break;
 			}


### PR DESCRIPTION
Fixed incorrect comparison in OS X console window
Removed useless operations from OS X system code
