### PR TITLE
Fixed: The player failed to unmorph upon resurrection

### DIFF
--- a/src/m_cheat.cpp
+++ b/src/m_cheat.cpp
@@ -348,7 +348,7 @@ void cht_DoCheat (player_t *player, int cheat)
 					P_SetPsprite(player, PSP_WEAPON, player->ReadyWeapon->GetUpState());
 				}
 
-				if (player->morphTics > 0)
+				if (player->morphTics)
 				{
 					P_UndoPlayerMorph(player, player);
 				}


### PR DESCRIPTION
This happened if the morphing was triggered by a PowerMorph power-up.