### PR TITLE
FastProjectile Enhancements

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -283,7 +283,7 @@ enum ActorFlag4
 enum ActorFlag5
 {
 	MF5_DONTDRAIN		= 0x00000001,	// cannot be drained health from.
-	/*		FREE SLOT	  0x00000002*/
+	MF5_GETOWNER		= 0x00000002,
 	MF5_NODROPOFF		= 0x00000004,	// cannot drop off under any circumstances.
 	MF5_NOFORWARDFALL	= 0x00000008,	// Does not make any actor fall forward by being damaged by this
 	MF5_COUNTSECRET		= 0x00000010,	// From Doom 64: actor acts like a secret

--- a/src/g_shared/a_fastprojectile.cpp
+++ b/src/g_shared/a_fastprojectile.cpp
@@ -166,8 +166,14 @@ void AFastProjectile::Effect()
 		if (trail != NULL)
 		{
 			AActor *act = Spawn (trail, PosAtZ(hitz), ALLOW_REPLACE);
-			if (act != NULL)
+			if (act != nullptr)
 			{
+				if ((flags5 & MF5_GETOWNER) && (target != nullptr))
+					act->target = target;
+				else
+					act->target = this;
+				
+				act->Angles.Pitch = Angles.Pitch;
 				act->Angles.Yaw = Angles.Yaw;
 			}
 		}

--- a/src/thingdef/thingdef_data.cpp
+++ b/src/thingdef/thingdef_data.cpp
@@ -182,6 +182,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF4, BOSSDEATH, AActor, flags4),
 
 	DEFINE_FLAG(MF5, DONTDRAIN, AActor, flags5),
+	DEFINE_FLAG(MF5, GETOWNER, AActor, flags5),
 	DEFINE_FLAG(MF5, NODROPOFF, AActor, flags5),
 	DEFINE_FLAG(MF5, NOFORWARDFALL, AActor, flags5),
 	DEFINE_FLAG(MF5, COUNTSECRET, AActor, flags5),


### PR DESCRIPTION
Enhanced FastProjectile trails.

- Trails now copy pitch, and set the projectile as the target.
- Added GETOWNER flag. Using it sets the owner of the fast projectile as the target instead, if it has an owner.