### PR TITLE
P_CheckMove Dropoff Checks

### DIFF
--- a/src/p_local.h
+++ b/src/p_local.h
@@ -221,7 +221,7 @@ void	P_FakeZMovement (AActor *mo);
 bool	P_TryMove(AActor* thing, const DVector2 &pos, int dropoff, const secplane_t * onfloor, FCheckPosition &tm, bool missileCheck = false);
 bool	P_TryMove(AActor* thing, const DVector2 &pos, int dropoff, const secplane_t * onfloor = NULL);
 
-bool	P_CheckMove(AActor *thing, const DVector2 &pos);
+bool	P_CheckMove(AActor *thing, const DVector2 &pos, bool dropoff = false);
 void	P_ApplyTorque(AActor *mo);
 
 bool	P_TeleportMove(AActor* thing, const DVector3 &pos, bool telefrag, bool modifyactor = true);	// [RH] Added z and telefrag parameters

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -2410,7 +2410,7 @@ bool P_TryMove(AActor *thing, const DVector2 &pos,
 //
 //==========================================================================
 
-bool P_CheckMove(AActor *thing, const DVector2 &pos)
+bool P_CheckMove(AActor *thing, const DVector2 &pos, bool dropoff)
 {
 	FCheckPosition tm;
 	double		newz = thing->Z();
@@ -2450,6 +2450,15 @@ bool P_CheckMove(AActor *thing, const DVector2 &pos)
 		}
 		if (!(thing->flags & MF_TELEPORT) && !(thing->flags3 & MF3_FLOORHUGGER))
 		{
+			// special logic to move a monster off a dropoff
+			// this intentionally does not check for standing on things.
+			if (dropoff && (
+				thing->floorz - tm.floorz > thing->MaxDropOffHeight ||
+				thing->dropoffz - tm.dropoffz > thing->MaxDropOffHeight))
+			{
+				thing->flags6 &= ~MF6_INTRYMOVE;
+				return false;
+			}
 			if (tm.floorz - newz > thing->MaxStepHeight)
 			{ // too big a step up
 				return false;

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -6707,7 +6707,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_CheckBlock)
 	if (flags & CBF_DROPOFF)
 	{
 		mobj->SetZ(pos.Z);
-		checker = P_CheckMove(mobj, pos);
+		checker = P_CheckMove(mobj, pos, true);
 		mobj->SetZ(oldpos.Z);
 	}
 	else


### PR DESCRIPTION
- Added dropoff checking to P_CheckMove. Disabled by default.
- Fixes A_CheckBlock's CBF_DROPOFF not actually working with dropoffs -- only step height.