### PR TITLE
A_SetScale Fix

### DIFF
--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -2913,13 +2913,14 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetScale)
 	PARAM_FIXED		(scalex);
 	PARAM_FIXED_OPT	(scaley)	{ scaley = scalex; }
 	PARAM_INT_OPT	(ptr)		{ ptr = AAPTR_DEFAULT; }
+	PARAM_BOOL_OPT	(usezero)	{ usezero = false; }
 
 	AActor *ref = COPY_AAPTR(self, ptr);
 
 	if (ref != NULL)
 	{
 		ref->scaleX = scalex;
-		ref->scaleY = scaley;
+		ref->scaleY = (!usezero && !scaley) ? scalex : scaley;
 	}
 	return 0;
 }

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -207,7 +207,7 @@ ACTOR Actor native //: Thinker
 	action native A_FadeIn(float reduce = 0.1, int flags = 0);
 	action native A_FadeOut(float reduce = 0.1, int flags = 1); //bool remove == true
 	action native A_FadeTo(float target, float amount = 0.1, int flags = 0);
-	action native A_SetScale(float scalex, float scaley = 0, int ptr = AAPTR_DEFAULT);
+	action native A_SetScale(float scalex, float scaley = 0, int ptr = AAPTR_DEFAULT, bool usezero = false);
 	action native A_SetMass(int mass);
 	action native A_SpawnDebris(class<Actor> spawntype, bool transfer_translation = false, float mult_h = 1, float mult_v = 1);
 	action native A_SpawnParticle(color color1, int flags = 0, int lifetime = 35, int size = 1, float angle = 0, float xoff = 0, float yoff = 0, float zoff = 0, float velx = 0, float vely = 0, float velz = 0, float accelx = 0, float accely = 0, float accelz = 0, float startalphaf = 1, float fadestepf = -1);


### PR DESCRIPTION
- Fixed: ScaleY was not defaulting to ScaleX when specified as 0, which is how the behavior originally was in 2.8. This behavior can now be toggled with a new boolean, 'usezero'.