### PR TITLE
Fixed support for automatic graphics switching on macOS

### DIFF
--- a/src/posix/osx/zdoom-info.plist
+++ b/src/posix/osx/zdoom-info.plist
@@ -44,6 +44,6 @@
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
-	<string>YES</string>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
The corresponding setting in .plist is wrong but Xcode fixes it automatically
This doesn't happen however when building via makefiles