### PR TITLE
Fixed serialization of DSeqPolyNode class objects

### DIFF
--- a/src/s_sndseq.cpp
+++ b/src/s_sndseq.cpp
@@ -442,7 +442,7 @@ IMPLEMENT_CLASS (DSeqPolyNode)
 void DSeqPolyNode::Serialize(FSerializer &arc)
 {
 	Super::Serialize (arc);
-	//arc << m_Poly;
+	arc("poly", m_Poly);
 }
 
 IMPLEMENT_CLASS (DSeqSectorNode)


### PR DESCRIPTION
Polyobject pointer was not serialized at all
Found this when fixing http://forum.zdoom.org/viewtopic.php?t=53787