### PR TITLE
A_Explode fix

### DIFF
--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -1422,7 +1422,11 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_Explode)
 		damagetype = self->DamageType;
 	}
 
-	int count = P_RadiusAttack (self, self->target, damage, distance, damagetype, flags, fulldmgdistance);
+	int pflags = 0;
+	if (flags & XF_HURTSOURCE)	pflags |= RADF_HURTSOURCE;
+	if (flags & XF_NOTMISSILE)	pflags |= RADF_SOURCEISSPOT;
+
+	int count = P_RadiusAttack (self, self->target, damage, distance, damagetype, pflags, fulldmgdistance);
 	P_CheckSplash(self, distance);
 	if (alert && self->target != NULL && self->target->player != NULL)
 	{

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -1406,12 +1406,17 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_Explode)
 
 	if (nails)
 	{
+		AActor *shooter = self;
+
+		if (self->target != nullptr && !(flags & XF_NOTMISSILE))
+			shooter = self->target;
+
 		DAngle ang;
 		for (int i = 0; i < nails; i++)
 		{
 			ang = i*360./nails;
 			// Comparing the results of a test wad with Eternity, it seems A_NailBomb does not aim
-			P_LineAttack (self, ang, MISSILERANGE, 0.,
+			P_LineAttack (shooter, ang, MISSILERANGE, 0.,
 				//P_AimLineAttack (self, ang, MISSILERANGE), 
 				naildamage, NAME_Hitscan, pufftype);
 		}


### PR DESCRIPTION
- Don't pass flags directly from A_Explode to P_RadiusAttack. XF_EXPLICITDAMAGETYPE would cause explosions to deal no damage otherwise.