### PR TITLE
A_CheckBlock Expansion

### DIFF
--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -6694,14 +6694,20 @@ enum CBF
 	CBF_SETONPTR		= 1 << 4,	//Sets the pointer change on the actor doing the checking instead of self.
 	CBF_DROPOFF			= 1 << 5,	//Check for dropoffs.
 	CBF_NOACTORS		= 1 << 6,	//Don't check actors.
+	CBF_ABSOLUTEPOS		= 1 << 7,	//Absolute position for offsets.
+	CBF_ABSOLUTEANGLE	= 1 << 8,	//Absolute angle for offsets.
 };
 
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_CheckBlock)
 {
 	PARAM_ACTION_PROLOGUE;
 	PARAM_STATE(block)
-	PARAM_INT_OPT(flags) { flags = 0; }
-	PARAM_INT_OPT(ptr) 	{ ptr = AAPTR_DEFAULT; }	
+	PARAM_INT_OPT(flags)	{ flags = 0; }
+	PARAM_INT_OPT(ptr)		{ ptr = AAPTR_DEFAULT; }
+	PARAM_FIXED_OPT(xofs)	{ xofs = 0; }
+	PARAM_FIXED_OPT(yofs)	{ yofs = 0; }
+	PARAM_FIXED_OPT(zofs)	{ zofs = 0; }
+	PARAM_ANGLE_OPT(angle)	{ angle = 0; }
 
 	AActor *mobj = COPY_AAPTR(self, ptr);
 
@@ -6711,8 +6717,48 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_CheckBlock)
 		ACTION_RETURN_STATE(NULL);
 	}
 
+	if (!(flags & CBF_ABSOLUTEANGLE))
+	{
+		angle += self->angle;
+	}
+
+	angle_t ang = angle >> ANGLETOFINESHIFT;
+	fixedvec3 oldpos = mobj->Pos();
+	fixedvec3 pos;
+
+	if (flags & CBF_ABSOLUTEPOS)
+	{
+		pos.x = xofs;
+		pos.y = yofs;
+		pos.z = zofs;
+	}
+	else
+	{
+		pos = mobj->Vec3Offset(
+			FixedMul(xofs, finecosine[ang]) + FixedMul(yofs, finesine[ang]),
+			FixedMul(xofs, finesine[ang]) - FixedMul(yofs, finecosine[ang]),
+			mobj->Z() + zofs);
+	}
+	
+	// Next, try checking the position based on the sensitivity desired.
+	// If checking for dropoffs, set the z so we can have maximum flexibility.
+	// Otherwise, set origin and set it back after testing.
+
+	bool checker = false;
+	if (flags & CBF_DROPOFF)
+	{
+		mobj->SetZ(pos.z);
+		checker = P_CheckMove(mobj, pos.x, pos.y);
+		mobj->SetZ(oldpos.z);
+	}
+	else
+	{
+		mobj->SetOrigin(pos, true);
+		checker = P_TestMobjLocation(mobj);
+		mobj->SetOrigin(oldpos, true);
+	}
+	
 	//Nothing to block it so skip the rest.
-	bool checker = (flags & CBF_DROPOFF) ? P_CheckMove(mobj, mobj->X(), mobj->Y()) : P_TestMobjLocation(mobj);
 	if (checker)
 	{
 		ACTION_RETURN_STATE(NULL);

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -317,7 +317,7 @@ ACTOR Actor native //: Thinker
 	action native A_SetRipMax(int maximum);
 	action native A_SetChaseThreshold(int threshold, bool def = false, int ptr = AAPTR_DEFAULT);
 	action native state A_CheckProximity(state jump, class<Actor> classname, float distance, int count = 1, int flags = 0, int ptr = AAPTR_DEFAULT);
-	action native state A_CheckBlock(state block, int flags = 0, int ptr = AAPTR_DEFAULT);
+	action native state A_CheckBlock(state block, int flags = 0, int ptr = AAPTR_DEFAULT, float xofs = 0, float yofs = 0, float zofs = 0, float angle = 0);
 	action native state A_CheckSightOrRange(float distance, state label, bool two_dimension = false);
 	action native state A_CheckRange(float distance, state label, bool two_dimension = false);
 	action native bool A_FaceMovementDirection(float offset = 0, float anglelimit = 0, float pitchlimit = 0, int flags = 0, int ptr = AAPTR_DEFAULT);

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -527,6 +527,8 @@ enum
 	CBF_SETONPTR		= 1 << 4,	//Sets the pointer change on the actor doing the checking instead of self.
 	CBF_DROPOFF			= 1 << 5,	//Check for dropoffs.
 	CBF_NOACTORS		= 1 << 6,	//Don't check actors.
+	CBF_ABSOLUTEPOS		= 1 << 7,	//Absolute position for offsets.
+	CBF_ABSOLUTEANGLE	= 1 << 8,	//Absolute angle for offsets.
 };
 
 enum


### PR DESCRIPTION
- Added offset and angle parameters to A_CheckBlock.
- Includes 2 flags, affixed by CBF_: AbsolutePos, and AbsoluteAngle.
- AbsolutePos: Absolute position of where to check.
- AbsoluteAngle: Angle parameter is used as is, not added onto the actor's current angle.