### PR TITLE
A_WeaponOffset

### DIFF
--- a/src/p_pspr.cpp
+++ b/src/p_pspr.cpp
@@ -785,6 +785,63 @@ DEFINE_ACTION_FUNCTION(AInventory, A_CheckReload)
 
 //---------------------------------------------------------------------------
 //
+// PROC A_WeaponOffset
+//
+//---------------------------------------------------------------------------
+enum WOFFlags
+{
+	WOF_KEEPX =		1,
+	WOF_KEEPY =		1 << 1,
+	WOF_ADD =		1 << 2,
+};
+
+DEFINE_ACTION_FUNCTION(AInventory, A_WeaponOffset)
+{
+	PARAM_ACTION_PROLOGUE;
+	PARAM_FLOAT_OPT(wx)		{ wx = 0.; }
+	PARAM_FLOAT_OPT(wy)		{ wy = 32.; }
+	PARAM_INT_OPT(flags)	{ flags = 0; }
+
+	if ((flags & WOF_KEEPX) && (flags & WOF_KEEPY))
+	{
+		return 0;
+	}
+
+	player_t *player = self->player;
+	pspdef_t *psp;
+
+	if (player && (player->playerstate != PST_DEAD))
+	{
+		psp = &player->psprites[ps_weapon];
+		if (!(flags & WOF_KEEPX))
+		{
+			if (flags & WOF_ADD)
+			{
+				psp->sx += wx;
+			}
+			else
+			{
+				psp->sx = wx;
+			}
+		}
+		if (!(flags & WOF_KEEPY))
+		{
+			if (flags & WOF_ADD)
+			{
+				psp->sy += wy;
+			}
+			else
+			{
+				psp->sy = wy;
+			}
+		}
+	}
+	
+	return 0;
+}
+
+//---------------------------------------------------------------------------
+//
 // PROC A_Lower
 //
 //---------------------------------------------------------------------------

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -561,3 +561,11 @@ enum
 	GZF_NOPORTALS =				1 << 4,		// Don't pass through any portals.
 	GZF_NO3DFLOOR =				1 << 5,		// Pass all 3D floors.
 };
+
+// Flags for A_WeaponOffset
+enum
+{
+	WOF_KEEPX =		1,
+	WOF_KEEPY =		1 << 1,
+	WOF_ADD =		1 << 2,
+};

--- a/wadsrc/static/actors/shared/inventory.txt
+++ b/wadsrc/static/actors/shared/inventory.txt
@@ -48,7 +48,7 @@ ACTOR Inventory native
 	action native A_RestoreSpecialDoomThing();
 	action native A_RestoreSpecialThing1();
 	action native A_RestoreSpecialThing2();
-	action native A_WeaponOFfset(float wx = 0, float wy = 32, int flags = 0);
+	action native A_WeaponOffset(float wx = 0, float wy = 32, int flags = 0);
 	
 	States
 	{

--- a/wadsrc/static/actors/shared/inventory.txt
+++ b/wadsrc/static/actors/shared/inventory.txt
@@ -48,6 +48,7 @@ ACTOR Inventory native
 	action native A_RestoreSpecialDoomThing();
 	action native A_RestoreSpecialThing1();
 	action native A_RestoreSpecialThing2();
+	action native A_WeaponOFfset(float wx = 0, float wy = 32, int flags = 0);
 	
 	States
 	{


### PR DESCRIPTION
- Added A_WeaponOffset(x = 0, y = 32, flags).
- Places the weapon offset by the defined x and y. Both are floats. This stacks with weapon bobbing.
- WOF_KEEPX: Don't change the X offset.
- WOF_KEEPY: Don't change the Y offset.
- WOF_ADD: Add onto instead of replacing the coordinates.