### PR TITLE
A_CopySpriteFrame

### DIFF
--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -7188,3 +7188,34 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FaceMovementDirection)
 	ACTION_RETURN_BOOL(true);
 }
 
+//==========================================================================
+//
+// A_CopySpriteFrame(from, to, flags)
+//
+// Copies the sprite and/or frame from one pointer to another.
+//==========================================================================
+enum CPSFFlags
+{
+	CPSF_NOSPRITE =			1,
+	CPSF_NOFRAME =			1 << 1,
+};
+
+DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_CopySpriteFrame)
+{
+	PARAM_SELF_PROLOGUE(AActor);
+	PARAM_INT(from);
+	PARAM_INT(to);
+	PARAM_INT_OPT(flags) { flags = 0; }
+
+	AActor *copyfrom = COPY_AAPTR(self, from);
+	AActor *copyto = COPY_AAPTR(self, to);
+
+	if (copyfrom == copyto || copyfrom == nullptr || copyto == nullptr || ((flags & CPSF_NOSPRITE) && (flags & CPSF_NOFRAME)))
+	{
+		ACTION_RETURN_BOOL(false);
+	}
+	
+	if (!(flags & CPSF_NOSPRITE))	copyto->sprite = copyfrom->sprite;
+	if (!(flags & CPSF_NOFRAME))	copyto->frame = copyfrom->frame;
+	ACTION_RETURN_BOOL(true);
+}

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -330,6 +330,7 @@ ACTOR Actor native //: Thinker
 	native state A_CheckRange(float distance, state label, bool two_dimension = false);
 	action native bool A_FaceMovementDirection(float offset = 0, float anglelimit = 0, float pitchlimit = 0, int flags = 0, int ptr = AAPTR_DEFAULT);
 	action native int A_ClearOverlays(int sstart = 0, int sstop = 0, bool safety = true);
+	action native bool A_CopySpriteFrame(int from, int to, int flags = 0);
 
 	native void A_RearrangePointers(int newtarget, int newmaster = AAPTR_DEFAULT, int newtracer = AAPTR_DEFAULT, int flags=0);
 	native void A_TransferPointer(int ptr_source, int ptr_recepient, int sourcefield, int recepientfield=AAPTR_DEFAULT, int flags=0);

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -164,6 +164,7 @@ const int MRF_UNDOBYDEATH = 512;
 const int MRF_UNDOBYDEATHFORCED = 1024;
 const int MRF_UNDOBYDEATHSAVES = 2048;
 const int MRF_UNDOALWAYS = 4096;
+const int MRF_TRANSFERTRANSLATION = 8192;
 
 // Flags for A_RailAttack and A_CustomRailgun
 const int RGF_SILENT = 1;

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -164,7 +164,6 @@ const int MRF_UNDOBYDEATH = 512;
 const int MRF_UNDOBYDEATHFORCED = 1024;
 const int MRF_UNDOBYDEATHSAVES = 2048;
 const int MRF_UNDOALWAYS = 4096;
-const int MRF_TRANSFERTRANSLATION = 8192;
 
 // Flags for A_RailAttack and A_CustomRailgun
 const int RGF_SILENT = 1;
@@ -666,4 +665,11 @@ enum
 {
 	GAF_RELATIVE =			1,
 	GAF_SWITCH =			1 << 1,
+};
+
+//Flags for A_CopySpriteFrame
+enum
+{
+	CPSF_NOSPRITE =			1,
+	CPSF_NOFRAME =			1 << 1,
 };


### PR DESCRIPTION
Added A_CopySpriteFrame(from, to, flags).

- Copies a sprite/frame from one actor pointer to another. Sprite and/or frame copying can be disabled with flags CPSF_NO(SPRITE/FRAME).