### PR TITLE
A_QuakeEx Roll Intensity + Wave

### DIFF
--- a/src/g_shared/a_quake.cpp
+++ b/src/g_shared/a_quake.cpp
@@ -72,7 +72,7 @@ void DEarthquake::Serialize (FArchive &arc)
 		<< m_QuakeSFX << m_Flags << m_CountdownStart
 		<< m_WaveSpeed
 		<< m_Falloff << m_Highpoint << m_MiniCount
-		<< m_RollIntensity;
+		<< m_RollIntensity << m_RollWave;
 }
 
 //==========================================================================

--- a/src/g_shared/a_sharedglobal.h
+++ b/src/g_shared/a_sharedglobal.h
@@ -153,8 +153,8 @@ struct FQuakeJiggers
 	DVector3 RelIntensity;
 	DVector3 Offset;
 	DVector3 RelOffset;
-	double Falloff;
-	double WFalloff;
+	double Falloff, WFalloff;
+	double RollIntensity, RollWave;
 };
 
 class DEarthquake : public DThinker
@@ -164,7 +164,7 @@ class DEarthquake : public DThinker
 public:
 	DEarthquake(AActor *center, int intensityX, int intensityY, int intensityZ, int duration,
 		int damrad, int tremrad, FSoundID quakesfx, int flags, 
-		double waveSpeedX, double waveSpeedY, double waveSpeedZ, int falloff, int highpoint);
+		double waveSpeedX, double waveSpeedY, double waveSpeedZ, int falloff, int highpoint, int rollIntensity, double rollWave);
 
 	void Serialize (FArchive &arc);
 	void Tick ();
@@ -178,6 +178,8 @@ public:
 	DVector3 m_WaveSpeed;
 	double m_Falloff;
 	int m_Highpoint, m_MiniCount;
+	double m_RollIntensity, m_RollWave;
+
 
 	double GetModIntensity(double intensity) const;
 	double GetModWave(double waveMultiplier) const;

--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -5768,7 +5768,9 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 				argCount > 10 ? ACSToDouble(args[10]) : 1.0,
 				argCount > 11 ? ACSToDouble(args[11]) : 1.0,
 				argCount > 12 ? args[12] : 0,
-				argCount > 13 ? args[13] : 0);
+				argCount > 13 ? args[13] : 0,
+				argCount > 14 ? args[14] : 0,
+				argCount > 15 ? args[15] : 0);
 		}
 
 		case ACSF_SetLineActivation:

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -238,6 +238,7 @@ void AActor::Serialize(FArchive &arc)
 		<< Angles.Yaw
 		<< Angles.Pitch
 		<< Angles.Roll
+		<< Angles.CamRoll
 		<< frame
 		<< Scale
 		<< RenderStyle
@@ -4592,7 +4593,7 @@ APlayerPawn *P_SpawnPlayer (FPlayerStart *mthing, int playernum, int flags)
 	}
 
 	mobj->Angles.Yaw = SpawnAngle;
-	mobj->Angles.Pitch = mobj->Angles.Roll = 0.;
+	mobj->Angles.Pitch = mobj->Angles.Roll = mobj->Angles.CamRoll = 0.;
 	mobj->health = p->health;
 
 	// [RH] Set player sprite based on skin
@@ -5074,7 +5075,7 @@ AActor *P_SpawnMapThing (FMapThing *mthing, int position)
 	if (mthing->pitch)
 		mobj->Angles.Pitch = (double)mthing->pitch;
 	if (mthing->roll)
-		mobj->Angles.Roll = (double)mthing->roll;
+		mobj->Angles.Roll = mobj->Angles.CamRoll = (double)mthing->roll;
 	if (mthing->score)
 		mobj->Score = mthing->score;
 	if (mthing->fillcolor)

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -238,7 +238,6 @@ void AActor::Serialize(FArchive &arc)
 		<< Angles.Yaw
 		<< Angles.Pitch
 		<< Angles.Roll
-		<< Angles.CamRoll
 		<< frame
 		<< Scale
 		<< RenderStyle
@@ -4593,7 +4592,7 @@ APlayerPawn *P_SpawnPlayer (FPlayerStart *mthing, int playernum, int flags)
 	}
 
 	mobj->Angles.Yaw = SpawnAngle;
-	mobj->Angles.Pitch = mobj->Angles.Roll = mobj->Angles.CamRoll = 0.;
+	mobj->Angles.Pitch = mobj->Angles.Roll = 0.;
 	mobj->health = p->health;
 
 	// [RH] Set player sprite based on skin
@@ -5075,7 +5074,7 @@ AActor *P_SpawnMapThing (FMapThing *mthing, int position)
 	if (mthing->pitch)
 		mobj->Angles.Pitch = (double)mthing->pitch;
 	if (mthing->roll)
-		mobj->Angles.Roll = mobj->Angles.CamRoll = (double)mthing->roll;
+		mobj->Angles.Roll = (double)mthing->roll;
 	if (mthing->score)
 		mobj->Score = mthing->score;
 	if (mthing->fillcolor)

--- a/src/p_spec.h
+++ b/src/p_spec.h
@@ -698,7 +698,7 @@ void P_DoDeferedScripts (void);
 //
 // [RH] p_quake.c
 //
-bool P_StartQuakeXYZ(AActor *activator, int tid, int intensityX, int intensityY, int intensityZ, int duration, int damrad, int tremrad, FSoundID quakesfx, int flags, double waveSpeedX, double waveSpeedY, double waveSpeedZ, int falloff, int highpoint);
+bool P_StartQuakeXYZ(AActor *activator, int tid, int intensityX, int intensityY, int intensityZ, int duration, int damrad, int tremrad, FSoundID quakesfx, int flags, double waveSpeedX, double waveSpeedY, double waveSpeedZ, int falloff, int highpoint, int rollIntensity, double rollWave);
 bool P_StartQuake(AActor *activator, int tid, int intensity, int duration, int damrad, int tremrad, FSoundID quakesfx);
 
 #endif

--- a/src/r_utility.cpp
+++ b/src/r_utility.cpp
@@ -799,6 +799,7 @@ void R_SetupFrame (AActor *actor)
 		P_AimCamera (camera, campos, camangle, viewsector, unlinked);	// fixme: This needs to translate the angle, too.
 		iview->New.Pos = campos;
 		iview->New.Angles.Yaw = camangle;
+		
 		r_showviewer = true;
 		// Interpolating this is a very complicated thing because nothing keeps track of the aim camera's movement, so whenever we detect a portal transition
 		// it's probably best to just reset the interpolation for this move.
@@ -868,6 +869,10 @@ void R_SetupFrame (AActor *actor)
 			double quakefactor = r_quakeintensity;
 			DAngle an;
 
+			if (jiggers.RollIntensity != 0 || jiggers.RollWave != 0)
+			{
+				camera->Angles.CamRoll = camera->Angles.Roll + QuakePower(quakefactor, jiggers.RollIntensity, jiggers.RollWave, jiggers.Falloff, jiggers.WFalloff);
+			}
 			if (jiggers.RelIntensity.X != 0 || jiggers.RelOffset.X != 0)
 			{
 				an = camera->Angles.Yaw;
@@ -897,6 +902,10 @@ void R_SetupFrame (AActor *actor)
 			{
 				ViewPos.Z += QuakePower(quakefactor, jiggers.Intensity.Z, jiggers.Offset.Z, jiggers.Falloff, jiggers.WFalloff);
 			}
+		}
+		else
+		{
+			camera->Angles.CamRoll = camera->Angles.Roll;
 		}
 	}
 

--- a/src/r_utility.cpp
+++ b/src/r_utility.cpp
@@ -108,6 +108,7 @@ int 			viewwindowy;
 DVector3		ViewPos;
 DAngle			ViewAngle;
 DAngle			ViewPitch;
+DAngle			ViewRoll;
 DVector3		ViewPath[2];
 
 extern "C" 
@@ -542,11 +543,13 @@ void R_InterpolateView (player_t *player, double Frac, InterpolationViewer *ivie
 		ViewAngle = (nviewangle + AngleToFloat(LocalViewAngle & 0xFFFF0000)).Normalized180();
 		DAngle delta = player->centering ? DAngle(0.) : AngleToFloat(int(LocalViewPitch & 0xFFFF0000));
 		ViewPitch = clamp<DAngle>((iview->New.Angles.Pitch - delta).Normalized180(), player->MinPitch, player->MaxPitch);
+		ViewRoll = iview->New.Angles.Roll.Normalized180();
 	}
 	else
 	{
 		ViewPitch = (iview->Old.Angles.Pitch + deltaangle(iview->Old.Angles.Pitch, iview->New.Angles.Pitch) * Frac).Normalized180();
 		ViewAngle = (oviewangle + deltaangle(oviewangle, nviewangle) * Frac).Normalized180();
+		ViewRoll = iview->Old.Angles.Roll.Normalized180();
 	}
 	
 	// Due to interpolation this is not necessarily the same as the sector the camera is in.
@@ -871,7 +874,7 @@ void R_SetupFrame (AActor *actor)
 
 			if (jiggers.RollIntensity != 0 || jiggers.RollWave != 0)
 			{
-				camera->Angles.CamRoll = camera->Angles.Roll + QuakePower(quakefactor, jiggers.RollIntensity, jiggers.RollWave, jiggers.Falloff, jiggers.WFalloff);
+				ViewRoll += QuakePower(quakefactor, jiggers.RollIntensity, jiggers.RollWave, jiggers.Falloff, jiggers.WFalloff);
 			}
 			if (jiggers.RelIntensity.X != 0 || jiggers.RelOffset.X != 0)
 			{
@@ -902,10 +905,6 @@ void R_SetupFrame (AActor *actor)
 			{
 				ViewPos.Z += QuakePower(quakefactor, jiggers.Intensity.Z, jiggers.Offset.Z, jiggers.Falloff, jiggers.WFalloff);
 			}
-		}
-		else
-		{
-			camera->Angles.CamRoll = camera->Angles.Roll;
 		}
 	}
 

--- a/src/r_utility.cpp
+++ b/src/r_utility.cpp
@@ -549,7 +549,7 @@ void R_InterpolateView (player_t *player, double Frac, InterpolationViewer *ivie
 	{
 		ViewPitch = (iview->Old.Angles.Pitch + deltaangle(iview->Old.Angles.Pitch, iview->New.Angles.Pitch) * Frac).Normalized180();
 		ViewAngle = (oviewangle + deltaangle(oviewangle, nviewangle) * Frac).Normalized180();
-		ViewRoll = iview->Old.Angles.Roll.Normalized180();
+		ViewRoll = (iview->Old.Angles.Roll + deltaangle(iview->Old.Angles.Roll, iview->New.Angles.Roll) * Frac).Normalized180();
 	}
 	
 	// Due to interpolation this is not necessarily the same as the sector the camera is in.

--- a/src/r_utility.h
+++ b/src/r_utility.h
@@ -15,6 +15,7 @@ extern DCanvas			*RenderTarget;
 extern DVector3			ViewPos;
 extern DAngle			ViewAngle;
 extern DAngle			ViewPitch;
+extern DAngle			ViewRoll;
 extern DVector3			ViewPath[2];
 
 extern "C" int			centerx, centerxwide;

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -2354,7 +2354,6 @@ static bool InitSpawnedItem(AActor *self, AActor *mo, int flags)
 	if (flags & SIXF_TRANSFERROLL)
 	{
 		mo->Angles.Roll = self->Angles.Roll;
-		mo->Angles.CamRoll = self->Angles.CamRoll;
 	}
 
 	if (flags & SIXF_ISTARGET)

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -2354,6 +2354,7 @@ static bool InitSpawnedItem(AActor *self, AActor *mo, int flags)
 	if (flags & SIXF_TRANSFERROLL)
 	{
 		mo->Angles.Roll = self->Angles.Roll;
+		mo->Angles.CamRoll = self->Angles.CamRoll;
 	}
 
 	if (flags & SIXF_ISTARGET)
@@ -4951,7 +4952,10 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_QuakeEx)
 	PARAM_FLOAT_OPT(mulWaveZ) { mulWaveZ = 1.; }
 	PARAM_INT_OPT(falloff) { falloff = 0; }
 	PARAM_INT_OPT(highpoint) { highpoint = 0; }
-	P_StartQuakeXYZ(self, 0, intensityX, intensityY, intensityZ, duration, damrad, tremrad, sound, flags, mulWaveX, mulWaveY, mulWaveZ, falloff, highpoint);
+	PARAM_INT_OPT(rollIntensity) { rollIntensity = 0; }
+	PARAM_FLOAT_OPT(rollWave) { rollWave = 0.; }
+	P_StartQuakeXYZ(self, 0, intensityX, intensityY, intensityZ, duration, damrad, tremrad, sound, flags, mulWaveX, mulWaveY, mulWaveZ, falloff, highpoint, 
+		rollIntensity, rollWave);
 	return 0;
 }
 

--- a/src/vectors.h
+++ b/src/vectors.h
@@ -1135,7 +1135,8 @@ struct TRotator
 
 	Angle Pitch;	// up/down
 	Angle Yaw;		// left/right
-	Angle Roll;		// rotation about the forward axis
+	Angle Roll;		// rotation about the forward axis.
+	Angle CamRoll;	// Roll specific to actor cameras. Used by quakes.
 
 	TRotator ()
 	{

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -280,7 +280,7 @@ ACTOR Actor native //: Thinker
 	native void A_SetUserArrayFloat(name varname, int index, float value);
 	native void A_SetSpecial(int spec, int arg0 = 0, int arg1 = 0, int arg2 = 0, int arg3 = 0, int arg4 = 0);
 	native void A_Quake(int intensity, int duration, int damrad, int tremrad, sound sfx = "world/quake");
-	native void A_QuakeEx(int intensityX, int intensityY, int intensityZ, int duration, int damrad, int tremrad, sound sfx = "world/quake", int flags = 0, float mulWaveX = 1, float mulWaveY = 1, float mulWaveZ = 1, int falloff = 0, int highpoint = 0);
+	native void A_QuakeEx(int intensityX, int intensityY, int intensityZ, int duration, int damrad, int tremrad, sound sfx = "world/quake", int flags = 0, float mulWaveX = 1, float mulWaveY = 1, float mulWaveZ = 1, int falloff = 0, int highpoint = 0, int rollIntensity = 0, float rollWave = 0);
 	action native A_SetTics(int tics);
 	native void A_SetDamageType(name damagetype);
 	native void A_DropItem(class<Actor> item, int dropamount = -1, int chance = 256);


### PR DESCRIPTION
- Adds rollIntensity and rollWave. Works just like their X/Y/Z counterparts, but the roll intensity is not capped.
- Only useful in GZDoom.