### PR TITLE
added SWF_SELECTPRIORITY flag to A_SelectWeapon

### DIFF
--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -3103,12 +3103,19 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_Recoil)
 // A_SelectWeapon
 //
 //===========================================================================
+enum SW_Flags
+{
+	SWF_SELECTPRIORITY = 1,
+};
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SelectWeapon)
 {
 	PARAM_SELF_PROLOGUE(AActor);
 	PARAM_CLASS(cls, AWeapon);
+	PARAM_INT_OPT(flags) { flags = 0; }
 
-	if (cls == NULL || self->player == NULL) 
+	bool selectPriority = !!(flags & SWF_SELECTPRIORITY);
+
+	if ((!selectPriority && cls == NULL) || self->player == NULL)
 	{
 		ACTION_RETURN_BOOL(false);
 	}
@@ -3121,6 +3128,14 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SelectWeapon)
 		{
 			self->player->PendingWeapon = weaponitem;
 		}
+		ACTION_RETURN_BOOL(true);
+	}
+	else if (selectPriority)
+	{
+		// [XA] if the named weapon cannot be found (or is a dummy like 'None'),
+		//      select the next highest priority weapon. This is basically
+		//      the same as A_CheckReload minus the ammo check. Handy.
+		self->player->mo->PickNewWeapon(NULL);
 		ACTION_RETURN_BOOL(true);
 	}
 	else

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -265,7 +265,7 @@ ACTOR Actor native //: Thinker
 	native state A_CheckLOF(state jump, int flags = 0, float range = 0, float minrange = 0, float angle = 0, float pitch = 0, float offsetheight = 0, float offsetwidth = 0, int ptr_target = AAPTR_DEFAULT, float offsetforward = 0);
 	native state A_JumpIfTargetInLOS (state label, float/*angle*/ fov = 0, int flags = 0, float dist_max = 0, float dist_close = 0);
 	native state A_JumpIfInTargetLOS (state label, float/*angle*/ fov = 0, int flags = 0, float dist_max = 0, float dist_close = 0);
-	native bool A_SelectWeapon(class<Weapon> whichweapon);
+	native bool A_SelectWeapon(class<Weapon> whichweapon, int flags = 0);
 	action native A_Punch();
 	action native A_Feathers();
 	action native A_ClassBossHealth();

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -150,6 +150,9 @@ const int WRF_ALLOWUSER2 = 256;
 const int WRF_ALLOWUSER3 = 512;
 const int WRF_ALLOWUSER4 = 1024;
 
+// Flags for A_SelectWeapon
+const int SWF_SELECTPRIORITY = 1;
+
 // Morph constants
 const int MRF_ADDSTAMINA = 1;
 const int MRF_FULLHEALTH = 2;


### PR DESCRIPTION
Added a new flag to A_SelectWeapon: SWF_SELECTPRIORITY.

When set, this flag will instruct A_SelectWeapon to switch to the highest priority weapon (in the same vein as running out of ammo) if the weapon specified in the first parameter cannot be selected (either because it's not in the player's inventory or it isn't a weapon).

As an added bonus, you can put "None" as the first parameter and get A_CheckReload's behavior minus the ammo check. This is useful if you're trying to simulate an out-of-ammo check without actually having an empty weapon.

Test wad:
http://static.angryscience.net/pub/doom/xatest/zd_selectweapon-priority.wad

Summon "TestShotgun" and "TestChaingun":
- TestShotgun's Altfire will attempt to select TestChaingun; if not present, it will pick the highest priority weapon.
- TestChaingun's altfire will unconditionally select the highest priority weapon.