### PR TITLE
Fix for crash on early fatal error exit

### DIFF
--- a/src/dobject.cpp
+++ b/src/dobject.cpp
@@ -330,7 +330,11 @@ DObject::~DObject ()
 				}
 			}
 		}
-		type->DestroySpecials(this);
+		
+		if (nullptr != type)
+		{
+			type->DestroySpecials(this);
+		}
 	}
 }
 


### PR DESCRIPTION
Process terminates correctly if zdoom.pk3 is missing