### PR TITLE
A_ClearOverlays + A_Overlay Extension

### DIFF
--- a/src/p_pspr.cpp
+++ b/src/p_pspr.cpp
@@ -1190,7 +1190,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_ClearOverlays)
 		// [MC]Don't affect non-hardcoded layers unless it's really desired.
 		pspr->SetState(nullptr);
 		count++;
-		pspr->GetNext();
+		pspr = pspr->GetNext();
 	}
 	ACTION_RETURN_INT(count);
 }

--- a/src/p_pspr.cpp
+++ b/src/p_pspr.cpp
@@ -1174,8 +1174,10 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_ClearOverlays)
 		int id = pspr->GetID();
 
 		//Do not wipe out layer 0. Ever.
-		if (!id || id > stop || id < start)
+		if (!id || id < start)
 			continue;
+		if (id > stop)
+			break;
 
 		if (safety)
 		{

--- a/src/p_pspr.cpp
+++ b/src/p_pspr.cpp
@@ -1163,8 +1163,8 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_ClearOverlays)
 	player_t *player = self->player;
 	if (!start && !stop)
 	{
-		start = -INT_MAX;
-		stop = PSP_TARGETCENTER - 1;
+		start = INT_MIN;
+		stop = safety ? PSP_TARGETCENTER - 1 : INT_MAX;
 	}
 
 	int count = 0;

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -329,12 +329,13 @@ ACTOR Actor native //: Thinker
 	native state A_CheckSightOrRange(float distance, state label, bool two_dimension = false);
 	native state A_CheckRange(float distance, state label, bool two_dimension = false);
 	action native bool A_FaceMovementDirection(float offset = 0, float anglelimit = 0, float pitchlimit = 0, int flags = 0, int ptr = AAPTR_DEFAULT);
+	action native int A_ClearOverlays(int start = 0, int stop = 0, bool safety = true);
 
 	native void A_RearrangePointers(int newtarget, int newmaster = AAPTR_DEFAULT, int newtracer = AAPTR_DEFAULT, int flags=0);
 	native void A_TransferPointer(int ptr_source, int ptr_recepient, int sourcefield, int recepientfield=AAPTR_DEFAULT, int flags=0);
 	action native A_CopyFriendliness(int ptr_source = AAPTR_MASTER);
 
-	action native A_Overlay(int layer, state start = "");
+	action native bool A_Overlay(int layer, state start = "", bool nooverride = false);
 	action native A_WeaponOffset(float wx = 0, float wy = 32, int flags = 0);
 	action native A_OverlayOffset(int layer = PSP_WEAPON, float wx = 0, float wy = 32, int flags = 0);
 	action native A_OverlayFlags(int layer, int flags, bool set);


### PR DESCRIPTION
Added A_ClearOverlays(int start, int stop, bool safety).

- Clears a set of overlays in ranges [start,stop]. If unspecified, wipes all non-hardcoded layers. Safety determines whether to affect core layers or not (i.e. weapon). Returns the number of layers cleared.

Added no override boolean to A_Overlay and a boolean return type.

- If true, and a layer already has an active layer, the function returns false. Otherwise, sets the layer and returns true.