### PR TITLE
Fixed bad serialization of float types

### DIFF
--- a/src/dobjtype.cpp
+++ b/src/dobjtype.cpp
@@ -1272,6 +1272,7 @@ void PFloat::WriteValue(FArchive &ar, const void *addr) const
 		{
 			ar.WriteByte(VAL_Float64);
 			ar << doubleprecision;
+			return;
 		}
 	}
 	else


### PR DESCRIPTION
The value was written twice if it couldn't be reduced to a single precision value