### PR TITLE
- Fixed a mistake in GiveInventory refactoring.

### DIFF
--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -638,20 +638,23 @@ bool AActor::GiveInventory(PClassInventory *type, int amount, bool givecheat)
 
 	// This shouldn't count for the item statistics!
 	item->ClearCounters();
-	if (type->IsDescendantOf (RUNTIME_CLASS(ABasicArmorPickup)))
+	if (!givecheat || amount > 0)
 	{
-		static_cast<ABasicArmorPickup*>(item)->SaveAmount *= amount;
-	}
-	else if (type->IsDescendantOf (RUNTIME_CLASS(ABasicArmorBonus)))
-	{
-		static_cast<ABasicArmorBonus*>(item)->SaveAmount *= amount;
-	}
-	else
-	{
-		if (!givecheat)
-			item->Amount = amount;
+		if (type->IsDescendantOf (RUNTIME_CLASS(ABasicArmorPickup)))
+		{
+			static_cast<ABasicArmorPickup*>(item)->SaveAmount *= amount;
+		}
+		else if (type->IsDescendantOf (RUNTIME_CLASS(ABasicArmorBonus)))
+		{
+			static_cast<ABasicArmorBonus*>(item)->SaveAmount *= amount;
+		}
 		else
-			item->Amount = MIN (amount, item->MaxAmount);
+		{
+			if (!givecheat)
+				item->Amount = amount;
+			else
+				item->Amount = MIN (amount, item->MaxAmount);
+		}
 	}
 	if (!item->CallTryPickup (this))
 	{


### PR DESCRIPTION
'give item' stopped working because commit 7b35f32f3de012ccb0ccabe9086cffddcfe0bd00 and 6aca7604eb37ba8e436261015603b4c9a2f1d311 didn't take account that give cheat with zero amount should not touch the item amount.

See http://forum.zdoom.org/viewtopic.php?f=4&t=51860&p=904276#p904228 .