### PR TITLE
Added support for older versions of DeHackEd patches

### DIFF
--- a/src/d_dehacked.cpp
+++ b/src/d_dehacked.cpp
@@ -2507,7 +2507,7 @@ static bool DoDehPatch()
 	cont = 0;
 	if (0 == strncmp (PatchFile, "Patch File for DeHackEd v", 25))
 	{
-		if (PatchFile[25] < '3')
+		if (PatchFile[25] < '3' && PatchFile[25] != '2' && PatchFile[27] != '3')
 		{
 			Printf (PRINT_BOLD, "\"%s\" is an old and unsupported DeHackEd patch\n", PatchName);
 			delete[] PatchName;
@@ -2544,7 +2544,7 @@ static bool DoDehPatch()
 		{}
 	}
 
-	if (pversion != 6)
+	if (pversion != 5 && pversion != 6)
 	{
 		Printf ("DeHackEd patch version is %d.\nUnexpected results may occur.\n", pversion);
 	}


### PR DESCRIPTION
Patches from DeHackEd 2.3 and 2.4 are now loaded without warnings/errors