### PR TITLE
Ripper Level Gate Removal

### DIFF
--- a/src/thingdef/thingdef_properties.cpp
+++ b/src/thingdef/thingdef_properties.cpp
@@ -1576,10 +1576,6 @@ DEFINE_PROPERTY(telefogdesttype, S, Actor)
 DEFINE_PROPERTY(ripperlevel, I, Actor)
 {
 	PROP_INT_PARM(id, 0);
-	if (id < 0)
-	{
-		I_Error ("RipperLevel must not be negative");
-	}
 	defaults->RipperLevel = id;
 }
 
@@ -1589,10 +1585,6 @@ DEFINE_PROPERTY(ripperlevel, I, Actor)
 DEFINE_PROPERTY(riplevelmin, I, Actor)
 {
 	PROP_INT_PARM(id, 0);
-	if (id < 0)
-	{
-		I_Error ("RipLevelMin must not be negative");
-	}
 	defaults->RipLevelMin = id;
 }
 
@@ -1602,10 +1594,6 @@ DEFINE_PROPERTY(riplevelmin, I, Actor)
 DEFINE_PROPERTY(riplevelmax, I, Actor)
 {
 	PROP_INT_PARM(id, 0);
-	if (id < 0)
-	{
-		I_Error ("RipLevelMax must not be negative");
-	}
 	defaults->RipLevelMax = id;
 }
 


### PR DESCRIPTION
Removed the positive-only ripper level requirement.
- Several mods were able to just take advantage of A_SetRipperLevel and the likes, essentially bypassing this gate so there really is no point in doing this anymore.