### PR TITLE
Fix delegate protocol for macOS application controller

### DIFF
--- a/src/posix/cocoa/i_main.mm
+++ b/src/posix/cocoa/i_main.mm
@@ -220,8 +220,8 @@ int OriginalMain(int argc, char** argv)
 
 
 @interface ApplicationController : NSResponder
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
-	<NSFileManagerDelegate>
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
+	<NSApplicationDelegate>
 #endif
 {
 }


### PR DESCRIPTION
Fixes compilation error with Xcode 8:
cannot initialize a parameter of type 'id<NSApplicationDelegate> _Nullable' with an lvalue of type 'ApplicationController *'