### PR TITLE
Zdoom CPack packaging, version 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,9 @@ function( add_pk3 PK3_NAME PK3_DIR )
 	# Create install rule for this PK3 archive, for use in CMake INSTALL
 	# and PACKAGE targets
 	# "." means the top level installation folder
-	install(FILES ${ZDOOM_OUTPUT_DIR}/${PK3_NAME} DESTINATION ".")
+	install(FILES ${ZDOOM_OUTPUT_DIR}/${PK3_NAME} 
+		DESTINATION "."
+		COMPONENT "PK3 Archives")
 
 endfunction()
 
@@ -319,7 +321,9 @@ endif()
 
 # Install rules below, used by CMake INSTALL and PACKAGE targets
 # Install the entire docs directory in the distributed zip package
-install(DIRECTORY docs/ DESTINATION docs)
+install(DIRECTORY docs/ 
+	DESTINATION docs
+	COMPONENT "Documentation")
 
 option(ZDOOM_ENABLE_PACKAGE_TARGET "Enables creations of game distribution packages" ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,20 +336,6 @@ else()
 endif()
 set(ZDOOM_TARGET_ARCHITECTURE "${ZDOOM_TARGET_OS_NAME}${ZDOOM_TARGET_ARCHITECTURE_BITS}") # e.g. "win32", "win64", "linux32" etc.
 
-# Install fmod shared library
-# fixme: create rules for whatever shared libraries are needed in the zdoom package distributed on Mac and Linux
-if (FMOD_LIBRARY AND WIN32)
-	get_filename_component(FMOD_DIR "${FMOD_LIBRARY}" PATH)
-	if (${ZDOOM_TARGET_ARCHITECTURE_BITS} MATCHES 64)
-		file(GLOB FMOD_SHLIBS "${FMOD_DIR}/../fmodex64.dll")
-	else()
-		file(GLOB FMOD_SHLIBS "${FMOD_DIR}/../fmodex.dll")
-	endif()
-	foreach(FMOD_SHLIB "" ${FMOD_SHLIBS})
-	    install(PROGRAMS ${FMOD_SHLIB} DESTINATION ".")
-	endforeach()
-endif()
-
 # Package rules, for creating distributed zip file (or whatever)
 
 # Parse zdoom version number and other attributes from header files.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,11 +322,25 @@ endif()
 # Install the entire docs directory in the distributed zip package
 install(DIRECTORY docs/ DESTINATION docs)
 
+# Construct a compact name for the build target, to use in the package file name
+set(ZDOOM_TARGET_ARCHITECTURE_BITS 32)
+if( CMAKE_SIZEOF_VOID_P EQUAL 8 )
+	set(ZDOOM_TARGET_ARCHITECTURE_BITS 64)
+endif()
+if( WIN32 )
+	set(ZDOOM_TARGET_OS_NAME win)
+elseif( APPLE )
+	set(ZDOOM_TARGET_OS_NAME mac)
+else()
+	set(ZDOOM_TARGET_OS_NAME linux)
+endif()
+set(ZDOOM_TARGET_ARCHITECTURE "${ZDOOM_TARGET_OS_NAME}${ZDOOM_TARGET_ARCHITECTURE_BITS}") # e.g. "win32", "win64", "linux32" etc.
+
 # Install fmod shared library
 # fixme: create rules for whatever shared libraries are needed in the zdoom package distributed on Mac and Linux
 if (FMOD_LIBRARY AND WIN32)
 	get_filename_component(FMOD_DIR "${FMOD_LIBRARY}" PATH)
-	if (${CMAKE_GENERATOR} MATCHES Win64) # e.g. "Visual Studio 14 Win64"
+	if (${ZDOOM_TARGET_ARCHITECTURE_BITS} MATCHES 64)
 		file(GLOB FMOD_SHLIBS "${FMOD_DIR}/../fmodex64.dll")
 	else()
 		file(GLOB FMOD_SHLIBS "${FMOD_DIR}/../fmodex.dll")
@@ -338,23 +352,60 @@ endif()
 
 # Package rules, for creating distributed zip file (or whatever)
 
-# PACKAGE installer
-set(INSTALL_PROGRAM_NAME ${ZDOOM_EXE_NAME})
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "${INSTALL_PROGRAM_NAME} game")
+# Parse zdoom version number and other attributes from header files.
+function( parse_header_define SRC_FILE DEFINE_NAME OUTPUT_VAR )
+	set(MYREGEX "^\#define ${DEFINE_NAME} \"?([^\"]+)\"?")
+	file(STRINGS ${SRC_FILE} PARSED_LINE REGEX ${MYREGEX}) # fetch one line of source code
+	string(REGEX MATCH ${MYREGEX} MATCH_RESULT ${PARSED_LINE}) # extract the one field we want
+	if(MATCH_RESULT)
+		set(${OUTPUT_VAR} ${CMAKE_MATCH_1} PARENT_SCOPE)
+	endif()
+endfunction()
+
+parse_header_define(src/version.h VERSIONSTR ZDOOM_VERSIONSTR)
+parse_header_define(src/version.h GAMENAME ZDOOM_GAMENAME)
+parse_header_define(src/gitinfo.h GIT_DESCRIPTION ZDOOM_GIT_DESCRIPTION)
+
+# Populate special CPACK variables for PACKAGE installer
+set(CPACK_PACKAGE_NAME ${ZDOOM_GAMENAME})
 set(CPACK_PACKAGE_VENDOR "zdoom.org")
-set(CPACK_PACKAGE_EXECUTABLES ${ZDOOM_EXE_NAME} ${INSTALL_PROGRAM_NAME})
-# fixme: read actual zdoom version from somewhere
-set(CPACK_PACKAGE_VERSION_MAJOR "2")
-set(CPACK_PACKAGE_VERSION_MINOR "9")
-set(CPACK_PACKAGE_VERSION_PATCH "pre")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "${ZDOOM_GAMENAME} game")
+set(CPACK_PACKAGE_DESCRIPTION "${ZDOOM_GAMENAME} is an enhanced port of the original DOOM game source code")
+# split zdoom version string into its component parts
+set(ZDOOM_VERSION_LIST ${ZDOOM_VERSIONSTR})
+string(REPLACE "." ";" ZDOOM_VERSION_LIST ${ZDOOM_VERSION_LIST}) # Convert string to list
+list(GET ZDOOM_VERSION_LIST 0 CPACK_PACKAGE_VERSION_MAJOR)
+list(GET ZDOOM_VERSION_LIST 1 CPACK_PACKAGE_VERSION_MINOR)
+list(LENGTH ZDOOM_VERSION_LIST ZDOOM_VERSION_LIST_LENGTH)
+if(${ZDOOM_VERSION_LIST_LENGTH} GREATER 2)
+	list(GET ZDOOM_VERSION_LIST 2 CPACK_PACKAGE_VERSION_PATCH)
+	set(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
+else()
+	set(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}")
+endif()
+if (NOT CPACK_SYSTEM_NAME)
+	set(CPACK_SYSTEM_NAME "${ZDOOM_TARGET_ARCHITECTURE}")
+endif ()
+set(ZDOOM_BUILD_OFFICIAL_RELEASE OFF CACHE BOOL "Creates package name with a compact version number")
+if (ZDOOM_BUILD_OFFICIAL_RELEASE)
+	# Use a more compact version string
+	set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_SYSTEM_NAME}-${ZDOOM_VERSIONSTR}") # without extension
+else()
+	# Use a more explicit version string
+	set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_SYSTEM_NAME}-${ZDOOM_GIT_DESCRIPTION}") # without extension
+endif()
+
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/docs/licenses/README.TXT")
-set(CPACK_PACKAGE_NAME ${INSTALL_PROGRAM_NAME})
+set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/docs/zdoom.txt")
+set(CPACK_PACKAGE_EXECUTABLES ${ZDOOM_EXE_NAME} ${ZDOOM_GAMENAME}) # for menu shortcuts
 
 if(WIN32)
 	set(DEFAULT_CPACK_GENERATOR ZIP) # ZIP is the standard way to distribute zdoom.
 else()
 	set(DEFAULT_CPACK_GENERATOR TGZ)
 endif()
+# fixme: the fancier package formats, such as DEB and DragNDrop, will likely 
+# require additional CPack configuration here in this CMakeLists.txt file
 set(CPACK_GENERATOR ${DEFAULT_CPACK_GENERATOR} CACHE STRING "File format for distribution package archive (ZIP, NSIS, TGZ, BUNDLE, DEB, etc.)")
 
 # "include(CPack)" must appear only after all the build and install rules have been defined

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ function( add_pk3 PK3_NAME PK3_DIR )
 	assort_pk3_source_folder("Source Files" ${PK3_DIR})
 	
 	# Create install rule for this PK3 archive, for use in CMake INSTALL
-    # and PACKAGE targets
+	# and PACKAGE targets
 	# "." means the top level installation folder
 	install(FILES ${ZDOOM_OUTPUT_DIR}/${PK3_NAME} DESTINATION ".")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,7 +386,7 @@ endif()
 if (NOT CPACK_SYSTEM_NAME)
 	set(CPACK_SYSTEM_NAME "${ZDOOM_TARGET_ARCHITECTURE}")
 endif ()
-set(ZDOOM_BUILD_OFFICIAL_RELEASE OFF CACHE BOOL "Creates package name with a compact version number")
+option(ZDOOM_BUILD_OFFICIAL_RELEASE "Creates package name with a compact version number" OFF)
 if (ZDOOM_BUILD_OFFICIAL_RELEASE)
 	# Use a more compact version string
 	set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_SYSTEM_NAME}-${ZDOOM_VERSIONSTR}") # without extension

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,81 +318,84 @@ if( NOT CMAKE_CROSSCOMPILING )
 endif()
 
 # Install rules below, used by CMake INSTALL and PACKAGE targets
-
 # Install the entire docs directory in the distributed zip package
 install(DIRECTORY docs/ DESTINATION docs)
 
-# Construct a compact name for the build target, to use in the package file name
-set(ZDOOM_TARGET_ARCHITECTURE_BITS 32)
-if( CMAKE_SIZEOF_VOID_P EQUAL 8 )
-	set(ZDOOM_TARGET_ARCHITECTURE_BITS 64)
-endif()
-if( WIN32 )
-	set(ZDOOM_TARGET_OS_NAME win)
-elseif( APPLE )
-	set(ZDOOM_TARGET_OS_NAME mac)
-else()
-	set(ZDOOM_TARGET_OS_NAME linux)
-endif()
-set(ZDOOM_TARGET_ARCHITECTURE "${ZDOOM_TARGET_OS_NAME}${ZDOOM_TARGET_ARCHITECTURE_BITS}") # e.g. "win32", "win64", "linux32" etc.
+option(ZDOOM_ENABLE_PACKAGE_TARGET "Enables creations of game distribution packages" ON)
 
-# Package rules, for creating distributed zip file (or whatever)
-
-# Parse zdoom version number and other attributes from header files.
-function( parse_header_define SRC_FILE DEFINE_NAME OUTPUT_VAR )
-	set(MYREGEX "^\#define ${DEFINE_NAME} \"?([^\"]+)\"?")
-	file(STRINGS ${SRC_FILE} PARSED_LINE REGEX ${MYREGEX}) # fetch one line of source code
-	string(REGEX MATCH ${MYREGEX} MATCH_RESULT ${PARSED_LINE}) # extract the one field we want
-	if(MATCH_RESULT)
-		set(${OUTPUT_VAR} ${CMAKE_MATCH_1} PARENT_SCOPE)
+if(ZDOOM_ENABLE_PACKAGE_TARGET)
+	# Construct a compact name for the build target, to use in the package file name
+	set(ZDOOM_TARGET_ARCHITECTURE_BITS 32)
+	if( CMAKE_SIZEOF_VOID_P EQUAL 8 )
+		set(ZDOOM_TARGET_ARCHITECTURE_BITS 64)
 	endif()
-endfunction()
+	if( WIN32 )
+		set(ZDOOM_TARGET_OS_NAME win)
+	elseif( APPLE )
+		set(ZDOOM_TARGET_OS_NAME mac)
+	else()
+		set(ZDOOM_TARGET_OS_NAME linux)
+	endif()
+	set(ZDOOM_TARGET_ARCHITECTURE "${ZDOOM_TARGET_OS_NAME}${ZDOOM_TARGET_ARCHITECTURE_BITS}") # e.g. "win32", "win64", "linux32" etc.
 
-parse_header_define(src/version.h VERSIONSTR ZDOOM_VERSIONSTR)
-parse_header_define(src/version.h GAMENAME ZDOOM_GAMENAME)
-parse_header_define(src/gitinfo.h GIT_DESCRIPTION ZDOOM_GIT_DESCRIPTION)
+	# Package rules, for creating distributed zip file (or whatever)
 
-# Populate special CPACK variables for PACKAGE installer
-set(CPACK_PACKAGE_NAME ${ZDOOM_GAMENAME})
-set(CPACK_PACKAGE_VENDOR "zdoom.org")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "${ZDOOM_GAMENAME} game")
-set(CPACK_PACKAGE_DESCRIPTION "${ZDOOM_GAMENAME} is an enhanced port of the original DOOM game source code")
-# split zdoom version string into its component parts
-set(ZDOOM_VERSION_LIST ${ZDOOM_VERSIONSTR})
-string(REPLACE "." ";" ZDOOM_VERSION_LIST ${ZDOOM_VERSION_LIST}) # Convert string to list
-list(GET ZDOOM_VERSION_LIST 0 CPACK_PACKAGE_VERSION_MAJOR)
-list(GET ZDOOM_VERSION_LIST 1 CPACK_PACKAGE_VERSION_MINOR)
-list(LENGTH ZDOOM_VERSION_LIST ZDOOM_VERSION_LIST_LENGTH)
-if(${ZDOOM_VERSION_LIST_LENGTH} GREATER 2)
-	list(GET ZDOOM_VERSION_LIST 2 CPACK_PACKAGE_VERSION_PATCH)
-	set(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
-else()
-	set(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}")
+	# Parse zdoom version number and other attributes from header files.
+	function( parse_header_define SRC_FILE DEFINE_NAME OUTPUT_VAR )
+		set(MYREGEX "^\#define ${DEFINE_NAME} \"?([^\"]+)\"?")
+		file(STRINGS ${SRC_FILE} PARSED_LINE REGEX ${MYREGEX}) # fetch one line of source code
+		string(REGEX MATCH ${MYREGEX} MATCH_RESULT ${PARSED_LINE}) # extract the one field we want
+		if(MATCH_RESULT)
+			set(${OUTPUT_VAR} ${CMAKE_MATCH_1} PARENT_SCOPE)
+		endif()
+	endfunction()
+
+	parse_header_define(src/version.h VERSIONSTR ZDOOM_VERSIONSTR)
+	parse_header_define(src/version.h GAMENAME ZDOOM_GAMENAME)
+	parse_header_define(src/gitinfo.h GIT_DESCRIPTION ZDOOM_GIT_DESCRIPTION)
+
+	# Populate special CPACK variables for PACKAGE installer
+	set(CPACK_PACKAGE_NAME ${ZDOOM_GAMENAME})
+	set(CPACK_PACKAGE_VENDOR "zdoom.org")
+	set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "${ZDOOM_GAMENAME} game")
+	set(CPACK_PACKAGE_DESCRIPTION "${ZDOOM_GAMENAME} is an enhanced port of the original DOOM game source code")
+	# split zdoom version string into its component parts
+	set(ZDOOM_VERSION_LIST ${ZDOOM_VERSIONSTR})
+	string(REPLACE "." ";" ZDOOM_VERSION_LIST ${ZDOOM_VERSION_LIST}) # Convert string to list
+	list(GET ZDOOM_VERSION_LIST 0 CPACK_PACKAGE_VERSION_MAJOR)
+	list(GET ZDOOM_VERSION_LIST 1 CPACK_PACKAGE_VERSION_MINOR)
+	list(LENGTH ZDOOM_VERSION_LIST ZDOOM_VERSION_LIST_LENGTH)
+	if(${ZDOOM_VERSION_LIST_LENGTH} GREATER 2)
+		list(GET ZDOOM_VERSION_LIST 2 CPACK_PACKAGE_VERSION_PATCH)
+		set(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
+	else()
+		set(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}")
+	endif()
+	if (NOT CPACK_SYSTEM_NAME)
+		set(CPACK_SYSTEM_NAME "${ZDOOM_TARGET_ARCHITECTURE}")
+	endif ()
+	option(ZDOOM_PACKAGE_OFFICIAL_RELEASE "Creates package name with a compact version number" OFF)
+	if (ZDOOM_PACKAGE_OFFICIAL_RELEASE)
+		# Use a more compact version string
+		set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_SYSTEM_NAME}-${ZDOOM_VERSIONSTR}") # without extension
+	else()
+		# Use a more explicit version string
+		set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_SYSTEM_NAME}-${ZDOOM_GIT_DESCRIPTION}") # without extension
+	endif()
+
+	set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/docs/licenses/README.TXT")
+	set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/docs/zdoom.txt")
+	set(CPACK_PACKAGE_EXECUTABLES ${ZDOOM_EXE_NAME} ${ZDOOM_GAMENAME}) # for menu shortcuts
+
+	if(WIN32)
+		set(DEFAULT_CPACK_GENERATOR ZIP) # ZIP is the standard way to distribute zdoom.
+	else()
+		set(DEFAULT_CPACK_GENERATOR TGZ)
+	endif()
+	# fixme: the fancier package formats, such as DEB and DragNDrop, will likely 
+	# require additional CPack configuration here in this CMakeLists.txt file
+	set(CPACK_GENERATOR ${DEFAULT_CPACK_GENERATOR} CACHE STRING "File format for distribution package archive (ZIP, NSIS, TGZ, BUNDLE, DEB, etc.)")
+
+	# "include(CPack)" must appear only after all the build and install rules have been defined
+	include(CPack)
 endif()
-if (NOT CPACK_SYSTEM_NAME)
-	set(CPACK_SYSTEM_NAME "${ZDOOM_TARGET_ARCHITECTURE}")
-endif ()
-option(ZDOOM_BUILD_OFFICIAL_RELEASE "Creates package name with a compact version number" OFF)
-if (ZDOOM_BUILD_OFFICIAL_RELEASE)
-	# Use a more compact version string
-	set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_SYSTEM_NAME}-${ZDOOM_VERSIONSTR}") # without extension
-else()
-	# Use a more explicit version string
-	set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_SYSTEM_NAME}-${ZDOOM_GIT_DESCRIPTION}") # without extension
-endif()
-
-set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/docs/licenses/README.TXT")
-set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/docs/zdoom.txt")
-set(CPACK_PACKAGE_EXECUTABLES ${ZDOOM_EXE_NAME} ${ZDOOM_GAMENAME}) # for menu shortcuts
-
-if(WIN32)
-	set(DEFAULT_CPACK_GENERATOR ZIP) # ZIP is the standard way to distribute zdoom.
-else()
-	set(DEFAULT_CPACK_GENERATOR TGZ)
-endif()
-# fixme: the fancier package formats, such as DEB and DragNDrop, will likely 
-# require additional CPack configuration here in this CMakeLists.txt file
-set(CPACK_GENERATOR ${DEFAULT_CPACK_GENERATOR} CACHE STRING "File format for distribution package archive (ZIP, NSIS, TGZ, BUNDLE, DEB, etc.)")
-
-# "include(CPack)" must appear only after all the build and install rules have been defined
-include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,12 @@ function( add_pk3 PK3_NAME PK3_DIR )
 		SOURCES ${PK3_SRCS})
 	# Phase 3: Assign source files to a nice folder structure in the IDE
 	assort_pk3_source_folder("Source Files" ${PK3_DIR})
+	
+	# Create install rule for this PK3 archive, for use in CMake INSTALL
+    # and PACKAGE targets
+	# "." means the top level installation folder
+	install(FILES ${ZDOOM_OUTPUT_DIR}/${PK3_NAME} DESTINATION ".")
+
 endfunction()
 
 # Macro for building libraries without debugging information
@@ -252,6 +258,7 @@ if( ZLIB_FOUND AND NOT FORCE_INTERNAL_ZLIB )
 	message( STATUS "Using system zlib, includes found at ${ZLIB_INCLUDE_DIR}" )
 else()
 	message( STATUS "Using internal zlib" )
+	set( SKIP_INSTALL_ALL TRUE ) # Avoid installing zlib alongside zdoom
 	add_subdirectory( zlib )
 	set( ZLIB_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/zlib )
 	set( ZLIB_LIBRARIES z )
@@ -309,3 +316,46 @@ endif()
 if( NOT CMAKE_CROSSCOMPILING )
 	export(TARGETS ${CROSS_EXPORTS} FILE "${CMAKE_BINARY_DIR}/ImportExecutables.cmake" )
 endif()
+
+# Install rules below, used by CMake INSTALL and PACKAGE targets
+
+# Install the entire docs directory in the distributed zip package
+install(DIRECTORY docs/ DESTINATION docs)
+
+# Install fmod shared library
+# fixme: create rules for whatever shared libraries are needed in the zdoom package distributed on Mac and Linux
+if (FMOD_LIBRARY AND WIN32)
+	get_filename_component(FMOD_DIR "${FMOD_LIBRARY}" PATH)
+	if (${CMAKE_GENERATOR} MATCHES Win64) # e.g. "Visual Studio 14 Win64"
+		file(GLOB FMOD_SHLIBS "${FMOD_DIR}/../fmodex64.dll")
+	else()
+		file(GLOB FMOD_SHLIBS "${FMOD_DIR}/../fmodex.dll")
+	endif()
+	foreach(FMOD_SHLIB "" ${FMOD_SHLIBS})
+	    install(PROGRAMS ${FMOD_SHLIB} DESTINATION ".")
+	endforeach()
+endif()
+
+# Package rules, for creating distributed zip file (or whatever)
+
+# PACKAGE installer
+set(INSTALL_PROGRAM_NAME ${ZDOOM_EXE_NAME})
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "${INSTALL_PROGRAM_NAME} game")
+set(CPACK_PACKAGE_VENDOR "zdoom.org")
+set(CPACK_PACKAGE_EXECUTABLES ${ZDOOM_EXE_NAME} ${INSTALL_PROGRAM_NAME})
+# fixme: read actual zdoom version from somewhere
+set(CPACK_PACKAGE_VERSION_MAJOR "2")
+set(CPACK_PACKAGE_VERSION_MINOR "9")
+set(CPACK_PACKAGE_VERSION_PATCH "pre")
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/docs/licenses/README.TXT")
+set(CPACK_PACKAGE_NAME ${INSTALL_PROGRAM_NAME})
+
+if(WIN32)
+	set(DEFAULT_CPACK_GENERATOR ZIP) # ZIP is the standard way to distribute zdoom.
+else()
+	set(DEFAULT_CPACK_GENERATOR TGZ)
+endif()
+set(CPACK_GENERATOR ${DEFAULT_CPACK_GENERATOR} CACHE STRING "File format for distribution package archive (ZIP, NSIS, TGZ, BUNDLE, DEB, etc.)")
+
+# "include(CPack)" must appear only after all the build and install rules have been defined
+include(CPack)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -333,7 +333,9 @@ if( NOT NO_FMOD )
 				DOC "Path to FMOD shared library, e.g. fmodex.dll"
 			)
 			if( FMOD_SHARED_LIBRARY )
-				install(PROGRAMS ${FMOD_SHARED_LIBRARY} DESTINATION ".")
+				install(PROGRAMS ${FMOD_SHARED_LIBRARY} 
+					DESTINATION "."
+					COMPONENT "Shared Libraries")
 			else()
 				message(WARNING "FMOD shared library was not found and will be neither installed nor packaged")
 			endif()
@@ -374,7 +376,9 @@ else()
 			DOC "Path to mpg124 shared library, e.g. libmpg123-0.dll"
 		)
 		if( MPG123_SHARED_LIBRARY )
-			install(PROGRAMS ${MPG123_SHARED_LIBRARY} DESTINATION ".")
+			install(PROGRAMS ${MPG123_SHARED_LIBRARY} 
+				DESTINATION "."
+				COMPONENT "Shared Libraries")
 		else()
 			message(WARNING "MPG123 shared library was not found and will be neither installed nor packaged")
 		endif()
@@ -390,7 +394,9 @@ else()
 			DOC "Path to sndfile shared library, e.g. libsndfile-1.dll"
 		)
 		if( SNDFILE_SHARED_LIBRARY )
-			install(PROGRAMS ${SNDFILE_SHARED_LIBRARY} DESTINATION ".")
+			install(PROGRAMS ${SNDFILE_SHARED_LIBRARY} 
+				DESTINATION "."
+				COMPONENT "Shared Libraries")
 		else()
 			message(WARNING "SNDFILE shared library was not found and will be neither installed nor packaged")
 		endif()
@@ -411,10 +417,29 @@ else()
 			DOC "Path to OpenAL shared library, e.g. soft_oal.dll"
 		)
 		if( OPENAL_SHARED_LIBRARY )
-			install(PROGRAMS ${OPENAL_SHARED_LIBRARY} DESTINATION ".")
+			install(PROGRAMS ${OPENAL_SHARED_LIBRARY} 
+				DESTINATION "."
+				RENAME OpenAL32.dll
+				COMPONENT "Shared Libraries")
 		else()
 			message(WARNING "OPENAL shared library was not found and will be neither installed nor packaged")
 		endif()
+	endif()
+endif()
+
+# install all shared libraries dev has placed in the executable output folder(s)
+# because I have no idea what else to do about libgcc_s_sjlj-1.dll
+if (ZDOOM_ENABLE_PACKAGE_TARGET)
+	file(GLOB DEV_SHARED_LIBRARIES 
+		"${CMAKE_BINARY_DIR}/Release/*.dll"
+		"${CMAKE_BINARY_DIR}/Debug/*.dll"
+		"${CMAKE_BINARY_DIR}/*.so"
+		"${CMAKE_BINARY_DIR}/*.dylib"
+	)
+	if (DEV_SHARED_LIBRARIES)
+		install(PROGRAMS ${DEV_SHARED_LIBRARIES} 
+			DESTINATION "."
+			COMPONENT "Shared Libraries")
 	endif()
 endif()
 
@@ -1499,7 +1524,9 @@ endif()
 # Create install rule for zdoom game program, for use in CMake INSTALL 
 # and PACKAGE targets.
 # "." means the top level installation folder
-install(TARGETS zdoom DESTINATION ".")
+install(TARGETS zdoom 
+	DESTINATION "."
+	COMPONENT "Game Program")
 
 source_group("Assembly Files\\ia32" REGULAR_EXPRESSION "^${CMAKE_CURRENT_SOURCE_DIR}/asm_ia32/.+")
 source_group("Assembly Files\\x86_64" REGULAR_EXPRESSION "^${CMAKE_CURRENT_SOURCE_DIR}/asm_x86_64/.+")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -317,6 +317,18 @@ if( NOT NO_FMOD )
 	if( FMOD_LIBRARY )
 		message( STATUS "FMOD library found at ${FMOD_LIBRARY}" )
 		set( ZDOOM_LIBS ${ZDOOM_LIBS} "${FMOD_LIBRARY}" )
+		# Install shared fmod library for PACKAGE target
+		if (WIN32) # fixme: also install for non-Windows platforms
+			get_filename_component(FMOD_DIR "${FMOD_LIBRARY}" PATH)
+			if (${CMAKE_GENERATOR} MATCHES Win64) # e.g. "Visual Studio 14 Win64"
+				file(GLOB FMOD_SHLIBS "${FMOD_DIR}/../fmodex64.dll")
+			else()
+				file(GLOB FMOD_SHLIBS "${FMOD_DIR}/../fmodex.dll")
+			endif()
+			foreach(FMOD_SHLIB "" ${FMOD_SHLIBS})
+				install(PROGRAMS ${FMOD_SHLIB} DESTINATION ".")
+			endforeach()
+		endif()
 	else()
 		message( STATUS "Could not find FMOD library" )
 		set( NO_FMOD ON )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -317,17 +317,15 @@ if( NOT NO_FMOD )
 	if( FMOD_LIBRARY )
 		message( STATUS "FMOD library found at ${FMOD_LIBRARY}" )
 		set( ZDOOM_LIBS ${ZDOOM_LIBS} "${FMOD_LIBRARY}" )
-		# Install shared fmod library for PACKAGE target
-		if (WIN32) # fixme: also install for non-Windows platforms
+		if (ZDOOM_ENABLE_PACKAGE_TARGET)
+			# Install shared fmod library for PACKAGE target
 			get_filename_component(FMOD_DIR "${FMOD_LIBRARY}" PATH)
-			if (${CMAKE_GENERATOR} MATCHES Win64) # e.g. "Visual Studio 14 Win64"
-				file(GLOB FMOD_SHLIBS "${FMOD_DIR}/../fmodex64.dll")
-			else()
-				file(GLOB FMOD_SHLIBS "${FMOD_DIR}/../fmodex.dll")
-			endif()
-			foreach(FMOD_SHLIB "" ${FMOD_SHLIBS})
-				install(PROGRAMS ${FMOD_SHLIB} DESTINATION ".")
-			endforeach()
+			find_file(FMOD_SHARED_LIBRARY
+				NAMES fmodex${X64}.dll fmod${X64}.dll
+				PATHS "${FMOD_DIR}/.."
+				DOC "Path to FMOD shared library, e.g. fmodex.dll"
+			)
+			install(PROGRAMS ${FMOD_SHARED_LIBRARY} DESTINATION ".")
 		endif()
 	else()
 		message( STATUS "Could not find FMOD library" )
@@ -351,6 +349,36 @@ else()
 	# Search for libmpg123
 
 	find_package( MPG123 )
+	
+	if (ZDOOM_ENABLE_PACKAGE_TARGET)
+		# Create install rules for dlls, for use in PACKAGE target
+		find_file(MPG123_SHARED_LIBRARY
+			NAMES libmpg123-0.dll
+			PATHS ${MPG123_INCLUDE_DIR}
+			DOC "Path to mpg124 shared library, e.g. libmpg123-0.dll"
+		)
+		install(PROGRAMS ${MPG123_SHARED_LIBRARY} DESTINATION ".")
+	
+		find_file(SNDFILE_SHARED_LIBRARY
+			NAMES libsndfile-1.dll
+			PATHS "${SNDFILE_INCLUDE_DIR}/../bin"
+			DOC "Path to sndfile shared library, e.g. libsndfile-1.dll"
+		)
+		install(PROGRAMS ${SNDFILE_SHARED_LIBRARY} DESTINATION ".")
+		
+		if (X64)
+			set(OAL_SUBFOLDER Win64)
+		else()
+			set(OAL_SUBFOLDER Win32)
+		endif()
+		find_file(OPENAL_SHARED_LIBRARY
+			NAMES soft_oal.dll
+			PATHS "C:/Program Files (x86)/openal-soft-1.17.2-bin/bin"
+			PATH_SUFFIXES ${OAL_SUBFOLDER}
+			DOC "Path to OpenAL shared library, e.g. soft_oal.dll"
+		)
+		install(PROGRAMS ${OPENAL_SHARED_LIBRARY} RENAME OpenAL32.dll DESTINATION ".")
+	endif()
 endif()
 
 # Search for FluidSynth

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,8 @@ endif()
 
 if( CMAKE_SIZEOF_VOID_P MATCHES "8" )
 	set( X64 64 )
+else()
+	set( X32 32 )
 endif()
 
 # You can either use "make install" on the FMOD distribution to put it
@@ -322,10 +324,19 @@ if( NOT NO_FMOD )
 			get_filename_component(FMOD_DIR "${FMOD_LIBRARY}" PATH)
 			find_file(FMOD_SHARED_LIBRARY
 				NAMES fmodex${X64}.dll fmod${X64}.dll
-				PATHS "${FMOD_DIR}/.."
+				PATHS 
+					${CMAKE_BINARY_DIR}
+					"${FMOD_DIR}/.."
+				PATH_SUFFIXES 
+					Release
+					Debug
 				DOC "Path to FMOD shared library, e.g. fmodex.dll"
 			)
-			install(PROGRAMS ${FMOD_SHARED_LIBRARY} DESTINATION ".")
+			if( FMOD_SHARED_LIBRARY )
+				install(PROGRAMS ${FMOD_SHARED_LIBRARY} DESTINATION ".")
+			else()
+				message(WARNING "FMOD shared library was not found and will be neither installed nor packaged")
+			endif()
 		endif()
 	else()
 		message( STATUS "Could not find FMOD library" )
@@ -362,7 +373,11 @@ else()
 				Debug
 			DOC "Path to mpg124 shared library, e.g. libmpg123-0.dll"
 		)
-		install(PROGRAMS ${MPG123_SHARED_LIBRARY} DESTINATION ".")
+		if( MPG123_SHARED_LIBRARY )
+			install(PROGRAMS ${MPG123_SHARED_LIBRARY} DESTINATION ".")
+		else()
+			message(WARNING "MPG123 shared library was not found and will be neither installed nor packaged")
+		endif()
 	
 		find_file(SNDFILE_SHARED_LIBRARY
 			NAMES libsndfile-1.dll
@@ -374,7 +389,11 @@ else()
 				Debug
 			DOC "Path to sndfile shared library, e.g. libsndfile-1.dll"
 		)
-		install(PROGRAMS ${SNDFILE_SHARED_LIBRARY} DESTINATION ".")
+		if( SNDFILE_SHARED_LIBRARY )
+			install(PROGRAMS ${SNDFILE_SHARED_LIBRARY} DESTINATION ".")
+		else()
+			message(WARNING "SNDFILE shared library was not found and will be neither installed nor packaged")
+		endif()
 		
 		if (X64)
 			set(OAL_SUBFOLDER Win64)
@@ -385,14 +404,17 @@ else()
 			NAMES soft_oal.dll OpenAL32.dll
 			PATHS
 				${CMAKE_BINARY_DIR} 
-				"C:/Program Files (x86)/openal-soft-1.17.2-bin/bin"
+				"C:/Program Files (x86)/openal-soft-1.17.2-bin/bin/Win${X32}${X64}"
 			PATH_SUFFIXES 
 				Release
 				Debug
-				${OAL_SUBFOLDER}
 			DOC "Path to OpenAL shared library, e.g. soft_oal.dll"
 		)
-		install(PROGRAMS ${OPENAL_SHARED_LIBRARY} RENAME OpenAL32.dll DESTINATION ".")
+		if( OPENAL_SHARED_LIBRARY )
+			install(PROGRAMS ${OPENAL_SHARED_LIBRARY} DESTINATION ".")
+		else()
+			message(WARNING "OPENAL shared library was not found and will be neither installed nor packaged")
+		endif()
 	endif()
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1419,6 +1419,11 @@ if( APPLE )
 	endif()
 endif()
 
+# Create install rule for zdoom game program, for use in CMake INSTALL 
+# and PACKAGE targets.
+# "." means the top level installation folder
+install(TARGETS zdoom DESTINATION ".")
+
 source_group("Assembly Files\\ia32" REGULAR_EXPRESSION "^${CMAKE_CURRENT_SOURCE_DIR}/asm_ia32/.+")
 source_group("Assembly Files\\x86_64" REGULAR_EXPRESSION "^${CMAKE_CURRENT_SOURCE_DIR}/asm_x86_64/.+")
 source_group("Audio Files" REGULAR_EXPRESSION "^${CMAKE_CURRENT_SOURCE_DIR}/sound/.+")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -354,14 +354,24 @@ else()
 		# Create install rules for dlls, for use in PACKAGE target
 		find_file(MPG123_SHARED_LIBRARY
 			NAMES libmpg123-0.dll
-			PATHS ${MPG123_INCLUDE_DIR}
+			PATHS 
+				${CMAKE_BINARY_DIR}
+				${MPG123_INCLUDE_DIR}
+			PATH_SUFFIXES 
+				Release
+				Debug
 			DOC "Path to mpg124 shared library, e.g. libmpg123-0.dll"
 		)
 		install(PROGRAMS ${MPG123_SHARED_LIBRARY} DESTINATION ".")
 	
 		find_file(SNDFILE_SHARED_LIBRARY
 			NAMES libsndfile-1.dll
-			PATHS "${SNDFILE_INCLUDE_DIR}/../bin"
+			PATHS 
+				${CMAKE_BINARY_DIR}
+				"${SNDFILE_INCLUDE_DIR}/../bin"
+			PATH_SUFFIXES 
+				Release
+				Debug
 			DOC "Path to sndfile shared library, e.g. libsndfile-1.dll"
 		)
 		install(PROGRAMS ${SNDFILE_SHARED_LIBRARY} DESTINATION ".")
@@ -372,9 +382,14 @@ else()
 			set(OAL_SUBFOLDER Win32)
 		endif()
 		find_file(OPENAL_SHARED_LIBRARY
-			NAMES soft_oal.dll
-			PATHS "C:/Program Files (x86)/openal-soft-1.17.2-bin/bin"
-			PATH_SUFFIXES ${OAL_SUBFOLDER}
+			NAMES soft_oal.dll OpenAL32.dll
+			PATHS
+				${CMAKE_BINARY_DIR} 
+				"C:/Program Files (x86)/openal-soft-1.17.2-bin/bin"
+			PATH_SUFFIXES 
+				Release
+				Debug
+				${OAL_SUBFOLDER}
 			DOC "Path to OpenAL shared library, e.g. soft_oal.dll"
 		)
 		install(PROGRAMS ${OPENAL_SHARED_LIBRARY} RENAME OpenAL32.dll DESTINATION ".")


### PR DESCRIPTION
This is an update to closed pull requests #830 and #827

This pull request creates cmake/cpack rules for creating a zip file very similar to the one used to distribute zdoom. The same rules can also be extended to allow packaging into installer wizards, dmgs with drag-and-drop app bundles, debian distributions, and other package types for distributing zdoom.

The following improvements have been added since pull request 827 was opened, based on the discussion at http://forum.zdoom.org/viewtopic.php?f=34&t=53663
1) The version string used in the package file name is parsed from src/version.h or src/gitinfo.h.
2) When OpenAL support is enabled, the needed shared libraries are installed.
3) A new CMake option, ZDOOM_ENABLE_PACKAGE_TARGET, is provided.
4) Shared libraries copied to the zdoom executable output folder are installed in the package.
