### PR TITLE
A_Explode Return Count

### DIFF
--- a/src/p_local.h
+++ b/src/p_local.h
@@ -392,7 +392,7 @@ enum
 	RADF_NODAMAGE = 8,
 	RADF_THRUSTZ = 16,
 };
-void	P_RadiusAttack (AActor *spot, AActor *source, int damage, int distance, 
+int	P_RadiusAttack (AActor *spot, AActor *source, int damage, int distance, 
 						FName damageType, int flags, int fulldamagedistance=0);
 
 void	P_DelSector_List();

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -5242,11 +5242,11 @@ CUSTOM_CVAR(Float, splashfactor, 1.f, CVAR_SERVERINFO)
 //
 //==========================================================================
 
-void P_RadiusAttack(AActor *bombspot, AActor *bombsource, int bombdamage, int bombdistance, FName bombmod,
+int P_RadiusAttack(AActor *bombspot, AActor *bombsource, int bombdamage, int bombdistance, FName bombmod,
 	int flags, int fulldamagedistance)
 {
 	if (bombdistance <= 0)
-		return;
+		return 0;
 	fulldamagedistance = clamp<int>(fulldamagedistance, 0, bombdistance - 1);
 
 	double bombdistancefloat = 1. / (double)(bombdistance - fulldamagedistance);
@@ -5261,6 +5261,7 @@ void P_RadiusAttack(AActor *bombspot, AActor *bombsource, int bombdamage, int bo
 		bombsource = bombspot;
 	}
 
+	int count = 0;
 	while ((it.Next(&cres)))
 	{
 		AActor *thing = cres.thing;
@@ -5356,7 +5357,12 @@ void P_RadiusAttack(AActor *bombspot, AActor *bombsource, int bombdamage, int bo
 				int newdam = damage;
 
 				if (!(flags & RADF_NODAMAGE))
+				{
+					//[MC] Don't count actors saved by buddha if already at 1 health.
+					int prehealth = thing->health;
 					newdam = P_DamageMobj(thing, bombspot, bombsource, damage, bombmod);
+					if (thing->health < prehealth)	count++;
+				}
 				else if (thing->player == NULL && (!(flags & RADF_NOIMPACTDAMAGE) && !(thing->flags7 & MF7_DONTTHRUST)))
 					thing->flags2 |= MF2_BLASTED;
 
@@ -5422,12 +5428,16 @@ void P_RadiusAttack(AActor *bombspot, AActor *bombsource, int bombdamage, int bo
 				damage = int(damage * factor);
 				if (damage > 0)
 				{
+					//[MC] Don't count actors saved by buddha if already at 1 health.
+					int prehealth = thing->health;
 					int newdam = P_DamageMobj(thing, bombspot, bombsource, damage, bombmod);
 					P_TraceBleed(newdam > 0 ? newdam : damage, thing, bombspot);
+					if (thing->health < prehealth)	count++;
 				}
 			}
 		}
 	}
+	return count;
 }
 
 //==========================================================================

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -1414,13 +1414,13 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_Explode)
 		}
 	}
 
-	P_RadiusAttack (self, self->target, damage, distance, self->DamageType, flags, fulldmgdistance);
+	int count = P_RadiusAttack (self, self->target, damage, distance, self->DamageType, flags, fulldmgdistance);
 	P_CheckSplash(self, distance);
 	if (alert && self->target != NULL && self->target->player != NULL)
 	{
 		P_NoiseAlert(self->target, self);
 	}
-	return 0;
+	ACTION_RETURN_INT(count);
 }
 
 //==========================================================================

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -253,7 +253,7 @@ ACTOR Actor native //: Thinker
 	action native A_Blast(int flags = 0, float strength = 255, float radius = 255, float speed = 20, class<Actor> blasteffect = "BlastEffect", sound blastsound = "BlastRadius");
 	action native A_RadiusThrust(int force = 128, int distance = -1, int flags = RTF_AFFECTSOURCE, int fullthrustdistance = 0);
 	action native A_RadiusDamageSelf(int damage = 128, float distance = 128, int flags = 0, class<Actor> flashtype = "None");
-	action native A_Explode(int damage = -1, int distance = -1, int flags = XF_HURTSOURCE, bool alert = false, int fulldamagedistance = 0, int nails = 0, int naildamage = 10, class<Actor> pufftype = "BulletPuff");
+	action native int A_Explode(int damage = -1, int distance = -1, int flags = XF_HURTSOURCE, bool alert = false, int fulldamagedistance = 0, int nails = 0, int naildamage = 10, class<Actor> pufftype = "BulletPuff");
 	action native A_Stop();
 	action native A_Respawn(int flags = 1);
 	action native A_BarrelDestroy();


### PR DESCRIPTION
A_Explode now returns the number of actors damaged and can be used in expressions.

- Enemies that do not take damage in any way are not counted.