### PR TITLE
Title text is always visible in OS X startup window

### DIFF
--- a/src/posix/cocoa/st_console.mm
+++ b/src/posix/cocoa/st_console.mm
@@ -363,6 +363,15 @@ void FConsoleWindow::SetTitleText()
 		textViewFrame.size.width,
 		TITLE_TEXT_HEIGHT);
 
+	// Temporary solution for the same foreground and background colors
+	// It's used in graphical startup screen, with Hexen style in particular
+	// Native OS X backend doesn't implement this yet
+
+	if (DoomStartupInfo.FgColor == DoomStartupInfo.BkColor)
+	{
+		DoomStartupInfo.FgColor = ~DoomStartupInfo.FgColor;
+	}
+
 	NSTextField* titleText = [[NSTextField alloc] initWithFrame:titleTextRect];
 	[titleText setStringValue:[NSString stringWithUTF8String:DoomStartupInfo.Name]];
 	[titleText setAlignment:NSCenterTextAlignment];


### PR DESCRIPTION
Added temporary solution for the same foreground and background colors of the title in OS X startup window
It's used in graphical startup screen, with Hexen style in particular (for example WolfenDoom - Blade of Agony)
Native OS X backend doesn't implement this yet and I doubt that it will be done in the nearest future 