### PR TITLE
Visibility Fix

### DIFF
--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -70,6 +70,7 @@
 #include "p_spec.h"
 #include "p_checkposition.h"
 #include "serializer.h"
+#include "r_utility.h"
 
 // MACROS ------------------------------------------------------------------
 
@@ -1040,11 +1041,11 @@ bool AActor::IsInsideVisibleAngles() const
 	if (players[consoleplayer].camera == nullptr)
 		return true;
 	
-	DAngle anglestart = VisibleStartAngle.Normalized180();
-	DAngle angleend = VisibleEndAngle.Normalized180();
-	DAngle pitchstart = VisibleStartPitch.Normalized180();
-	DAngle pitchend = VisibleEndPitch.Normalized180();
-
+	DAngle anglestart = VisibleStartAngle;
+	DAngle angleend = VisibleEndAngle;
+	DAngle pitchstart = VisibleStartPitch;
+	DAngle pitchend = VisibleEndPitch;
+	
 	if (anglestart > angleend)
 	{
 		DAngle temp = anglestart;
@@ -1058,22 +1059,20 @@ bool AActor::IsInsideVisibleAngles() const
 		pitchstart = pitchend;
 		pitchend = temp;
 	}
+	
 
-	player_t* pPlayer = players[consoleplayer].camera->player;
+	AActor *mo = players[consoleplayer].camera;
 
-	if (pPlayer && pPlayer->mo)
+	if (mo != nullptr)
 	{
-		AActor *mo = pPlayer->mo;
-		DVector3 diffang = Vec3To(mo);
+		
+		DVector3 diffang = ViewPos - Pos();
 		DAngle to = diffang.Angle();
 
 		if (!(renderflags & RF_ABSMASKANGLE)) 
 			to = deltaangle(Angles.Yaw, to);
 
-		// Note that this check is inversed due to only being able to vectorize
-		// from one way (this actor to the player). It still means to pass
-		// if the player is within the visible angles.
-		if ((to <= anglestart || to >= angleend))
+		if ((to >= anglestart && to <= angleend))
 		{
 			to = diffang.Pitch();
 			if (!(renderflags & RF_ABSMASKPITCH))

--- a/src/thingdef/thingdef_properties.cpp
+++ b/src/thingdef/thingdef_properties.cpp
@@ -1437,7 +1437,7 @@ DEFINE_PROPERTY(spriterotation, F, Actor)
 DEFINE_PROPERTY(visibleangles, Ff, Actor)
 {
 	PROP_DOUBLE_PARM(visstart, 0);
-	PROP_DOUBLE_PARM(visend, 0);
+	PROP_DOUBLE_PARM(visend, 1);
 	defaults->VisibleStartAngle = visstart;
 	defaults->VisibleEndAngle = visend;
 }
@@ -1448,7 +1448,7 @@ DEFINE_PROPERTY(visibleangles, Ff, Actor)
 DEFINE_PROPERTY(visiblepitch, Ff, Actor)
 {
 	PROP_DOUBLE_PARM(visstart, 0);
-	PROP_DOUBLE_PARM(visend, 0);
+	PROP_DOUBLE_PARM(visend, 1);
 	defaults->VisibleStartPitch = visstart;
 	defaults->VisibleEndPitch = visend;
 }


### PR DESCRIPTION
- Don't use Normalized180() on angles. This could result in ranges being wrongly inverted.
- Fixed properties not having the proper indices.
- Use ViewPos-to-actor instead of measuring actor-to-actor.
- Use the actual camera instead of the actor so camera textures can work.