### PR TITLE
Fixed A_Blast parameter type and default values

### DIFF
--- a/src/g_hexen/a_blastradius.cpp
+++ b/src/g_hexen/a_blastradius.cpp
@@ -99,9 +99,9 @@ DEFINE_ACTION_FUNCTION_PARAMS (AActor, A_Blast)
 {
 	PARAM_ACTION_PROLOGUE;
 	PARAM_INT_OPT	(blastflags)			{ blastflags = 0; }
-	PARAM_INT_OPT	(strength)				{ strength = 255; }
+	PARAM_FIXED_OPT	(strength)				{ strength = 255*FRACUNIT; }
 	PARAM_FIXED_OPT	(radius)				{ radius = 255*FRACUNIT; }
-	PARAM_FIXED_OPT	(speed)					{ speed = 20; }
+	PARAM_FIXED_OPT	(speed)					{ speed = 20*FRACUNIT; }
 	PARAM_CLASS_OPT	(blasteffect, AActor)	{ blasteffect = PClass::FindActor("BlastEffect"); }
 	PARAM_SOUND_OPT	(blastsound)			{ blastsound = "BlastRadius"; }
 

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -240,7 +240,7 @@ ACTOR Actor native //: Thinker
 	action native A_CustomMeleeAttack(int damage = 0, sound meleesound = "", sound misssound = "", name damagetype = "none", bool bleed = true);
 	action native A_CustomComboAttack(class<Actor> missiletype, float spawnheight, int damage, sound meleesound = "", name damagetype = "none", bool bleed = true);
 	action native A_Burst(class<Actor> chunktype);
-	action native A_Blast(int flags = 0, int strength = 255, float radius = 255, float speed = 20, class<Actor> blasteffect = "BlastEffect", sound blastsound = "BlastRadius");
+	action native A_Blast(int flags = 0, float strength = 255, float radius = 255, float speed = 20, class<Actor> blasteffect = "BlastEffect", sound blastsound = "BlastRadius");
 	action native A_RadiusThrust(int force = 128, int distance = -1, int flags = RTF_AFFECTSOURCE, int fullthrustdistance = 0);
 	action native A_Explode(int damage = -1, int distance = -1, int flags = XF_HURTSOURCE, bool alert = false, int fulldamagedistance = 0, int nails = 0, int naildamage = 10, class<Actor> pufftype = "BulletPuff");
 	action native A_Stop();


### PR DESCRIPTION
Default values for strength and speed parameter are fixed type, not integers
Also strength parameter needs to have floating point type