### PR TITLE
Fixed potential crash in DeHackEd loading

### DIFF
--- a/src/d_dehacked.cpp
+++ b/src/d_dehacked.cpp
@@ -2505,9 +2505,9 @@ static bool DoDehPatch()
 	{
 		if (PatchFile[25] < '3')
 		{
+			Printf (PRINT_BOLD, "\"%s\" is an old and unsupported DeHackEd patch\n", PatchName);
 			delete[] PatchName;
 			delete[] PatchFile;
-			Printf (PRINT_BOLD, "\"%s\" is an old and unsupported DeHackEd patch\n", PatchFile);
 			return false;
 		}
 		// fix for broken WolfenDoom patches which contain \0 characters in some places.


### PR DESCRIPTION
The patch content was destructed and then accessed when loading DeHackEd file of old/unsupported version
Do not print the whole patch content to console but only a filename