### PR TITLE
- Fixed resurrect cheat not unmorphing sometimes.

### DIFF
--- a/src/m_cheat.cpp
+++ b/src/m_cheat.cpp
@@ -348,7 +348,7 @@ void cht_DoCheat (player_t *player, int cheat)
 					P_SetPsprite(player, PSP_WEAPON, player->ReadyWeapon->GetUpState());
 				}
 
-				if (player->morphTics > 0)
+				if (player->morphTics)
 				{
 					P_UndoPlayerMorph(player, player);
 				}


### PR DESCRIPTION
The resurrect code didn't take into account that the morph powerup starts the morph mechanism with infinite duration (because the powerup duration is handled by the powerup itself), hence it gives the player negative morphTics.