### PR TITLE
Fixes for a few C++11 warnings

### DIFF
--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -1695,9 +1695,9 @@ bool AM_clipMline (mline_t *ml, fline_t *fl)
 		TOP		=8
 	};
 
-	register int outcode1 = 0;
-	register int outcode2 = 0;
-	register int outside;
+	int outcode1 = 0;
+	int outcode2 = 0;
+	int outside;
 
 	fpoint_t tmp = { 0, 0 };
 	int dx;

--- a/src/md5.cpp
+++ b/src/md5.cpp
@@ -166,7 +166,7 @@ void MD5Context::Final(BYTE digest[16])
 void
 MD5Transform(DWORD buf[4], const DWORD in[16])
 {
-	register DWORD a, b, c, d;
+	DWORD a, b, c, d;
 
 	a = buf[0];
 	b = buf[1];

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -972,7 +972,7 @@ bool PIT_CheckLine(FMultiBlockLinesIterator &mit, FMultiBlockLinesIterator::Chec
 		spec.oldrefpos = tm.thing->PosRelative(ld);
 		spechit.Push(spec);
 	}
-	if (ld->portalindex >= 0 && ld->portalindex != UINT_MAX)
+	if (ld->portalindex != UINT_MAX)
 	{
 		spec.line = ld;
 		spec.refpos = cres.position;

--- a/src/p_spec.cpp
+++ b/src/p_spec.cpp
@@ -1861,7 +1861,7 @@ static void P_SpawnScrollers(void)
 
 		switch (special)
 		{
-			register int s;
+			int s;
 
 		case Scroll_Ceiling:
 		{
@@ -2393,7 +2393,7 @@ static void P_SpawnPushers ()
 {
 	int i;
 	line_t *l = lines;
-	register int s;
+	int s;
 
 	for (i = 0; i < numlines; i++, l++)
 	{

--- a/src/thingdef/thingdef_exp.h
+++ b/src/thingdef/thingdef_exp.h
@@ -841,7 +841,7 @@ class FxFlopFunctionCall : public FxExpression
 
 public:
 
-	FxFlopFunctionCall(int index, FArgumentList *args, const FScriptPosition &pos);
+	FxFlopFunctionCall(size_t index, FArgumentList *args, const FScriptPosition &pos);
 	~FxFlopFunctionCall();
 	FxExpression *Resolve(FCompileContext&);
 	ExpEmit Emit(VMFunctionBuilder *build);

--- a/src/thingdef/thingdef_expression.cpp
+++ b/src/thingdef/thingdef_expression.cpp
@@ -3176,7 +3176,7 @@ FxFunctionCall::~FxFunctionCall()
 
 FxExpression *FxFunctionCall::Resolve(FCompileContext& ctx)
 {
-	for (int i = 0; i < countof(FxFlops); ++i)
+	for (size_t i = 0; i < countof(FxFlops); ++i)
 	{
 		if (MethodName == FxFlops[i].Name)
 		{
@@ -3514,10 +3514,10 @@ ExpEmit FxVMFunctionCall::Emit(VMFunctionBuilder *build, bool tailcall)
 //
 //==========================================================================
 
-FxFlopFunctionCall::FxFlopFunctionCall(int index, FArgumentList *args, const FScriptPosition &pos)
+FxFlopFunctionCall::FxFlopFunctionCall(size_t index, FArgumentList *args, const FScriptPosition &pos)
 : FxExpression(pos)
 {
-	assert(index >= 0 && index < countof(FxFlops) && "FLOP index out of range");
+	assert(index < countof(FxFlops) && "FLOP index out of range");
 	Index = index;
 	ArgList = args;
 }


### PR DESCRIPTION
Removed usage of register keyword
Removed redundant comparison
Made index of VM intrinsic functions unsigned
