### PR TITLE
Added detection for broken WAD files

### DIFF
--- a/src/resourcefiles/file_wad.cpp
+++ b/src/resourcefiles/file_wad.cpp
@@ -39,6 +39,7 @@
 #include "v_text.h"
 #include "w_wad.h"
 #include "gi.h"
+#include "i_system.h"
 
 // Console Doom LZSS wrapper.
 class FileReaderLZSS : public FileReaderBase
@@ -343,6 +344,12 @@ bool FWadFile::Open(bool quiet)
 		NumLumps = BigLong(header.NumLumps);
 		InfoTableOfs = BigLong(header.InfoTableOfs);
 		isBigEndian = true;
+
+		// Check again to detect broken wads
+		if (InfoTableOfs + NumLumps*sizeof(wadlump_t) > (unsigned)wadSize)
+		{
+			I_Error("Cannot load broken WAD file %s\n", Filename);
+		}
 	}
 
 	wadlump_t *fileinfo = new wadlump_t[NumLumps];


### PR DESCRIPTION
Do not try to allocate nonsensical amount of memory and bail out when broken WAD is detected
See http://forum.drdteam.org/viewtopic.php?t=6844