### PR TITLE
IfCvar() (partial)

### DIFF
--- a/src/menu/menudef.cpp
+++ b/src/menu/menudef.cpp
@@ -157,6 +157,54 @@ static bool CheckSkipGameBlock(FScanner &sc)
 //
 //=============================================================================
 
+static bool CheckSkipCvarBlock(FScanner &sc)
+{
+	bool filter = false;
+	sc.MustGetStringName("(");
+	sc.MustGetString();
+	FString name = sc.String;
+	FBaseCVar *cv = FindCVar(name, nullptr);
+
+	if (cv != nullptr)
+	{
+		ECVarType check = cv->GetRealType();
+
+		switch (check)
+		{
+		case CVAR_Int:
+			filter = (cv->GetGenericRep(CVAR_Int).Int != 0);
+			break;
+		case CVAR_Float:
+			filter = (cv->GetGenericRep(CVAR_Float).Float != 0.);
+			break;
+		case CVAR_Bool:
+			filter = cv->GetGenericRep(CVAR_Bool).Bool;
+			break;
+		default:
+			filter = false;
+			break;
+		}
+	}
+	else
+	{
+		filter = false;
+	}
+
+	sc.MustGetStringName(")");
+	if (!filter)
+	{
+		SkipSubBlock(sc);
+		return !sc.CheckString("else");
+	}
+	return false;
+}
+
+//=============================================================================
+//
+//
+//
+//=============================================================================
+
 static bool CheckSkipOptionBlock(FScanner &sc)
 {
 	bool filter = false;
@@ -230,6 +278,14 @@ static void ParseListMenuBody(FScanner &sc, FListMenuDescriptor *desc)
 		else if (sc.Compare("ifoption"))
 		{
 			if (!CheckSkipOptionBlock(sc))
+			{
+				// recursively parse sub-block
+				ParseListMenuBody(sc, desc);
+			}
+		}
+		else if (sc.Compare("ifcvar"))
+		{
+			if (!CheckSkipCvarBlock(sc))
 			{
 				// recursively parse sub-block
 				ParseListMenuBody(sc, desc);
@@ -692,6 +748,14 @@ static void ParseOptionMenuBody(FScanner &sc, FOptionMenuDescriptor *desc)
 		else if (sc.Compare("ifoption"))
 		{
 			if (!CheckSkipOptionBlock(sc))
+			{
+				// recursively parse sub-block
+				ParseOptionMenuBody(sc, desc);
+			}
+		}
+		else if (sc.Compare("ifcvar"))
+		{
+			if (!CheckSkipCvarBlock(sc))
 			{
 				// recursively parse sub-block
 				ParseOptionMenuBody(sc, desc);


### PR DESCRIPTION
Added IfCvar() for list and option menus. Only effective on start-up.
- If the cvar evaluates to 0 or false, the menu in question will not be visible.