### PR TITLE
Fixed usages of abs() function with double arguments

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -1566,7 +1566,7 @@ bool P_CheckPosition(AActor *thing, const DVector2 &pos, FCheckPosition &tm, boo
 				tm.floorpic = *rover->top.texture;
 				tm.floorterrain = rover->model->GetTerrain(rover->top.isceiling);
 			}
-			if (ff_bottom < tm.ceilingz && abs(delta1) >= abs(delta2))
+			if (ff_bottom < tm.ceilingz && fabs(delta1) >= fabs(delta2))
 			{
 				tm.ceilingz = ff_bottom;
 				tm.ceilingpic = *rover->bottom.texture;

--- a/src/r_things.cpp
+++ b/src/r_things.cpp
@@ -916,7 +916,7 @@ void R_ProjectSprite (AActor *thing, int fakeside, F3DFloor *fakefloor, F3DFloor
 	// too far off the side?
 	// if it's a voxel, it can be further off the side
 	if ((voxel == NULL && (fabs(tx / 64) > fabs(tz))) ||
-		(voxel != NULL && (fabs(tx / 128) > abs(tz))))
+		(voxel != NULL && (fabs(tx / 128) > fabs(tz))))
 	{
 		return;
 	}


### PR DESCRIPTION
Clang no longer issues "warning: using integer absolute value function 'abs' when argument is of floating point type"