### PR TITLE
- Fix for DamageFactor bug w/ PowerDamage & PowerProtection

### DIFF
--- a/src/g_shared/a_artifacts.cpp
+++ b/src/g_shared/a_artifacts.cpp
@@ -1668,7 +1668,7 @@ void APowerDamage::ModifyDamage(int damage, FName damageType, int &newdamage, bo
 			newdam = damage * 4;
 		}
 		if (Owner != NULL && newdam > damage) S_Sound(Owner, 5, ActiveSound, 1.0f, ATTN_NONE);
-		newdamage = newdam;
+		newdamage = damage = newdam;
 	}
 	if (Inventory != NULL) Inventory->ModifyDamage(damage, damageType, newdamage, passive);
 }
@@ -1743,7 +1743,7 @@ void APowerProtection::ModifyDamage(int damage, FName damageType, int &newdamage
 			newdam = damage / 4;
 		}
 		if (Owner != NULL && newdam < damage) S_Sound(Owner, CHAN_AUTO, ActiveSound, 1.0f, ATTN_NONE);
-		newdamage = newdam;
+		newdamage = damage = newdam;
 	}
 	if (Inventory != NULL)
 	{


### PR DESCRIPTION
Referencing http://forum.zdoom.org/viewtopic.php?f=2&t=53544 where PowerDamage and PowerProtection didn't stack their effects for PowerDamage and PowerProtection. This means right now having two or more powerups of those kinds at the same time don't stack, and only the first one of each type will give the player/actor their effects.

Hope this works. :o 