### PR TITLE
FORCE_INTERNAL_GME now defaults to OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,7 +193,7 @@ set( CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${DEB_C_FLAGS} -D_DEBUG" )
 option(FORCE_INTERNAL_ZLIB "Use internal zlib")
 option(FORCE_INTERNAL_JPEG "Use internal jpeg")
 option(FORCE_INTERNAL_BZIP2 "Use internal bzip2")
-option(FORCE_INTERNAL_GME "Use internal gme" ON)
+option(FORCE_INTERNAL_GME "Use internal gme")
 
 # Fast math flags, required by some subprojects
 set( ZD_FASTMATH_FLAG "" )


### PR DESCRIPTION
No real reason to have it on by default.