### PR TITLE
GetDistance and GetAngle Fixes

### DIFF
--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -41,8 +41,8 @@ ACTOR Actor native //: Thinker
 	native bool CheckClass(class<Actor> checkclass, int ptr_select = AAPTR_DEFAULT, bool match_superclass = false);
 	native bool IsPointerEqual(int ptr_select1, int ptr_select2);
 	native int	CountInv(class<Inventory> itemtype, int ptr_select = AAPTR_DEFAULT);
-	native float GetDistance(bool checkz, int ptr = AAPTR_DEFAULT);
-	native float GetAngle(bool relative, int ptr = AAPTR_DEFAULT);
+	native float GetDistance(bool checkz, int ptr = AAPTR_TARGET);
+	native float GetAngle(bool relative, int ptr = AAPTR_TARGET);
 	native int GetSpawnHealth();
 	native int GetGibHealth();
 


### PR DESCRIPTION
- Fixed: GetDistance and GetAngle were both set to self instead of target, nullifying the effects of the functions if left unspecified.