### PR TITLE
CMake rule to show PK3 source files in IDE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ function( add_pk3 PK3_NAME PK3_DIR )
 			COMMAND zipdir -udf ${ZDOOM_OUTPUT_DIR}/${PK3_NAME} ${PK3_DIR}
 			DEPENDS zipdir )
 	endif()
-
+        # Grab a list of top-level PK3 folder files, so we can conveniently see them in the IDE
 		file(GLOB PK3_SRCS ${PK3_DIR}/*)
 		# Touch the zipdir executable here so that the pk3s are forced to
 		# rebuild each time since their dependecy has "changed."

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,14 +48,14 @@ function( add_pk3 PK3_NAME PK3_DIR )
 			COMMAND zipdir -udf ${ZDOOM_OUTPUT_DIR}/${PK3_NAME} ${PK3_DIR}
 			DEPENDS zipdir )
 	endif()
-        # Grab a list of top-level PK3 folder files, so we can conveniently see them in the IDE
-		file(GLOB PK3_SRCS ${PK3_DIR}/*)
-		# Touch the zipdir executable here so that the pk3s are forced to
-		# rebuild each time since their dependecy has "changed."
-		add_custom_target( ${PK3_TARGET} ALL
-			COMMAND ${CMAKE_COMMAND} -E touch $<TARGET_FILE:zipdir>
-			DEPENDS ${ZDOOM_OUTPUT_DIR}/${PK3_NAME}
-			SOURCES "${PK3_SRCS}")
+	# Grab a list of top-level PK3 folder files, so we can conveniently see them in the IDE
+	file(GLOB PK3_SRCS ${PK3_DIR}/*)
+	# Touch the zipdir executable here so that the pk3s are forced to
+	# rebuild each time since their dependecy has "changed."
+	add_custom_target( ${PK3_TARGET} ALL
+		COMMAND ${CMAKE_COMMAND} -E touch $<TARGET_FILE:zipdir>
+		DEPENDS ${ZDOOM_OUTPUT_DIR}/${PK3_NAME}
+		SOURCES "${PK3_SRCS}")
 endfunction()
 
 # Macro for building libraries without debugging information

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,11 +49,13 @@ function( add_pk3 PK3_NAME PK3_DIR )
 			DEPENDS zipdir )
 	endif()
 
-	# Touch the zipdir executable here so that the pk3s are forced to
-	# rebuild each time since their dependecy has "changed."
-	add_custom_target( ${PK3_TARGET} ALL
-		COMMAND ${CMAKE_COMMAND} -E touch $<TARGET_FILE:zipdir>
-		DEPENDS ${ZDOOM_OUTPUT_DIR}/${PK3_NAME} )
+		file(GLOB PK3_SRCS ${PK3_DIR}/*)
+		# Touch the zipdir executable here so that the pk3s are forced to
+		# rebuild each time since their dependecy has "changed."
+		add_custom_target( ${PK3_TARGET} ALL
+			COMMAND ${CMAKE_COMMAND} -E touch $<TARGET_FILE:zipdir>
+			DEPENDS ${ZDOOM_OUTPUT_DIR}/${PK3_NAME}
+			SOURCES "${PK3_SRCS}")
 endfunction()
 
 # Macro for building libraries without debugging information


### PR DESCRIPTION
I like to be able to see PK3 source files such as "menudef.txt" and "language.enu" directly from my Visual Studio IDE, under the "pk3" target. This pull request adds a list of the top-level source files for the PK3 target in Visual Studio. 

This pull request does NOT change the dependencies for actually building the PK3. This pull request is based on a change I made to the GZDOOM code in my local working copy. So I'm hoping this pull request would propagate down to gzdoom eventually too.
