### PR TITLE
Used ISO Latin 1 encoding for title text in startup window on OS X

### DIFF
--- a/src/posix/cocoa/st_console.mm
+++ b/src/posix/cocoa/st_console.mm
@@ -373,7 +373,8 @@ void FConsoleWindow::SetTitleText()
 	}
 
 	NSTextField* titleText = [[NSTextField alloc] initWithFrame:titleTextRect];
-	[titleText setStringValue:[NSString stringWithUTF8String:DoomStartupInfo.Name]];
+	[titleText setStringValue:[NSString stringWithCString:DoomStartupInfo.Name
+												 encoding:NSISOLatin1StringEncoding]];
 	[titleText setAlignment:NSCenterTextAlignment];
 	[titleText setTextColor:RGB(DoomStartupInfo.FgColor)];
 	[titleText setBackgroundColor:RGB(DoomStartupInfo.BkColor)];


### PR DESCRIPTION
Windows version uses ANSI_CHARSET to handle the corresponding text
This solves the problem like in https://github.com/alexey-lysiuk/gzdoom/issues/63:
```
*** Assertion failure in -[NSTextFieldCell _objectValue:forString:errorDescription:], /Library/Caches/com.apple.xbs/Sources/AppKit/AppKit-1404.47/AppKit.subproj/NSCell.m:1684
Invalid parameter not satisfying: aString != nil
```