### PR TITLE
A_SetInventory

### DIFF
--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -634,6 +634,7 @@ void AActor::RemoveInventory(AInventory *item)
 
 bool AActor::TakeInventory(PClassActor *itemclass, int amount, bool fromdecorate, bool notakeinfinite)
 {
+	amount = abs(amount);
 	AInventory *item = FindInventory(itemclass);
 
 	if (item == NULL)
@@ -666,6 +667,7 @@ bool AActor::TakeInventory(PClassActor *itemclass, int amount, bool fromdecorate
 		item->IsKindOf(RUNTIME_CLASS(AAmmo)))
 	{
 		// Nothing to do here, except maybe res = false;? Would it make sense?
+		result = false;
 	}
 	else if (!amount || amount>=item->Amount)
 	{

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -2624,6 +2624,92 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_GiveToSiblings)
 
 //===========================================================================
 //
+// A_SetInventory
+//
+//===========================================================================
+
+DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetInventory)
+{
+	PARAM_ACTION_PROLOGUE;
+	PARAM_CLASS(itemtype, AInventory);
+	PARAM_INT(amount);
+	PARAM_INT_OPT(ptr)			{ ptr = AAPTR_DEFAULT; }
+	PARAM_BOOL_OPT(beyondMax)	{ beyondMax = false; }
+
+	bool res = false;
+
+	if (itemtype == nullptr)
+	{
+		ACTION_RETURN_BOOL(false);
+	}
+
+	AActor *mobj = COPY_AAPTR(self, ptr);
+
+	if (mobj == nullptr)
+	{
+		ACTION_RETURN_BOOL(false);
+	}
+
+	AInventory *item = mobj->FindInventory(itemtype);
+
+	if (item != nullptr)
+	{
+		// A_SetInventory sets the absolute amount. 
+		// Subtract or set the appropriate amount as necessary.
+
+		if (amount == item->Amount)
+		{
+			// Nothing was changed.
+			ACTION_RETURN_BOOL(false);
+		}
+		else if (amount <= 0)
+		{
+			//Remove it all.
+			res = (mobj->TakeInventory(itemtype, item->Amount, true, false));
+			ACTION_RETURN_BOOL(res);
+		}
+		else if (amount < item->Amount)
+		{
+			int amt = abs(item->Amount - amount);
+			res = (mobj->TakeInventory(itemtype, amt, true, false));
+			ACTION_RETURN_BOOL(res);
+		}
+		else
+		{
+			item->Amount = (beyondMax ? amount : clamp(amount, 0, item->MaxAmount));
+			ACTION_RETURN_BOOL(true);
+		}
+	}
+	else
+	{
+		if (amount <= 0)
+		{
+			ACTION_RETURN_BOOL(false);
+		}
+		item = static_cast<AInventory *>(Spawn(itemtype));
+		if (item == nullptr)
+		{
+			ACTION_RETURN_BOOL(false);
+		}
+		else
+		{
+			item->Amount = amount;
+			item->flags |= MF_DROPPED;
+			item->ItemFlags |= IF_IGNORESKILL;
+			item->ClearCounters();
+			if (!item->CallTryPickup(mobj))
+			{
+				item->Destroy();
+				ACTION_RETURN_BOOL(false);
+			}
+			ACTION_RETURN_BOOL(true);
+		}
+	}
+	ACTION_RETURN_BOOL(false);
+}
+
+//===========================================================================
+//
 // A_TakeInventory
 //
 //===========================================================================

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -211,6 +211,7 @@ ACTOR Actor native //: Thinker
 	native state A_JumpIfTargetInsideMeleeRange(state label);
 	native state A_JumpIfInventory(class<Inventory> itemtype, int itemamount, state label, int owner = AAPTR_DEFAULT);
 	native state A_JumpIfArmorType(name Type, state label, int amount = 1);
+	action native bool A_SetInventory(class<Inventory> itemtype, int amount, int ptr = AAPTR_DEFAULT, bool beyondMax = false);
 	native bool A_GiveInventory(class<Inventory> itemtype, int amount = 0, int giveto = AAPTR_DEFAULT);
 	native bool A_TakeInventory(class<Inventory> itemtype, int amount = 0, int flags = 0, int giveto = AAPTR_DEFAULT);
 	action native bool A_SpawnItem(class<Actor> itemtype = "Unknown", float distance = 0, float zheight = 0, bool useammo = true, bool transfer_translation = false);


### PR DESCRIPTION
Added A_SetInventory(type, amount, ptr = AAPTR_DEFAULT, beyondMax = false).

- Sets the absolute amount of an inventory actor.
- Limits itself to the range [0, MaxAmount]. Setting beyondMax to true disregards the MaxAmount. Default is false.