### PR TITLE
Misc openal updates

### DIFF
--- a/src/sound/oalload.h
+++ b/src/sound/oalload.h
@@ -22,7 +22,7 @@ static oalloadentry oalfuncs[] = {
 { NULL, 0 }
 };
 
-
+#ifndef IN_IDE_PARSER
 #define alEnable p_alEnable
 #define alDisable p_alDisable
 #define alIsEnabled p_alIsEnabled
@@ -116,6 +116,7 @@ static oalloadentry oalfuncs[] = {
 #define alcCaptureStart p_alcCaptureStart
 #define alcCaptureStop p_alcCaptureStop
 #define alcCaptureSamples p_alcCaptureSamples
+#endif
 
 #endif
 #endif

--- a/src/sound/oalsound.cpp
+++ b/src/sound/oalsound.cpp
@@ -40,6 +40,8 @@
 #include <dlfcn.h>
 #endif
 
+#include <chrono>
+
 #include "except.h"
 #include "doomstat.h"
 #include "templates.h"
@@ -1472,7 +1474,7 @@ FISoundChannel *OpenALSoundRenderer::StartSound3D(SoundHandle sfx, SoundListener
     else
         alSourcef(source, AL_PITCH, PITCH(pitch));
 
-    if(!reuse_chan)
+    if(!reuse_chan || reuse_chan->StartTime.AsOne == 0)
         alSourcef(source, AL_SEC_OFFSET, 0.f);
     else
     {
@@ -1480,8 +1482,11 @@ FISoundChannel *OpenALSoundRenderer::StartSound3D(SoundHandle sfx, SoundListener
             alSourcef(source, AL_SEC_OFFSET, reuse_chan->StartTime.Lo/1000.f);
         else
         {
-            // FIXME: set offset based on the current time and the StartTime
-            alSourcef(source, AL_SAMPLE_OFFSET, 0.f);
+            float offset = std::chrono::duration_cast<std::chrono::duration<float>>(
+                std::chrono::steady_clock::now().time_since_epoch() -
+                std::chrono::steady_clock::time_point::duration(reuse_chan->StartTime.AsOne)
+            ).count();
+            if(offset > 0.f) alSourcef(source, AL_SEC_OFFSET, offset);
         }
     }
     if(getALError() != AL_NO_ERROR)
@@ -1819,7 +1824,7 @@ void OpenALSoundRenderer::MarkStartTime(FISoundChannel *chan)
 {
     // FIXME: Get current time (preferably from the audio clock, but the system
     // time will have to do)
-    chan->StartTime.AsOne = 0;
+    chan->StartTime.AsOne = std::chrono::steady_clock::now().time_since_epoch().count();
 }
 
 float OpenALSoundRenderer::GetAudibility(FISoundChannel *chan)

--- a/src/sound/oalsound.cpp
+++ b/src/sound/oalsound.cpp
@@ -1326,7 +1326,6 @@ FISoundChannel *OpenALSoundRenderer::StartSound(SoundHandle sfx, float vol, int 
     chan->Rolloff.RolloffType = ROLLOFF_Log;
     chan->Rolloff.RolloffFactor = 0.f;
     chan->Rolloff.MinDistance = 1.f;
-    chan->DistanceScale = 1.f;
     chan->DistanceSqr = 0.f;
     chan->ManualRolloff = false;
 
@@ -1510,7 +1509,6 @@ FISoundChannel *OpenALSoundRenderer::StartSound3D(SoundHandle sfx, SoundListener
     else chan->SysChannel = MAKE_PTRID(source);
 
     chan->Rolloff = *rolloff;
-    chan->DistanceScale = distscale;
     chan->DistanceSqr = dist_sqr;
     chan->ManualRolloff = manualRolloff;
 

--- a/src/sound/oalsound.cpp
+++ b/src/sound/oalsound.cpp
@@ -1634,12 +1634,18 @@ void OpenALSoundRenderer::SetInactive(SoundRenderer::EInactiveState state)
         case SoundRenderer::INACTIVE_Active:
             alListenerf(AL_GAIN, 1.0f);
             if(ALC.SOFT_pause_device)
+            {
                 alcDeviceResumeSOFT(Device);
+                getALCError(Device);
+            }
             break;
 
         case SoundRenderer::INACTIVE_Complete:
             if(ALC.SOFT_pause_device)
+            {
                 alcDevicePauseSOFT(Device);
+                getALCError(Device);
+            }
             /* fall-through */
         case SoundRenderer::INACTIVE_Mute:
             alListenerf(AL_GAIN, 0.0f);

--- a/src/sound/oalsound.cpp
+++ b/src/sound/oalsound.cpp
@@ -69,7 +69,7 @@ static void* hmodOpenAL;
 #ifdef __APPLE__
 #define OPENALLIB "OpenAL.framework/OpenAL"
 #else
-#define OPENALLIB "libopenal.so"
+#define OPENALLIB "libopenal.so.1"
 #endif
 #define LoadLibrary(x) dlopen((x), RTLD_LAZY)
 #define GetProcAddress(a,b) dlsym((a),(b))

--- a/src/sound/oalsound.cpp
+++ b/src/sound/oalsound.cpp
@@ -1045,7 +1045,7 @@ std::pair<SoundHandle,bool> OpenALSoundRenderer::LoadSoundRaw(BYTE *sfxdata, int
             {
                 int sum = 0;
                 for(int c = 0;c < channels;c++)
-                    sum = ((short*)sfxdata)[i*channels + c];
+                    sum += ((short*)sfxdata)[i*channels + c];
                 ((short*)sfxdata)[i] = sum / channels;
             }
         }
@@ -1055,7 +1055,7 @@ std::pair<SoundHandle,bool> OpenALSoundRenderer::LoadSoundRaw(BYTE *sfxdata, int
             {
                 int sum = 0;
                 for(int c = 0;c < channels;c++)
-                    sum = sfxdata[i*channels + c] - 128;
+                    sum += sfxdata[i*channels + c] - 128;
                 sfxdata[i] = (sum / channels) + 128;
             }
         }

--- a/src/sound/oalsound.cpp
+++ b/src/sound/oalsound.cpp
@@ -1431,7 +1431,8 @@ FISoundChannel *OpenALSoundRenderer::StartSound3D(SoundHandle sfx, SoundListener
             /* Since the OpenAL distance is decoupled from the sound's distance, get the OpenAL
              * distance that corresponds to the area radius. */
             alSourcef(source, AL_SOURCE_RADIUS, (chanflags&SNDF_AREA) ?
-                1.f / GetRolloff(rolloff, AREA_SOUND_RADIUS) : 0.f
+                // Clamp in case the max distance is <= the area radius
+                1.f/MAX<float>(GetRolloff(rolloff, AREA_SOUND_RADIUS), 0.00001f) : 0.f
             );
         }
         else if((chanflags&SNDF_AREA) && dist_sqr < AREA_SOUND_RADIUS*AREA_SOUND_RADIUS)

--- a/src/sound/oalsound.h
+++ b/src/sound/oalsound.h
@@ -129,6 +129,7 @@ private:
     struct {
         bool EXT_EFX;
         bool EXT_disconnect;
+        bool SOFT_pause_device;
     } ALC;
     struct {
         bool EXT_source_distance_model;
@@ -179,6 +180,9 @@ private:
 
     ALvoid (AL_APIENTRY*alDeferUpdatesSOFT)(void);
     ALvoid (AL_APIENTRY*alProcessUpdatesSOFT)(void);
+
+    void (ALC_APIENTRY*alcDevicePauseSOFT)(ALCdevice *device);
+    void (ALC_APIENTRY*alcDeviceResumeSOFT)(ALCdevice *device);
 
 	void LoadReverb(const ReverbContainer *env);
 	void PurgeStoppedSources();

--- a/src/sound/oalsound.h
+++ b/src/sound/oalsound.h
@@ -58,6 +58,11 @@
 #define AL_FORMAT_71CHN32                        0x1212
 #endif
 
+#ifndef AL_EXT_SOURCE_RADIUS
+#define AL_EXT_SOURCE_RADIUS 1
+#define AL_SOURCE_RADIUS                         0x1031
+#endif
+
 #include "efx.h"
 
 
@@ -127,6 +132,7 @@ private:
     } ALC;
     struct {
         bool EXT_source_distance_model;
+        bool EXT_SOURCE_RADIUS;
         bool SOFT_deferred_updates;
         bool SOFT_loop_points;
     } AL;


### PR DESCRIPTION
Notable changes:
* Use libopenal.so.1 on Linux instead of libopenal.so (the latter being part of dev packages, with the former being the run-time).
* Area sounds can now be handled with the ```AL_EXT_SOURCE_RADIUS``` extension. This isn't exactly the same behavior has FMOD, but it still follows the intent. Rather than just interpolating between 2D and 3D within the radius area, such sources are treated as if every point within the area is emanating the sound, effectively causing it to "widen" and lose locality as you get closer (volume remains consistent).
* A more proper start offset is calculated and set for sounds that are being restarted.
* ```SetInactive``` can use the ```ALC_SOFT_pause_device``` extension to pause processing, instead of just going mute.
* A small fix for monoization of raw sounds, to actually sum the channels instead of taking the right channel.