### PR TITLE
Quake Roll Fix

### DIFF
--- a/src/g_shared/a_quake.cpp
+++ b/src/g_shared/a_quake.cpp
@@ -283,7 +283,8 @@ int DEarthquake::StaticGetQuakeIntensities(AActor *victim, FQuakeJiggers &jigger
 			double dist = quake->m_Spot->Distance2D (victim, true);
 			if (dist < quake->m_TremorRadius)
 			{
-				double falloff = quake->GetFalloff(dist);
+				const double falloff = quake->GetFalloff(dist);
+				const double rfalloff = (quake->m_RollIntensity != 0) ? falloff : 0.;
 				++count;
 				double x = quake->GetModIntensity(quake->m_Intensity.X);
 				double y = quake->GetModIntensity(quake->m_Intensity.Y);
@@ -293,6 +294,7 @@ int DEarthquake::StaticGetQuakeIntensities(AActor *victim, FQuakeJiggers &jigger
 				if (!(quake->m_Flags & QF_WAVE))
 				{
 					jiggers.Falloff = MAX(falloff, jiggers.Falloff);
+					jiggers.RFalloff = MAX(rfalloff, jiggers.RFalloff);
 					jiggers.RollIntensity = MAX(r, jiggers.RollIntensity);
 					if (quake->m_Flags & QF_RELATIVE)
 					{
@@ -310,11 +312,11 @@ int DEarthquake::StaticGetQuakeIntensities(AActor *victim, FQuakeJiggers &jigger
 				else
 				{
 					jiggers.WFalloff = MAX(falloff, jiggers.WFalloff);
-					double mr = r * quake->GetModWave(quake->m_RollWave);
+					jiggers.RWFalloff = MAX(rfalloff, jiggers.RWFalloff);
+					jiggers.RollWave = r * quake->GetModWave(quake->m_RollWave);
 					double mx = x * quake->GetModWave(quake->m_WaveSpeed.X);
 					double my = y * quake->GetModWave(quake->m_WaveSpeed.Y);
 					double mz = z * quake->GetModWave(quake->m_WaveSpeed.Z);
-					jiggers.RollWave = r * quake->GetModWave(quake->m_RollWave);
 
 					// [RH] This only gives effect to the last sine quake. I would
 					// prefer if some way was found to make multiples coexist

--- a/src/g_shared/a_sharedglobal.h
+++ b/src/g_shared/a_sharedglobal.h
@@ -153,7 +153,7 @@ struct FQuakeJiggers
 	DVector3 RelIntensity;
 	DVector3 Offset;
 	DVector3 RelOffset;
-	double Falloff, WFalloff;
+	double Falloff, WFalloff, RFalloff, RWFalloff;
 	double RollIntensity, RollWave;
 };
 

--- a/src/r_utility.cpp
+++ b/src/r_utility.cpp
@@ -872,9 +872,9 @@ void R_SetupFrame (AActor *actor)
 			double quakefactor = r_quakeintensity;
 			DAngle an;
 
-			if (jiggers.RollIntensity != 0 || jiggers.RollWave != 0)
+			if (jiggers.RollIntensity != 0)
 			{
-				ViewRoll += QuakePower(quakefactor, jiggers.RollIntensity, jiggers.RollWave, jiggers.Falloff, jiggers.WFalloff);
+				ViewRoll += QuakePower(quakefactor, jiggers.RollIntensity, jiggers.RollWave, jiggers.RFalloff, jiggers.RWFalloff);
 			}
 			if (jiggers.RelIntensity.X != 0 || jiggers.RelOffset.X != 0)
 			{

--- a/src/r_utility.cpp
+++ b/src/r_utility.cpp
@@ -872,7 +872,7 @@ void R_SetupFrame (AActor *actor)
 			double quakefactor = r_quakeintensity;
 			DAngle an;
 
-			if (jiggers.RollIntensity != 0)
+			if (jiggers.RollIntensity != 0 || jiggers.RollWave != 0)
 			{
 				ViewRoll += QuakePower(quakefactor, jiggers.RollIntensity, jiggers.RollWave, jiggers.RFalloff, jiggers.RWFalloff);
 			}


### PR DESCRIPTION
- Fixed: Quakes with rolling were not unique; they borrowed from any other quakes that didn't have rolling, thus preventing the rolling from falling off properly.