### PR TITLE
Fixed instant boss brain spawning

### DIFF
--- a/src/g_doom/a_bossbrain.cpp
+++ b/src/g_doom/a_bossbrain.cpp
@@ -147,7 +147,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_BrainSpit)
 			{
 				spit->special2 = 0;
 			}
-			else if (fabs(spit->Vel.X) > fabs(spit->Vel.Y))
+			else if (fabs(spit->Vel.Y) > fabs(spit->Vel.X))
 			{
 				spit->special2 = int((targ->Y() - self->Y()) / spit->Vel.Y);
 			}


### PR DESCRIPTION
There was a possibility of division by zero which led to nonsensical spawn time
http://forum.zdoom.org/viewtopic.php?t=52760