### PR TITLE
Fixed unknown actor class error in Strife

### DIFF
--- a/wadsrc/static/actors/strife/questitems.txt
+++ b/wadsrc/static/actors/strife/questitems.txt
@@ -44,6 +44,16 @@ ACTOR QuestItem : Inventory
 	}
 }
 
+ACTOR QuestItemThatDoesNotExist : CustomInventory
+{
+	States
+	{
+	Pickup:
+		TNT1 A 0
+		Fail
+	}
+}
+
 // Quest Items -------------------------------------------------------------
 
 ACTOR QuestItem1 : QuestItem


### PR DESCRIPTION
No more error ACS: I don't know what 'QuestItemThatDoesNotExist' is
Walk through an arch on Strife's MAP02 near position -230 6480