### PR TITLE
[Mar29+] bitshift issue with User-Variables during save/load

### DIFF
--- a/src/farchive.cpp
+++ b/src/farchive.cpp
@@ -728,13 +728,13 @@ void FArchive::WriteByte(BYTE val)
 
 void FArchive::WriteInt16(WORD val)
 {
-	WORD out = LittleShort(val);
+	WORD out = SWAP_WORD(val);
 	m_File->Write(&out, 2);
 }
 
 void FArchive::WriteInt32(DWORD val)
 {
-	int out = LittleLong(val);
+	int out = SWAP_DWORD(val);
 	m_File->Write(&out, 4);
 }
 


### PR DESCRIPTION
Implemented fix discussed in http://forum.zdoom.org/viewtopic.php?f=2&t=52428 regarding UserVar corruption in savegames

Tested both with int and fixed type uservars and this change corrects the error in both cases.