### PR TITLE
Fix single layer skies by using a cube box rather than a cylinder

### DIFF
--- a/src/r_plane.cpp
+++ b/src/r_plane.cpp
@@ -845,21 +845,17 @@ static BYTE skybuf[4][512];
 static DWORD lastskycol[4];
 static int skycolplace;
 
-// Treat sky as a cube rather than a cylinder
-CVAR(Bool, r_cubesky, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG);
+CVAR(Bool, r_linearsky, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG);
 
 // Get a column of sky when there is only one sky texture.
 static const BYTE *R_GetOneSkyColumn (FTexture *fronttex, int x)
 {
 	int tx;
-	if (r_cubesky)
+	if (r_linearsky)
 	{
-		int tx0 = (UMulScale16((skyangle + xtoviewangle[0]) ^ skyflip, frontcyl) + frontpos) >> FRACBITS;
-		int tx1 = tx0 - ((UMulScale16(xtoviewangle[0], frontcyl) * 2) >> FRACBITS);
-		tx = (int)(tx0 + (tx1 - tx0) * x / viewwidth + 0.5);
-		tx %= fronttex->GetWidth();
-		if (tx < 0)
-			tx += fronttex->GetWidth();
+		angle_t xangle = (angle_t)((0.5 - x / (double)viewwidth) * FocalTangent * ANGLE_90);
+		angle_t column = (skyangle + xangle) ^ skyflip;
+		tx = (UMulScale16(column, frontcyl) + frontpos) >> FRACBITS;
 	}
 	else
 	{


### PR DESCRIPTION
Fixes the stretched skies by using a cube instead of a cylinder for texture mapping.
Only fixes it for single layer skies as the caching method used in R_GetTwoSkyColumns cannot easily be changed to do the right thing.