### PR TITLE
GetZAt DECORATE Function

### DIFF
--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -441,39 +441,38 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, GetZAt)
 				double c = angle.Cos();
 				pos = mobj->Vec2Offset(pos.X * c + pos.Y * s, pos.X * s - pos.Y * c);
 			}
+			sector_t *sec = P_PointInSector(pos);
 
-			int secnum = int(P_PointInSector(pos) - sectors);
-
-			if (secnum >= 0)
+			if (sec)
 			{
 				if (flags & GZF_CEILING)
 				{
 					if ((flags & GZF_NO3DFLOOR) && (flags & GZF_NOPORTALS))
 					{
-						z = sectors[secnum].ceilingplane.ZatPoint(pos);
+						z = sec->ceilingplane.ZatPoint(pos);
 					}
 					else if (flags & GZF_NO3DFLOOR)
 					{
-						z = sectors[secnum].HighestCeilingAt(pos);
+						z = sec->HighestCeilingAt(pos);
 					}
 					else
 					{	// [MC] Handle strict 3D floors and portal toggling via the flags passed to it.
-						z = sectors[secnum].NextHighestCeilingAt(pos.X, pos.Y, mobj->Z(), mobj->Top(), pflags);
+						z = sec->NextHighestCeilingAt(pos.X, pos.Y, mobj->Z(), mobj->Top(), pflags);
 					}
 				}
 				else
 				{
 					if ((flags & GZF_NO3DFLOOR) && (flags & GZF_NOPORTALS))
 					{
-						z = sectors[secnum].floorplane.ZatPoint(pos);
+						z = sec->floorplane.ZatPoint(pos);
 					}
 					else if (flags & GZF_NO3DFLOOR)
 					{
-						z = sectors[secnum].LowestFloorAt(pos);
+						z = sec->LowestFloorAt(pos);
 					}
 					else
 					{
-						z = sectors[secnum].NextLowestFloorAt(pos.X, pos.Y, mobj->Z(), pflags, mobj->MaxStepHeight);
+						z = sec->NextLowestFloorAt(pos.X, pos.Y, mobj->Z(), pflags, mobj->MaxStepHeight);
 					}
 				}
 			}

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -43,6 +43,7 @@ ACTOR Actor native //: Thinker
 	native int	CountInv(class<Inventory> itemtype, int ptr_select = AAPTR_DEFAULT);
 	native float GetDistance(bool checkz, int ptr = AAPTR_DEFAULT);
 	native float GetAngle(bool relative, int ptr = AAPTR_DEFAULT);
+	native float GetZAt(float px = 0, float py = 0, float angle = 0, int flags = 0, int pick_pointer = AAPTR_DEFAULT);
 	native int GetSpawnHealth();
 	native int GetGibHealth();
 

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -549,3 +549,11 @@ enum
 	FMDF_INTERPOLATE =		1 << 1,
 	FMDF_NOANGLE =			1 << 2,
 };
+
+// Flags for GetZAt
+enum
+{
+	GZF_ABSOLUTEPOS =			1,
+	GZF_ABSOLUTEANG =			1 << 1,
+	GZF_CEILING =				1 << 2,
+};

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -553,7 +553,10 @@ enum
 // Flags for GetZAt
 enum
 {
-	GZF_ABSOLUTEPOS =			1,
-	GZF_ABSOLUTEANG =			1 << 1,
-	GZF_CEILING =				1 << 2,
+	GZF_ABSOLUTEPOS =			1,			// Use the absolute position instead of an offsetted one.
+	GZF_ABSOLUTEANG =			1 << 1,		// Don't add the actor's angle to the parameter.
+	GZF_CEILING =				1 << 2,		// Check the ceiling instead of the floor.
+	GZF_3DRESTRICT =			1 << 3,		// Ignore midtextures and 3D floors above the pointer's z.
+	GZF_NOPORTALS =				1 << 4,		// Don't pass through any portals.
+	GZF_NO3DFLOOR =				1 << 5,		// Pass all 3D floors.
 };


### PR DESCRIPTION
- float GetZAt(x, y, angle, flags, pick_pointer);
- Gets the floor z  at x distance ahead and y distance to the side in relative form from the calling actor pointer. Flags are as follows (GZF_ prefix):
- CEILING: Returns the ceiling z instead of floor.
- ABSOLUTEPOS: x and y are absolute positions.
- ABSOLUTEANG: angle parameter does not add the pointer's angle to the angle parameter.
- 3DRESTRICT: Ignore midtextures and 3D floors whose floorz is above the actor's z.
- NOPORTALS: Don't check through portals, only the sector the check originates in.
- NO3DFLOORS: Ignore all 3D floors.