### PR TITLE
Fixed compilation with Clang and GCC

### DIFF
--- a/src/thingdef/thingdef_expression.cpp
+++ b/src/thingdef/thingdef_expression.cpp
@@ -4212,7 +4212,7 @@ ExpEmit FxJumpStatement::Emit(VMFunctionBuilder *build)
 {
 	if (AddressResolver == nullptr)
 	{
-		ScriptPosition.Message(MSG_ERROR, "Jump statement %s has nowhere to go!", FScanner::TokenName(Token));
+		ScriptPosition.Message(MSG_ERROR, "Jump statement %s has nowhere to go!", FScanner::TokenName(Token).GetChars());
 	}
 
 	Address = build->Emit(OP_JMP, 0);


### PR DESCRIPTION
No more "error: cannot pass object of non-trivial type 'FString' through variadic method; call will abort at runtime"