### PR TITLE
Load mono copies of multichannel sounds that are used in 3D

### DIFF
--- a/src/s_advsound.cpp
+++ b/src/s_advsound.cpp
@@ -500,6 +500,7 @@ int S_AddSoundLump (const char *logicalname, int lump)
 	sfxinfo_t newsfx;
 
 	newsfx.data.Clear();
+    newsfx.data3d.Clear();
 	newsfx.name = logicalname;
 	newsfx.lumpnum = lump;
 	newsfx.next = 0;

--- a/src/s_sound.h
+++ b/src/s_sound.h
@@ -36,6 +36,9 @@ struct sfxinfo_t
 	// Next field is for use by the system sound interface.
 	// A non-null data means the sound has been loaded.
 	SoundHandle	data;
+    // Also for the sound interface. Used for 3D positional
+    // sounds, may be the same as data.
+    SoundHandle data3d;
 
 	FString		name;					// [RH] Sound name defined in SNDINFO
 	int 		lumpnum;				// lump number of sfx

--- a/src/sound/fmodsound.cpp
+++ b/src/sound/fmodsound.cpp
@@ -2510,7 +2510,7 @@ void FMODSoundRenderer::UpdateSounds()
 //
 //==========================================================================
 
-SoundHandle FMODSoundRenderer::LoadSoundRaw(BYTE *sfxdata, int length, int frequency, int channels, int bits, int loopstart, int loopend)
+std::pair<SoundHandle,bool> FMODSoundRenderer::LoadSoundRaw(BYTE *sfxdata, int length, int frequency, int channels, int bits, int loopstart, int loopend, bool monoize)
 {
 	FMOD_CREATESOUNDEXINFO exinfo;
 	SoundHandle retval = { NULL };
@@ -2518,7 +2518,7 @@ SoundHandle FMODSoundRenderer::LoadSoundRaw(BYTE *sfxdata, int length, int frequ
 
 	if (length <= 0)
 	{
-		return retval;
+		return std::make_pair(retval, true);
 	}
 
 	InitCreateSoundExInfo(&exinfo);
@@ -2550,7 +2550,7 @@ SoundHandle FMODSoundRenderer::LoadSoundRaw(BYTE *sfxdata, int length, int frequ
 		break;
 
 	default:
-		return retval;
+		return std::make_pair(retval, true);
 	}
 
 	const FMOD_MODE samplemode = FMOD_3D | FMOD_OPENMEMORY | FMOD_SOFTWARE | FMOD_OPENRAW;
@@ -2561,7 +2561,7 @@ SoundHandle FMODSoundRenderer::LoadSoundRaw(BYTE *sfxdata, int length, int frequ
 	if (result != FMOD_OK)
 	{
 		DPrintf("Failed to allocate sample: Error %d\n", result);
-		return retval;
+		return std::make_pair(retval, true);
 	}
 
 	if (loopstart >= 0)
@@ -2572,7 +2572,7 @@ SoundHandle FMODSoundRenderer::LoadSoundRaw(BYTE *sfxdata, int length, int frequ
 	}
 
 	retval.data = sample;
-	return retval;
+	return std::make_pair(retval, true);
 }
 
 //==========================================================================
@@ -2581,12 +2581,12 @@ SoundHandle FMODSoundRenderer::LoadSoundRaw(BYTE *sfxdata, int length, int frequ
 //
 //==========================================================================
 
-SoundHandle FMODSoundRenderer::LoadSound(BYTE *sfxdata, int length)
+std::pair<SoundHandle,bool> FMODSoundRenderer::LoadSound(BYTE *sfxdata, int length, bool monoize)
 {
 	FMOD_CREATESOUNDEXINFO exinfo;
 	SoundHandle retval = { NULL };
 
-	if (length == 0) return retval;
+	if (length == 0) return std::make_pair(retval, true);
 
 	InitCreateSoundExInfo(&exinfo);
 	exinfo.length = length;
@@ -2599,11 +2599,11 @@ SoundHandle FMODSoundRenderer::LoadSound(BYTE *sfxdata, int length)
 	if (result != FMOD_OK)
 	{
 		DPrintf("Failed to allocate sample: Error %d\n", result);
-		return retval;
+		return std::make_pair(retval, true);
 	}
 	SetCustomLoopPts(sample);
 	retval.data = sample;
-	return retval;
+	return std::make_pair(retval, true);
 }
 
 //==========================================================================

--- a/src/sound/fmodsound.h
+++ b/src/sound/fmodsound.h
@@ -15,8 +15,8 @@ public:
 
 	void SetSfxVolume (float volume);
 	void SetMusicVolume (float volume);
-	SoundHandle LoadSound(BYTE *sfxdata, int length);
-	SoundHandle LoadSoundRaw(BYTE *sfxdata, int length, int frequency, int channels, int bits, int loopstart, int loopend = -1);
+	std::pair<SoundHandle,bool> LoadSound(BYTE *sfxdata, int length, bool monoize);
+	std::pair<SoundHandle,bool> LoadSoundRaw(BYTE *sfxdata, int length, int frequency, int channels, int bits, int loopstart, int loopend = -1, bool monoize = false);
 	void UnloadSound (SoundHandle sfx);
 	unsigned int GetMSLength(SoundHandle sfx);
 	unsigned int GetSampleLength(SoundHandle sfx);

--- a/src/sound/i_sound.cpp
+++ b/src/sound/i_sound.cpp
@@ -135,15 +135,15 @@ public:
 	void SetMusicVolume (float volume)
 	{
 	}
-	SoundHandle LoadSound(BYTE *sfxdata, int length)
+	std::pair<SoundHandle,bool> LoadSound(BYTE *sfxdata, int length, bool monoize)
 	{
 		SoundHandle retval = { NULL };
-		return retval;
+		return std::make_pair(retval, true);
 	}
-	SoundHandle LoadSoundRaw(BYTE *sfxdata, int length, int frequency, int channels, int bits, int loopstart, int loopend)
+	std::pair<SoundHandle,bool> LoadSoundRaw(BYTE *sfxdata, int length, int frequency, int channels, int bits, int loopstart, int loopend, bool monoize)
 	{
 		SoundHandle retval = { NULL };
-		return retval;
+        return std::make_pair(retval, true);
 	}
 	void UnloadSound (SoundHandle sfx)
 	{
@@ -456,7 +456,7 @@ FString SoundStream::GetStats()
 //
 //==========================================================================
 
-SoundHandle SoundRenderer::LoadSoundVoc(BYTE *sfxdata, int length)
+std::pair<SoundHandle,bool> SoundRenderer::LoadSoundVoc(BYTE *sfxdata, int length, bool monoize)
 {
 	BYTE * data = NULL;
 	int len, frequency, channels, bits, loopstart, loopend;
@@ -600,7 +600,7 @@ SoundHandle SoundRenderer::LoadSoundVoc(BYTE *sfxdata, int length)
 		}
 
 	} while (false);
-	SoundHandle retval = LoadSoundRaw(data, len, frequency, channels, bits, loopstart, loopend);
+	std::pair<SoundHandle,bool> retval = LoadSoundRaw(data, len, frequency, channels, bits, loopstart, loopend, monoize);
 	if (data) delete[] data;
 	return retval;
 }

--- a/src/sound/i_sound.h
+++ b/src/sound/i_sound.h
@@ -95,9 +95,10 @@ public:
 	virtual bool IsNull() { return false; }
 	virtual void SetSfxVolume (float volume) = 0;
 	virtual void SetMusicVolume (float volume) = 0;
-	virtual SoundHandle LoadSound(BYTE *sfxdata, int length) = 0;
-	SoundHandle LoadSoundVoc(BYTE *sfxdata, int length);
-	virtual SoundHandle LoadSoundRaw(BYTE *sfxdata, int length, int frequency, int channels, int bits, int loopstart, int loopend = -1) = 0;
+    // Returns a pair containing a sound handle and a boolean indicating the sound can be used in 3D.
+	virtual std::pair<SoundHandle,bool> LoadSound(BYTE *sfxdata, int length, bool monoize=false) = 0;
+	std::pair<SoundHandle,bool> LoadSoundVoc(BYTE *sfxdata, int length, bool monoize=false);
+	virtual std::pair<SoundHandle,bool> LoadSoundRaw(BYTE *sfxdata, int length, int frequency, int channels, int bits, int loopstart, int loopend = -1, bool monoize = false) = 0;
 	virtual void UnloadSound (SoundHandle sfx) = 0;	// unloads a sound from memory
 	virtual unsigned int GetMSLength(SoundHandle sfx) = 0;	// Gets the length of a sound at its default frequency
 	virtual unsigned int GetSampleLength(SoundHandle sfx) = 0;	// Gets the length of a sound at its default frequency

--- a/src/sound/i_soundinternal.h
+++ b/src/sound/i_soundinternal.h
@@ -91,6 +91,11 @@ struct SoundHandle
 
 	bool isValid() const { return data != NULL; }
 	void Clear() { data = NULL; }
+
+	bool operator==(const SoundHandle &rhs) const
+	{ return data == rhs.data; }
+	bool operator!=(const SoundHandle &rhs) const
+	{ return !(*this == rhs); }
 };
 
 struct FISoundChannel

--- a/src/sound/oalsound.h
+++ b/src/sound/oalsound.h
@@ -71,8 +71,8 @@ public:
 
 	virtual void SetSfxVolume(float volume);
 	virtual void SetMusicVolume(float volume);
-	virtual SoundHandle LoadSound(BYTE *sfxdata, int length);
-	virtual SoundHandle LoadSoundRaw(BYTE *sfxdata, int length, int frequency, int channels, int bits, int loopstart, int loopend = -1);
+	virtual std::pair<SoundHandle,bool> LoadSound(BYTE *sfxdata, int length, bool monoize);
+	virtual std::pair<SoundHandle,bool> LoadSoundRaw(BYTE *sfxdata, int length, int frequency, int channels, int bits, int loopstart, int loopend = -1, bool monoize = false);
 	virtual void UnloadSound(SoundHandle sfx);
 	virtual unsigned int GetMSLength(SoundHandle sfx);
 	virtual unsigned int GetSampleLength(SoundHandle sfx);


### PR DESCRIPTION
For http://forum.zdoom.org/viewtopic.php?f=2&t=50422. Hopefully it doesn't conflict will the other pull request. This doesn't change FMOD's behavior, though with OpenAL it will load mono copies of stereo sounds when played in 3D. Sounds that are already mono will be used as-is for 3D.