### PR TITLE
Use verbose error message with DECORATE array indices

### DIFF
--- a/src/thingdef/thingdef_expression.cpp
+++ b/src/thingdef/thingdef_expression.cpp
@@ -3585,7 +3585,8 @@ ExpEmit FxArrayElement::Emit(VMFunctionBuilder *build)
 		unsigned indexval = static_cast<FxConstant *>(index)->GetValue().GetInt();
 		if (indexval >= arraytype->ElementCount)
 		{
-			I_Error("Array index out of bounds");
+			I_Error("Array index out of bounds, \"%s\" line %d\n",
+				ScriptPosition.FileName.GetChars(), ScriptPosition.ScriptLine);
 		}
 		indexval *= arraytype->ElementSize;
 


### PR DESCRIPTION
To address the issue raised by Major Cooke [here](http://forum.zdoom.org/viewtopic.php?f=2&t=53148).