### PR TITLE
Fixed serialization of MovePoly class objects

### DIFF
--- a/src/po_man.cpp
+++ b/src/po_man.cpp
@@ -265,7 +265,6 @@ void DMovePoly::Serialize(FSerializer &arc)
 {
 	Super::Serialize (arc);
 	arc("angle", m_Angle)
-		("speed", m_Speed);
 		("speedv", m_Speedv);
 }
 


### PR DESCRIPTION
Removed "speed" field which is saved in the parent class

See http://forum.zdoom.org/viewtopic.php?t=53787