### PR TITLE
- Added GetCrouchFactor(ptr).

### DIFF
--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -483,6 +483,36 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, GetZAt)
 	return 0;
 }
 
+//==========================================================================
+//
+// GetCrouchFactor
+//
+// NON-ACTION function to retrieve a player's crouching factor.
+//
+//==========================================================================
+
+DEFINE_ACTION_FUNCTION_PARAMS(AActor, GetCrouchFactor)
+{
+	if (numret > 0)
+	{
+		assert(ret != NULL);
+		PARAM_SELF_PROLOGUE(AActor);
+		PARAM_INT_OPT(ptr) { ptr = AAPTR_PLAYER1; }
+		AActor *mobj = COPY_AAPTR(self, ptr);
+
+		if (!mobj || !mobj->player)
+		{
+			ret->SetFloat(0);
+		}
+		else
+		{
+			ret->SetFloat(mobj->player->crouchfactor);
+		}
+		return 1;
+	}
+	return 0;
+}
+
 //===========================================================================
 //
 // __decorate_internal_state__

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -46,6 +46,7 @@ ACTOR Actor native //: Thinker
 	native float GetZAt(float px = 0, float py = 0, float angle = 0, int flags = 0, int pick_pointer = AAPTR_DEFAULT);
 	native int GetSpawnHealth();
 	native int GetGibHealth();
+	native float GetCrouchFactor(int ptr = AAPTR_PLAYER1);
 
 	// Action functions
 	// Meh, MBF redundant functions. Only for DeHackEd support.


### PR DESCRIPTION

Gets the crouch factor of a player. Can be set to target/master/tracer, as long as it's a player. Defaults to the first player.