### PR TITLE
Fix for fullscreen on non-default monitor in OS X

### DIFF
--- a/src/posix/cocoa/i_video.mm
+++ b/src/posix/cocoa/i_video.mm
@@ -665,7 +665,6 @@ void CocoaVideo::SetFullscreenMode(const int width, const int height)
 	}
 
 	[m_window setFrame:screenFrame display:YES];
-	[m_window setFrameOrigin:NSMakePoint(0.0f, 0.0f)];
 }
 
 void CocoaVideo::SetWindowedMode(const int width, const int height)


### PR DESCRIPTION
Fullscreen window was incorrectly placed on the main screen instead of the current one
Honestly I have no idea what was the reason behind that [NSWindow setFrameOrigin:] call
Apparently it's redundant and moreover it's incorrect for multi-monitor configuration