### PR TITLE
Overlay Extensions

### DIFF
--- a/src/p_pspr.cpp
+++ b/src/p_pspr.cpp
@@ -111,14 +111,16 @@ END_POINTERS
 //------------------------------------------------------------------------
 
 DPSprite::DPSprite(player_t *owner, AActor *caller, int id)
-: x(.0), y(.0),
-  oldx(.0), oldy(.0),
-  firstTic(true),
-  Flags(0),
-  Caller(caller),
-  Owner(owner),
-  ID(id),
-  processPending(true)
+:	x(.0), y(.0),
+	oldx(.0), oldy(.0),
+	alpha(1.),
+	firstTic(true),
+	Flags(0),
+	Caller(caller),
+	Owner(owner),
+	ID(id),
+	processPending(true),
+	RenderStyle(STYLE_Normal)
 {
 	DPSprite *prev = nullptr;
 	DPSprite *next = Owner->psprites;
@@ -967,7 +969,7 @@ void A_OverlayOffset(AActor *self, int layer, double wx, double wy, int flags)
 	player_t *player = self->player;
 	DPSprite *psp;
 
-	if (player && (player->playerstate != PST_DEAD))
+	if (player)
 	{
 		psp = player->FindPSprite(layer);
 
@@ -1051,22 +1053,80 @@ DEFINE_ACTION_FUNCTION(AActor, A_OverlayFlags)
 
 //---------------------------------------------------------------------------
 //
-// PROC OverlayID
-// Because non-action functions cannot acquire the ID of the overlay...
+// PROC A_OverlayAlpha
+//
 //---------------------------------------------------------------------------
 
-DEFINE_ACTION_FUNCTION(AActor, OverlayID)
+DEFINE_ACTION_FUNCTION(AActor, A_OverlayAlpha)
 {
 	PARAM_ACTION_PROLOGUE;
+	PARAM_INT(layer);
+	PARAM_FLOAT(alphaset);
 
-	if (ACTION_CALL_FROM_PSPRITE())
-	{
-		ACTION_RETURN_INT(stateinfo->mPSPIndex);
-	}
-	ACTION_RETURN_INT(0);
+	if (self->player == nullptr)
+		return 0;
+
+	DPSprite *pspr = self->player->FindPSprite(layer);
+
+	if (pspr == nullptr)
+		return 0;
+
+	pspr->alpha = clamp<double>(alphaset, 0.0, 1.0);
+
+	return 0;
 }
 
+// NON-ACTION function to get the overlay alpha of a layer.
+DEFINE_ACTION_FUNCTION(AActor, OverlayAlpha)
+{
+	if (numret > 0)
+	{
+		assert(ret != nullptr);
+		PARAM_SELF_PROLOGUE(AActor);
+		PARAM_INT(layer);
 
+		if (self->player == nullptr)
+			return 0;
+
+		DPSprite *pspr = self->player->FindPSprite(layer);
+
+		if (pspr == nullptr)
+		{
+			ret->SetFloat(0.0);
+		}
+		else
+		{
+			ret->SetFloat(pspr->alpha);
+		}
+		return 1;
+	}
+	return 0;
+}
+
+//---------------------------------------------------------------------------
+//
+// PROC A_OverlayRenderStyle
+//
+//---------------------------------------------------------------------------
+
+DEFINE_ACTION_FUNCTION(AActor, A_OverlayRenderStyle)
+{
+	PARAM_ACTION_PROLOGUE;
+	PARAM_INT(layer);
+	PARAM_INT(style);
+
+	if (self->player == nullptr)
+		return 0;
+
+	DPSprite *pspr = self->player->FindPSprite(layer);
+
+	if (pspr == nullptr || style >= STYLE_Count)
+		return 0;
+
+	pspr->RenderStyle = style;
+
+	return 0;
+}
 
 //---------------------------------------------------------------------------
 //
@@ -1483,7 +1543,8 @@ void DPSprite::Serialize(FSerializer &arc)
 		("x", x)
 		("y", y)
 		("oldx", oldx)
-		("oldy", oldy);
+		("oldy", oldy)
+		("alpha", alpha);
 }
 
 //------------------------------------------------------------------------

--- a/src/p_pspr.h
+++ b/src/p_pspr.h
@@ -53,10 +53,13 @@ enum PSPLayers
 
 enum PSPFlags
 {
-	PSPF_ADDWEAPON	= 1 << 0,
-	PSPF_ADDBOB		= 1 << 1,
-	PSPF_POWDOUBLE	= 1 << 2,
-	PSPF_CVARFAST	= 1 << 3,
+	PSPF_ADDWEAPON		= 1 << 0,
+	PSPF_ADDBOB			= 1 << 1,
+	PSPF_POWDOUBLE		= 1 << 2,
+	PSPF_CVARFAST		= 1 << 3,
+	PSPF_ALPHA			= 1 << 4,
+	PSPF_RENDERSTYLE	= 1 << 5,
+	PSPF_FLIP			= 1 << 6,
 };
 
 class DPSprite : public DObject
@@ -77,11 +80,12 @@ public:
 	AActor*		GetCaller()	      { return Caller; }
 	void		SetCaller(AActor *newcaller) { Caller = newcaller; }
 
-	double x, y;
+	double x, y, alpha;
 	double oldx, oldy;
 	bool firstTic;
 	int Tics;
 	int Flags;
+	int RenderStyle;
 
 private:
 	DPSprite () {}

--- a/src/p_pspr.h
+++ b/src/p_pspr.h
@@ -60,6 +60,8 @@ enum PSPFlags
 	PSPF_ALPHA			= 1 << 4,
 	PSPF_RENDERSTYLE	= 1 << 5,
 	PSPF_FLIP			= 1 << 6,
+	PSPF_FORCEALPHA		= 1 << 7,
+	PSPF_FORCESTYLE		= 1 << 8,
 };
 
 class DPSprite : public DObject

--- a/src/r_data/renderstyle.h
+++ b/src/r_data/renderstyle.h
@@ -125,6 +125,9 @@ enum ERenderFlags
 	// Actors only: Ignore sector fade and fade to black. To fade to white,
 	// combine this with STYLEF_InvertOverlay.
 	STYLEF_FadeToBlack = 64,
+
+	// Force alpha.
+	STYLEF_ForceAlpha = 128,
 };
 
 union FRenderStyle

--- a/src/r_draw.cpp
+++ b/src/r_draw.cpp
@@ -2373,7 +2373,11 @@ ESPSResult R_SetPatchStyle (FRenderStyle style, fixed_t alpha, int translation, 
 		color = 0;
 	}
 
-	if (style.Flags & STYLEF_TransSoulsAlpha)
+	if (style.Flags & STYLEF_ForceAlpha)
+	{
+		alpha = clamp<fixed_t>(alpha, 0, OPAQUE);
+	}
+	else if (style.Flags & STYLEF_TransSoulsAlpha)
 	{
 		alpha = fixed_t(transsouls * OPAQUE);
 	}

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -59,6 +59,9 @@ ACTOR Actor native //: Thinker
 	native int GetMissileDamage(int mask, int add, int ptr = AAPTR_DEFAULT);
 	action native int OverlayID();
 
+	// Overlay Functions
+	native float OverlayAlpha(int layer);
+
 	// Action functions
 	// Meh, MBF redundant functions. Only for DeHackEd support.
 	action native A_Turn(float angle = 0);
@@ -340,7 +343,6 @@ ACTOR Actor native //: Thinker
 	native state A_CheckSightOrRange(float distance, state label, bool two_dimension = false);
 	native state A_CheckRange(float distance, state label, bool two_dimension = false);
 	action native bool A_FaceMovementDirection(float offset = 0, float anglelimit = 0, float pitchlimit = 0, int flags = 0, int ptr = AAPTR_DEFAULT);
-	action native int A_ClearOverlays(int sstart = 0, int sstop = 0, bool safety = true);
 	action native bool A_CopySpriteFrame(int from, int to, int flags = 0);
 	action native bool A_SetSpriteAngle(float angle = 0, int ptr = AAPTR_DEFAULT);
 	action native bool A_SetSpriteRotation(float angle = 0, int ptr = AAPTR_DEFAULT);
@@ -352,9 +354,12 @@ ACTOR Actor native //: Thinker
 	action native A_CopyFriendliness(int ptr_source = AAPTR_MASTER);
 
 	action native bool A_Overlay(int layer, state start = "", bool nooverride = false);
+	action native int A_ClearOverlays(int sstart = 0, int sstop = 0, bool safety = true);
 	action native A_WeaponOffset(float wx = 0, float wy = 32, int flags = 0);
 	action native A_OverlayOffset(int layer = PSP_WEAPON, float wx = 0, float wy = 32, int flags = 0);
 	action native A_OverlayFlags(int layer, int flags, bool set);
+	action native A_OverlayAlpha(int layer, float alphaset);
+	action native A_OverlayRenderStyle(int layer, int style);
 
 	native int ACS_NamedExecute(name script, int mapnum=0, int arg1=0, int arg2=0, int arg3=0);
 	native int ACS_NamedSuspend(name script, int mapnum=0);

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -594,10 +594,15 @@ enum
 // Flags for psprite layers
 enum
 {
-	PSPF_ADDWEAPON	= 1 << 0,
-	PSPF_ADDBOB		= 1 << 1,
-	PSPF_POWDOUBLE	= 1 << 2,
-	PSPF_CVARFAST	= 1 << 3,
+	PSPF_ADDWEAPON		= 1 << 0,
+	PSPF_ADDBOB			= 1 << 1,
+	PSPF_POWDOUBLE		= 1 << 2,
+	PSPF_CVARFAST		= 1 << 3,
+	PSPF_ALPHA			= 1 << 4,
+	PSPF_RENDERSTYLE	= 1 << 5,
+	PSPF_FLIP			= 1 << 6,
+	PSPF_FORCEALPHA		= 1 << 7,
+	PSPF_FORCESTYLE		= 1 << 8,
 };
 
 // Default psprite layers


### PR DESCRIPTION
Added ability to change overlay alphas independently and renderstyles.

- **A_OverlayRenderStyle(int layer, int style)** - Sets the renderstyle of a layer to one of the STYLE_ types.
- **A_OverlayAlpha(int layer, float alphaset)** - Sets the alpha of a layer.
- **OverlayAlpha(int layer)** - Non-action function retrieves the alpha of a layer.

New overlay flags:
- **PSPF_ALPHA/STYLE** - enables individual alpha and render styles on the layers set with them.
- **PSPF_FORCE(ALPHA/STYLE)** - Forces the overlay's alpha to be rendered with its own amount instead of multiplying. This does not count towards fuzzy, transsouls, or stencil (use stenciladd, etc. for stencil).
- **PSPF_FLIP** - Flips the X of the layer over, drawing it in reverse.