### PR TITLE
A_Explode Damagetype + Flag

### DIFF
--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -1373,8 +1373,9 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_JumpIfArmorType)
 
 enum
 {
-	XF_HURTSOURCE = 1,
-	XF_NOTMISSILE = 4,
+	XF_HURTSOURCE =		1,
+	XF_NOTMISSILE =		4,
+	XF_NOACTORTYPE =	1 << 3,
 };
 
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_Explode)
@@ -1388,6 +1389,7 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_Explode)
 	PARAM_INT_OPT	(nails)			   { nails = 0; }
 	PARAM_INT_OPT	(naildamage)	   { naildamage = 10; }
 	PARAM_CLASS_OPT	(pufftype, AActor) { pufftype = PClass::FindActor(NAME_BulletPuff); }
+	PARAM_NAME_OPT	(damagetype)		{ damagetype = NAME_None; }
 
 	if (damage < 0)	// get parameters from metadata
 	{
@@ -1415,6 +1417,12 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_Explode)
 	}
 
 	int count = P_RadiusAttack (self, self->target, damage, distance, self->DamageType, flags, fulldmgdistance);
+	if (!(flags & XF_NOACTORTYPE) && damagetype == NAME_None)
+	{
+		damagetype = self->DamageType;
+	}
+
+	P_RadiusAttack (self, self->target, damage, distance, damagetype, flags, fulldmgdistance);
 	P_CheckSplash(self, distance);
 	if (alert && self->target != NULL && self->target->player != NULL)
 	{

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -253,7 +253,7 @@ ACTOR Actor native //: Thinker
 	action native A_Blast(int flags = 0, float strength = 255, float radius = 255, float speed = 20, class<Actor> blasteffect = "BlastEffect", sound blastsound = "BlastRadius");
 	action native A_RadiusThrust(int force = 128, int distance = -1, int flags = RTF_AFFECTSOURCE, int fullthrustdistance = 0);
 	action native A_RadiusDamageSelf(int damage = 128, float distance = 128, int flags = 0, class<Actor> flashtype = "None");
-	action native int A_Explode(int damage = -1, int distance = -1, int flags = XF_HURTSOURCE, bool alert = false, int fulldamagedistance = 0, int nails = 0, int naildamage = 10, class<Actor> pufftype = "BulletPuff");
+	action native int A_Explode(int damage = -1, int distance = -1, int flags = XF_HURTSOURCE, bool alert = false, int fulldamagedistance = 0, int nails = 0, int naildamage = 10, class<Actor> pufftype = "BulletPuff", name damagetype = "none");
 	action native A_Stop();
 	action native A_Respawn(int flags = 1);
 	action native A_BarrelDestroy();

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -185,6 +185,7 @@ const int MSF_DontHurt = 2;
 // Flags for A_Explode
 const int XF_HURTSOURCE = 1;
 const int XF_NOTMISSILE = 4;
+const int XF_NOACTORTYPE = 1 << 3;
 
 // Flags for A_RadiusThrust
 const int RTF_AFFECTSOURCE = 1;


### PR DESCRIPTION
Added damagetype parameter and XF_NOACTORTYPE to A_Explode.
- By default, A_Explode will refer to the actor's damagetype if using none. The flag forces the function's type if used regardless of type.