### PR TITLE
WOF_AUTOADJUST

### DIFF
--- a/src/p_pspr.cpp
+++ b/src/p_pspr.cpp
@@ -937,9 +937,10 @@ DEFINE_ACTION_FUNCTION(AInventory, A_CheckReload)
 //---------------------------------------------------------------------------
 enum WOFFlags
 {
-	WOF_KEEPX =		1,
-	WOF_KEEPY =		1 << 1,
-	WOF_ADD =		1 << 2,
+	WOF_KEEPX =			1,
+	WOF_KEEPY =			1 << 1,
+	WOF_ADD =			1 << 2,
+	WOF_AUTOADJUST =	1 << 3,
 };
 
 void A_OverlayOffset(AActor *self, int layer, double wx, double wy, int flags)
@@ -955,6 +956,10 @@ void A_OverlayOffset(AActor *self, int layer, double wx, double wy, int flags)
 	if (player && (player->playerstate != PST_DEAD))
 	{
 		psp = player->FindPSprite(layer);
+		if ((flags & WOF_AUTOADJUST) && (psp->Flags & PSPF_ADDWEAPON) && (psp->GetID() != PSP_WEAPON))
+		{
+			wy -= 32;
+		}
 
 		if (psp == nullptr)
 			return;

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -573,9 +573,10 @@ enum
 // Flags for A_WeaponOffset
 enum
 {
-	WOF_KEEPX =		1,
-	WOF_KEEPY =		1 << 1,
-	WOF_ADD =		1 << 2,
+	WOF_KEEPX =			1,
+	WOF_KEEPY =			1 << 1,
+	WOF_ADD =			1 << 2,
+	WOF_AUTOADJUST =	1 << 3,
 };
 
 // Flags for psprite layers


### PR DESCRIPTION
- Added WOF_AUTOADJUST
- When using A_Overlay/WeaponOffset on layers that follow the weapon's offsets, having a default value of 32 could offset the overlay and cause confusion. This flag will cause the function to detect for such a case and automatically subtract 32 units from the Y value, for the sake of compatibility and ease.