### PR TITLE
Bunch of fixes for OS X startup window

### DIFF
--- a/src/posix/cocoa/i_common.h
+++ b/src/posix/cocoa/i_common.h
@@ -145,6 +145,10 @@ enum
 
 static const NSOpenGLPixelFormatAttribute NSOpenGLPFAAllowOfflineRenderers = NSOpenGLPixelFormatAttribute(96);
 
+@interface NSWindow(SetCollectionBehavior)
+- (void)setCollectionBehavior:(NSUInteger)collectionBehavior;
+@end
+
 #endif // prior to 10.5
 
 
@@ -181,6 +185,8 @@ typedef NSInteger NSApplicationActivationPolicy;
 @interface NSScreen(HiDPIStubs)
 - (NSRect)convertRectToBacking:(NSRect)aRect;
 @end
+
+static const NSWindowCollectionBehavior NSWindowCollectionBehaviorFullScreenAuxiliary = NSWindowCollectionBehavior(1 << 8);
 
 #endif // prior to 10.7
 

--- a/src/posix/cocoa/st_console.h
+++ b/src/posix/cocoa/st_console.h
@@ -89,6 +89,8 @@ private:
 	void ExpandTextView(float height);
 
 	void AddText(const PalEntry& color, const char* message);
+
+	void ScrollTextToBottom();
 };
 
 #endif // COCOA_ST_CONSOLE_INCLUDED

--- a/src/posix/cocoa/st_console.mm
+++ b/src/posix/cocoa/st_console.mm
@@ -94,7 +94,7 @@ FConsoleWindow::FConsoleWindow()
 	[textContainer setContainerSize:NSMakeSize(initialWidth, FLT_MAX)];
 	[textContainer setWidthTracksTextView:YES];
 
-	[m_scrollView initWithFrame:NSMakeRect(0.0f, 0.0f, initialWidth, initialHeight)];
+	[m_scrollView initWithFrame:initialRect];
 	[m_scrollView setBorderType:NSNoBorder];
 	[m_scrollView setHasVerticalScroller:YES];
 	[m_scrollView setHasHorizontalScroller:NO];

--- a/src/posix/cocoa/st_console.mm
+++ b/src/posix/cocoa/st_console.mm
@@ -313,9 +313,10 @@ void FConsoleWindow::AddText(const char* message)
 
 	if ([m_window isVisible])
 	{
-		[m_textView scrollRangeToVisible:NSMakeRange(m_characterCount, 0)];
-
-		[[NSRunLoop currentRunLoop] limitDateForMode:NSDefaultRunLoopMode];
+		UpdateTimed([&]()
+		{
+			[m_textView scrollRangeToVisible:NSMakeRange(m_characterCount, 0)];
+		});
 	}
 }
 

--- a/src/posix/cocoa/st_console.mm
+++ b/src/posix/cocoa/st_console.mm
@@ -188,6 +188,8 @@ void FConsoleWindow::ShowFatalError(const char* const message)
 	AddText(PalEntry(255, 255, 170), message);
 	AddText("\n");
 
+	ScrollTextToBottom();
+
 	[NSApp runModalForWindow:m_window];
 }
 
@@ -338,6 +340,14 @@ void FConsoleWindow::AddText(const PalEntry& color, const char* const message)
 }
 
 
+void FConsoleWindow::ScrollTextToBottom()
+{
+	[m_textView scrollRangeToVisible:NSMakeRange(m_characterCount, 0)];
+
+	[[NSRunLoop currentRunLoop] limitDateForMode:NSDefaultRunLoopMode];
+}
+
+
 void FConsoleWindow::SetTitleText()
 {
 	static const CGFloat TITLE_TEXT_HEIGHT = 32.0f;
@@ -485,6 +495,8 @@ void FConsoleWindow::NetInit(const char* const message, const int playerCount)
 
 		[m_window setFrame:windowRect display:YES];
 		[[m_window contentView] addSubview:m_netView];
+
+		ScrollTextToBottom();
 	}
 
 	[m_netMessageText setStringValue:[NSString stringWithUTF8String:message]];

--- a/src/posix/cocoa/st_console.mm
+++ b/src/posix/cocoa/st_console.mm
@@ -113,6 +113,12 @@ FConsoleWindow::FConsoleWindow()
 	[m_window center];
 	[m_window exitAppOnClose];
 
+	if (NSAppKitVersionNumber >= AppKit10_7)
+	{
+		// Do not allow fullscreen mode for this window
+		[m_window setCollectionBehavior:NSWindowCollectionBehaviorFullScreenAuxiliary];
+	}
+
 	[[m_window contentView] addSubview:m_scrollView];
 
 	[m_window makeKeyAndOrderFront:nil];

--- a/src/posix/cocoa/st_console.mm
+++ b/src/posix/cocoa/st_console.mm
@@ -324,7 +324,8 @@ void FConsoleWindow::AddText(const char* message)
 
 void FConsoleWindow::AddText(const PalEntry& color, const char* const message)
 {
-	NSString* const text = [NSString stringWithUTF8String:message];
+	NSString* const text = [NSString stringWithCString:message
+											  encoding:NSISOLatin1StringEncoding];
 
 	NSDictionary* const attributes = [NSDictionary dictionaryWithObjectsAndKeys:
 									  [NSFont systemFontOfSize:14.0f], NSFontAttributeName,

--- a/src/posix/cocoa/st_console.mm
+++ b/src/posix/cocoa/st_console.mm
@@ -377,7 +377,12 @@ void FConsoleWindow::SetProgressBar(const bool visible)
 	{
 		ExpandTextView(-PROGRESS_BAR_HEIGHT);
 
-		m_progressBar = [[NSProgressIndicator alloc] initWithFrame:NSMakeRect(2.0f, 0.0f, 508.0f, 16.0f)];
+		static const CGFloat PROGRESS_BAR_X = 2.0f;
+		const NSRect PROGRESS_BAR_RECT = NSMakeRect(
+			PROGRESS_BAR_X, 0.0f,
+			[m_window frame].size.width - PROGRESS_BAR_X * 2, 16.0f);
+
+		m_progressBar = [[NSProgressIndicator alloc] initWithFrame:PROGRESS_BAR_RECT];
 		[m_progressBar setIndeterminate:NO];
 		[m_progressBar setAutoresizingMask:NSViewWidthSizable];
 


### PR DESCRIPTION
Disabled fullscreen mode for startup window
Fixed default width of progress bar in startup window
Made sure that the last text line is always visible in startup wind
Fixed particular slowdown in startup window