### PR TITLE
Added "Miscellaneous Options" -> "Save/Load confirmation" option (def…

### DIFF
--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -2064,6 +2064,7 @@ FString G_BuildSaveName (const char *prefix, int slot)
 CVAR (Int, autosavenum, 0, CVAR_NOSET|CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 static int nextautosave = -1;
 CVAR (Int, disableautosave, 0, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
+CVAR (Bool, saveloadconfirmation, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG) // [mxd]
 CUSTOM_CVAR (Int, autosavecount, 4, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 {
 	if (self < 0)

--- a/wadsrc/static/language.enu
+++ b/wadsrc/static/language.enu
@@ -1853,6 +1853,7 @@ MISCMNU_QUERYIWAD				= "Show IWAD selection dialog";
 MISCMNU_ALLCHEATS				= "Enable cheats from all games";
 MISCMNU_ENABLEAUTOSAVES			= "Enable autosaves";
 MISCMNU_AUTOSAVECOUNT			= "Number of autosaves";
+MISCMNU_SAVELOADCONFIRMATION  = "Save/Load confirmation";
 MISCMNU_DEHLOAD					= "Load *.deh/*.bex lumps";
 MISCMNU_CACHENODES				= "Cache nodes";
 MISCMNU_CACHETIME				= "Time threshold for node caching";

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -892,6 +892,7 @@ OptionMenu "MiscOptions"
 	StaticText " "
 	Option "$MISCMNU_ALLCHEATS",				"allcheats", "OnOff"
 	Option "$MISCMNU_ENABLEAUTOSAVES",			"disableautosave", "Autosave"
+	Option "$MISCMNU_SAVELOADCONFIRMATION",			"saveloadconfirmation", "OnOff"
 	Slider "$MISCMNU_AUTOSAVECOUNT",			"autosavecount", 1, 20, 1, 0
 	Option "$MISCMNU_DEHLOAD",					"dehload", "dehopt"
 	StaticText " "


### PR DESCRIPTION
…aults to true). When disabled, confirmation dialog won't be shown when performing quicksave/quickload.