### PR TITLE
VisibleFilter 

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -380,6 +380,7 @@ enum ActorFlag7
 	MF7_LAXTELEFRAGDMG	= 0x00100000,	// [MC] Telefrag damage can be reduced.
 	MF7_ICESHATTER		= 0x00200000,	// [MC] Shatters ice corpses regardless of damagetype.
 	MF7_ALLOWTHRUFLAGS	= 0x00400000,	// [MC] Allow THRUACTORS and the likes on puffs to prevent mod breakage.
+	MF7_FILTERHIDES		= 0x00800000,	// [MC] Show the actor to anything not covered by the filter
 };
 
 // --- mobj.renderflags ---
@@ -1019,6 +1020,8 @@ public:
 	// [BB] If 0, everybody can see the actor, if > 0, only members of team (VisibleToTeam-1) can see it.
 	DWORD			VisibleToTeam;
 
+	// Inclusive filter (AAPTR_ bitmask) to tell who can see this actor; inverted by MF6_FILTERHIDES
+	int				VisibleFilter;
 	int				special1;		// Special info
 	int				special2;		// Special info
 	double			specialf1;		// With floats we cannot use the int versions for storing position or angle data without reverting to fixed point (which we do not want.)

--- a/src/actorptrselect.cpp
+++ b/src/actorptrselect.cpp
@@ -203,6 +203,7 @@ void ASSIGN_AAPTR(AActor *toActor, int toSlot, AActor *ptr, int flags)
 
 bool AAPTR_FILTER(AActor *context, AActor *target, int aaptr_filter)
 {
+	if (aaptr_filter & AAPTR_NULL)	return true;
 	if (target)
 	{
 		// Because we're going through the lot, and returning on first match (or after processing all) order has no impact on logic, only performance
@@ -219,10 +220,10 @@ bool AAPTR_FILTER(AActor *context, AActor *target, int aaptr_filter)
 				if ((aaptr_filter & AAPTR_PLAYER_GETCONVERSATION) && context->player->ConversationNPC == target) return true;
 				if (aaptr_filter & AAPTR_PLAYER_GETTARGET)
 				{
-					FTranslatedLineTarget gettarget;
-					gettarget.linetarget = NULL;
-					P_BulletSlope(context, &gettarget);
-					if (gettarget.linetarget == target) return true;
+					FTranslatedLineTarget get;
+					get.linetarget = nullptr;
+					P_BulletSlope(context, &get);
+					if (get.linetarget && get.linetarget == target) return true;
 				}
 			}
 		}

--- a/src/actorptrselect.cpp
+++ b/src/actorptrselect.cpp
@@ -184,3 +184,55 @@ void ASSIGN_AAPTR(AActor *toActor, int toSlot, AActor *ptr, int flags)
 			break;
 	}
 }
+
+//==========================================================================
+//
+// Search references from one actor (context)
+// to find another actor (target)
+// using references specified in aaptr_filter
+//
+// a null context will only match static filter specifications
+// a null target will only match AAPTR_NULL
+//
+// a null filter will match nothing (and it will check the bits one by one, so it is better to preempt the call)
+// null filter is not handled specifically here because specific handling is better handled by the calling code
+//
+// There is no filter for AAPTR_DEFAULT
+//
+//==========================================================================
+
+bool AAPTR_FILTER(AActor *context, AActor *target, int aaptr_filter)
+{
+	if (target)
+	{
+		// Because we're going through the lot, and returning on first match (or after processing all) order has no impact on logic, only performance
+		// For this reason, it seems viable to put target master and tracer rather high up, and rare/processing-intensive tests later
+		// Also note that since target is not null at this point, there is no need to re-verify that stuff is not equal to null; NULL != target
+		if (context)
+		{
+			if ((aaptr_filter & AAPTR_TARGET) && context->target == target) return true;
+			if ((aaptr_filter & AAPTR_MASTER) && context->master == target) return true;
+			if ((aaptr_filter & AAPTR_TRACER) && context->tracer == target) return true;
+			if ((aaptr_filter & AAPTR_FRIENDPLAYER) && context->FriendPlayer && AAPTR_RESOLVE_PLAYERNUM(context->FriendPlayer - 1) == target) return true;
+			if (context->player)
+			{
+				if ((aaptr_filter & AAPTR_PLAYER_GETCONVERSATION) && context->player->ConversationNPC == target) return true;
+				if (aaptr_filter & AAPTR_PLAYER_GETTARGET)
+				{
+					FTranslatedLineTarget gettarget;
+					gettarget.linetarget = NULL;
+					P_BulletSlope(context, &gettarget);
+					if (gettarget.linetarget == target) return true;
+				}
+			}
+		}
+
+		for (int p = 0; p < MAXPLAYERS; p++)
+		{
+			if ((aaptr_filter & (AAPTR_PLAYER1 << p)) && AAPTR_RESOLVE_PLAYERNUM(p) == target)
+				return true;
+		}
+		return false;
+	}
+	return !!(aaptr_filter & AAPTR_NULL);
+}

--- a/src/actorptrselect.h
+++ b/src/actorptrselect.h
@@ -90,5 +90,6 @@ enum PTROP
 
 void VerifyTargetChain(AActor *self, bool preciseMissileCheck=true);
 void VerifyMasterChain(AActor *self);
-void ASSIGN_AAPTR(AActor *toActor, int toSlot, AActor *ptr, int flags) ;
+void ASSIGN_AAPTR(AActor *toActor, int toSlot, AActor *ptr, int flags);
+bool AAPTR_FILTER(AActor *context, AActor *target, int aaptr_filter);
 

--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -3703,6 +3703,8 @@ enum
 	APROP_DamageMultiplier=43,
 	APROP_MaxStepHeight	= 44,
 	APROP_MaxDropOffHeight= 45,
+	APROP_VisibleFilter = 46,
+	APROP_FilterHides	= 47,
 };
 
 // These are needed for ACS's APROP_RenderStyle
@@ -3952,6 +3954,17 @@ void DLevelScript::DoSetActorProperty (AActor *actor, int property, int value)
 
 	case APROP_Friction:
 		actor->Friction = ACSToDouble(value);
+		break;
+		
+	case APROP_VisibleFilter:
+		actor->VisibleFilter = value;
+		break;
+	case APROP_FilterHides:
+		if (value)
+			actor->flags7 |= MF7_FILTERHIDES;
+		else
+			actor->flags7 &= ~MF7_FILTERHIDES;
+		break;
 
 	case APROP_MaxStepHeight:
 		actor->MaxStepHeight = ACSToDouble(value);
@@ -4064,6 +4077,8 @@ int DLevelScript::GetActorProperty (int tid, int property)
 	case APROP_Friction:	return DoubleToACS(actor->Friction);
 	case APROP_MaxStepHeight: return DoubleToACS(actor->MaxStepHeight);
 	case APROP_MaxDropOffHeight: return DoubleToACS(actor->MaxDropOffHeight);
+	case APROP_VisibleFilter:	return actor->VisibleFilter;
+	case APROP_FilterHides:		return !!(actor->flags7 & MF7_FILTERHIDES);
 
 	default:				return 0;
 	}
@@ -4113,6 +4128,7 @@ int DLevelScript::CheckActorProperty (int tid, int property, int value)
 		case APROP_MaxStepHeight:
 		case APROP_MaxDropOffHeight:
 		case APROP_StencilColor:
+		case APROP_VisibleFilter:
 			return (GetActorProperty(tid, property) == value);
 
 		// Boolean values need to compare to a binary version of value
@@ -4125,6 +4141,7 @@ int DLevelScript::CheckActorProperty (int tid, int property, int value)
 		case APROP_Notarget:
 		case APROP_Notrigger:
 		case APROP_Dormant:
+		case APROP_FilterHides:
 			return (GetActorProperty(tid, property) == (!!value));
 
 		// Strings are covered by GetActorProperty, but they're fairly

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -1140,7 +1140,7 @@ bool AActor::IsVisibleToPlayer() const
 	}
 
 	// [FDARI] Passed all checks but the filter
-	if (VisibleFilter > 0 && !(VisibleFilter & AAPTR_NULL))
+	if (VisibleFilter > 0)
 	{
 		bool visible = AAPTR_FILTER(const_cast<AActor *>(this), pPlayer->mo, VisibleFilter);
 		return (flags7 & MF7_FILTERHIDES) ? !visible : visible;

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -70,6 +70,7 @@
 #include "po_man.h"
 #include "p_spec.h"
 #include "p_checkposition.h"
+#include "actorptrselect.h"
 
 // MACROS ------------------------------------------------------------------
 
@@ -263,6 +264,10 @@ void AActor::Serialize(FArchive &arc)
 		<< Vel
 		<< tics
 		<< state;
+	if (SaveVersion >= 4546)
+	{
+		arc << VisibleFilter;
+	}
 	if (arc.IsStoring())
 	{
 		int dmg;
@@ -1132,6 +1137,13 @@ bool AActor::IsVisibleToPlayer() const
 		}
 		if (!visible)
 			return false;
+	}
+
+	// [FDARI] Passed all checks but the filter
+	if (VisibleFilter > 0 && !(VisibleFilter & AAPTR_NULL))
+	{
+		bool visible = AAPTR_FILTER(const_cast<AActor *>(this), pPlayer->mo, VisibleFilter);
+		return (flags7 & MF7_FILTERHIDES) ? !visible : visible;
 	}
 
 	// [BB] Passed all checks.

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -6881,3 +6881,29 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FaceMovementDirection)
 	}
 	ACTION_RETURN_BOOL(true);
 }
+
+//===========================================================================
+//
+// A_SetVisibleFilter
+//
+// Sets the visible filter of ptr. A player who is that pointer is the only
+// one who can see that actor. The FILTERHIDES flag inverses this ability:
+// Only to that player is the actor invisible to.
+//
+// Note, this has no effect on if the actor is 'truly' invisible. This simply
+// prevents the sprite from being drawn, and nothing more.
+//===========================================================================
+DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetVisibleFilter)
+{
+	PARAM_SELF_PROLOGUE(AActor);
+	PARAM_INT_OPT(visFilter)		{ visFilter = AAPTR_DEFAULT; }
+	PARAM_INT_OPT(ptr)				{ ptr = AAPTR_DEFAULT; }
+
+	AActor *mobj = COPY_AAPTR(self, ptr);
+
+	if (mobj)
+	{
+		mobj->VisibleFilter = visFilter;
+	}
+	return 0;
+}

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -6903,7 +6903,10 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetVisibleFilter)
 
 	if (mobj)
 	{
-		mobj->VisibleFilter = visFilter;
+		if (visFilter >= 0)
+			mobj->VisibleFilter = visFilter;
+		else
+			mobj->VisibleFilter = AAPTR_DEFAULT;
 	}
 	return 0;
 }

--- a/src/thingdef/thingdef_data.cpp
+++ b/src/thingdef/thingdef_data.cpp
@@ -257,6 +257,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF7, LAXTELEFRAGDMG, AActor, flags7),
 	DEFINE_FLAG(MF7, ICESHATTER, AActor, flags7),
 	DEFINE_FLAG(MF7, ALLOWTHRUFLAGS, AActor, flags7),
+	DEFINE_FLAG(MF7, FILTERHIDES, AActor, flags7),
 
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),

--- a/src/thingdef/thingdef_parse.cpp
+++ b/src/thingdef/thingdef_parse.cpp
@@ -55,6 +55,7 @@
 #include "version.h"
 #include "v_text.h"
 #include "m_argv.h"
+#include "actorptrselect.h"
 
 void ParseOldDecoration(FScanner &sc, EDefinitionType def);
 
@@ -728,6 +729,33 @@ static int ParseThingActivation (FScanner &sc)
 	return ParseFlagExpressionString(sc, activationstyles);
 }
 
+static int ParseThingPointer(FScanner &sc)
+{
+	static const FParseValue pointers[] = {
+
+		{ "AAPTR_DEFAULT",					AAPTR_DEFAULT },
+		{ "AAPTR_NULL",						AAPTR_NULL },
+		{ "AAPTR_TARGET",					AAPTR_TARGET },
+		{ "AAPTR_MASTER",					AAPTR_MASTER },
+		{ "AAPTR_TRACER",					AAPTR_TRACER },
+		{ "AAPTR_PLAYER1",					AAPTR_PLAYER1 },
+		{ "AAPTR_PLAYER2",					AAPTR_PLAYER2 },
+		{ "AAPTR_PLAYER3",					AAPTR_PLAYER3 },
+		{ "AAPTR_PLAYER4",					AAPTR_PLAYER4 },
+		{ "AAPTR_PLAYER5",					AAPTR_PLAYER5 },
+		{ "AAPTR_PLAYER6",					AAPTR_PLAYER6 },
+		{ "AAPTR_PLAYER7",					AAPTR_PLAYER7 },
+		{ "AAPTR_PLAYER8",					AAPTR_PLAYER8 },
+		{ "AAPTR_PLAYER_GETTARGET",			AAPTR_PLAYER_GETTARGET },
+		{ "AAPTR_PLAYER_GETCONVERSATION",	AAPTR_PLAYER_GETCONVERSATION },
+		{ "AAPTR_FRIENDPLAYER",				AAPTR_FRIENDPLAYER },
+		{ "AAPTR_GET_LINETARGET",			AAPTR_GET_LINETARGET },
+		{ NULL, 0 }
+	};
+
+	return ParseFlagExpressionString(sc, pointers);
+}
+
 //==========================================================================
 //
 // For getting a state address from the parent
@@ -901,6 +929,10 @@ static bool ParsePropertyParams(FScanner &sc, FPropertyInfo *prop, AActor *defau
 				
 			case 'N':	// special case. An expression-aware parser will not need this.
 				conv.i = ParseThingActivation(sc);
+				break;
+
+			case 'P':	// special case. An expression-aware parser will not need this.
+				conv.i = ParseThingPointer(sc);
 				break;
 
 			case 'L':	// Either a number or a list of strings

--- a/src/thingdef/thingdef_parse.cpp
+++ b/src/thingdef/thingdef_parse.cpp
@@ -750,7 +750,8 @@ static int ParseThingPointer(FScanner &sc)
 		{ "AAPTR_PLAYER_GETCONVERSATION",	AAPTR_PLAYER_GETCONVERSATION },
 		{ "AAPTR_FRIENDPLAYER",				AAPTR_FRIENDPLAYER },
 		{ "AAPTR_GET_LINETARGET",			AAPTR_GET_LINETARGET },
-		{ NULL, 0 }
+		{ NULL, 0 },
+		{ nullptr, 0 },
 	};
 
 	return ParseFlagExpressionString(sc, pointers);

--- a/src/thingdef/thingdef_properties.cpp
+++ b/src/thingdef/thingdef_properties.cpp
@@ -69,6 +69,7 @@
 #include "teaminfo.h"
 #include "v_video.h"
 #include "r_data/colormaps.h"
+#include "actorptrselect.h"
 
 
 //==========================================================================
@@ -565,7 +566,14 @@ DEFINE_PROPERTY(threshold, I, Actor)
 		I_Error("Threshold cannot be negative.");
 	defaults->threshold = id;
 }
-
+//==========================================================================
+// [FDARI]
+//==========================================================================
+DEFINE_PROPERTY(visiblefilter, P, Actor)
+{
+	PROP_INT_PARM(id, 0);
+	defaults->VisibleFilter = id;
+}
 //==========================================================================
 //
 //==========================================================================

--- a/src/thingdef/thingdef_properties.cpp
+++ b/src/thingdef/thingdef_properties.cpp
@@ -572,6 +572,8 @@ DEFINE_PROPERTY(threshold, I, Actor)
 DEFINE_PROPERTY(visiblefilter, P, Actor)
 {
 	PROP_INT_PARM(id, 0);
+	if (id < 0)
+		I_Error("VisibleFilter cannot be negative.");
 	defaults->VisibleFilter = id;
 }
 //==========================================================================

--- a/src/version.h
+++ b/src/version.h
@@ -76,7 +76,7 @@ const char *GetVersionString();
 
 // Use 4500 as the base git save version, since it's higher than the
 // SVN revision ever got.
-#define SAVEVER 4545
+#define SAVEVER 4546
 
 #define SAVEVERSTRINGIFY2(x) #x
 #define SAVEVERSTRINGIFY(x) SAVEVERSTRINGIFY2(x)

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -325,6 +325,7 @@ ACTOR Actor native //: Thinker
 	native state A_CheckSightOrRange(float distance, state label, bool two_dimension = false);
 	native state A_CheckRange(float distance, state label, bool two_dimension = false);
 	action native bool A_FaceMovementDirection(float offset = 0, float anglelimit = 0, float pitchlimit = 0, int flags = 0, int ptr = AAPTR_DEFAULT);
+	action native A_SetVisibleFilter(int visFilter, int ptr = AAPTR_DEFAULT);
 
 	native void A_RearrangePointers(int newtarget, int newmaster = AAPTR_DEFAULT, int newtracer = AAPTR_DEFAULT, int flags=0);
 	native void A_TransferPointer(int ptr_source, int ptr_recepient, int sourcefield, int recepientfield=AAPTR_DEFAULT, int flags=0);


### PR DESCRIPTION
- Added VisibleFilter, originally by FDARI.
- Assigning a pointer to the VisibilityFilter prevents other players except for the one matching this pointer from seeing it.
- FILTERHIDES inverses the effect: only that player cannot see the actor.
- A_SetVisibleFilter allows changing the pointer filtering upon itself or another actor.

https://github.com/rheit/acc/pull/49