### PR TITLE
Added KILL Script type and associated flags and GameInfo keyword. (Death Scripts 2.0)

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -380,6 +380,8 @@ enum ActorFlag7
 	MF7_LAXTELEFRAGDMG	= 0x00100000,	// [MC] Telefrag damage can be reduced.
 	MF7_ICESHATTER		= 0x00200000,	// [MC] Shatters ice corpses regardless of damagetype.
 	MF7_ALLOWTHRUFLAGS	= 0x00400000,	// [MC] Allow THRUACTORS and the likes on puffs to prevent mod breakage.
+	MF7_USEKILLSCRIPTS	= 0x00800000,	// [JM] Use "KILL" Script on death if not forced by GameInfo.
+	MF7_NOKILLSCRIPTS	= 0x01000000,	// [JM] No "KILL" Script on death whatsoever, even if forced by GameInfo.
 };
 
 // --- mobj.renderflags ---

--- a/src/gi.cpp
+++ b/src/gi.cpp
@@ -354,6 +354,7 @@ void FMapInfoParser::ParseGameInfo()
 		GAMEINFOKEY_PATCH(mStatscreenFinishedFont, "statscreen_finishedpatch")
 		GAMEINFOKEY_PATCH(mStatscreenEnteringFont, "statscreen_enteringpatch")
 		GAMEINFOKEY_BOOL(norandomplayerclass, "norandomplayerclass")
+		GAMEINFOKEY_BOOL(forcekillscripts, "forcekillscripts") // [JM] Force kill scripts on thing death. (MF7_NOKILLSCRIPTS overrides.)
 
 		else
 		{

--- a/src/gi.h
+++ b/src/gi.h
@@ -173,6 +173,7 @@ struct gameinfo_t
 	FGIFont mStatscreenFinishedFont;
 	FGIFont mStatscreenEnteringFont;
 	bool norandomplayerclass;
+	bool forcekillscripts;
 
 	const char *GetFinalePage(unsigned int num) const;
 };

--- a/src/p_acs.h
+++ b/src/p_acs.h
@@ -270,6 +270,8 @@ enum
 	SCRIPT_Unloading	= 13,
 	SCRIPT_Disconnect	= 14,
 	SCRIPT_Return		= 15,
+	SCRIPT_Event		= 16, // [BB]
+	SCRIPT_Kill			= 17, // [JM]
 };
 
 // Script flags

--- a/src/p_interaction.cpp
+++ b/src/p_interaction.cpp
@@ -379,6 +379,12 @@ void AActor::Die (AActor *source, AActor *inflictor, int dmgflags)
 		target = source;
 	}
 
+	// [JM] Fire KILL type scripts for actor. Not needed for players, since they have the "DEATH" script type.
+	if (!player && !(flags7 & MF7_NOKILLSCRIPTS) && ((flags7 & MF7_USEKILLSCRIPTS) || gameinfo.forcekillscripts))
+	{
+		FBehavior::StaticStartTypedScripts(SCRIPT_Kill, this, true, 0, true);
+	}
+
 	flags &= ~(MF_SHOOTABLE|MF_FLOAT|MF_SKULLFLY);
 	if (!(flags4 & MF4_DONTFALL)) flags&=~MF_NOGRAVITY;
 	flags |= MF_DROPOFF;

--- a/src/thingdef/thingdef_data.cpp
+++ b/src/thingdef/thingdef_data.cpp
@@ -257,6 +257,8 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF7, LAXTELEFRAGDMG, AActor, flags7),
 	DEFINE_FLAG(MF7, ICESHATTER, AActor, flags7),
 	DEFINE_FLAG(MF7, ALLOWTHRUFLAGS, AActor, flags7),
+	DEFINE_FLAG(MF7, USEKILLSCRIPTS, AActor, flags7),
+	DEFINE_FLAG(MF7, NOKILLSCRIPTS, AActor, flags7),
 
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),


### PR DESCRIPTION
This is different from the original "Death Scripts" idea. This tackles
some issues I've found with the original idea. Now you can have as many
scripts as you want, not just global and actor-defined. It also stacks with other mods, accomplishing the "universal-ness" I originally desired, while taking care of the other complaints about the original idea and pull request.

It's also much simpler. But also needs changes to ACC: https://github.com/rheit/acc/pull/55

Decorate:
+USEKILLSCRIPTS // Use "KILL" Script on death if not forced by GameInfo.
+NOKILLSCRIPTS // No "KILL" Script on death whatsoever, even if forced by GameInfo.

GameInfo:
forcekillscripts = <bool> // Forces all killed actors to fire KILL scripts.

