### PR TITLE
Custom goodbye restriction

### DIFF
--- a/specs/usdf.txt
+++ b/specs/usdf.txt
@@ -87,14 +87,14 @@ conversation // Starts a dialog.
 
     page // Starts a new page.  Pages are automatically numbered starting at 1.
     {
-        name    = <string>;  // Name that goes in the upper left hand corner
-        panel   = <string>;  // Name of lump to render as the background.
-        voice   = <string>;  // Narration sound lump.
-        dialog  = <string>;  // Dialog of the page.
-        drop    = <integer>; // mobj for the object to drop if the actor is 
-                             // killed.
-        link    = <integer>; // Page to jump to if all ifitem conditions are
-                             // satisified.
+        name   = <string>;  // Name that goes in the upper left hand corner
+        panel  = <string>;  // Name of lump to render as the background.
+        voice  = <string>;  // Narration sound lump.
+        dialog = <string>;  // Dialog of the page.
+        drop   = <integer>; // mobj for the object to drop if the actor is 
+                            // killed.
+        link   = <integer>; // Page to jump to if all ifitem conditions are
+                            // satisified.
 
         // jumps to the specified page if the player has the specified amount 
         // or more of item in their inventory.  This can be repeated as many

--- a/specs/usdf.txt
+++ b/specs/usdf.txt
@@ -91,8 +91,6 @@ conversation // Starts a dialog.
         panel   = <string>;  // Name of lump to render as the background.
         voice   = <string>;  // Narration sound lump.
         dialog  = <string>;  // Dialog of the page.
-	goodbye = <string>;  // Custom goodbye message. If omitted then the
-                             // generic goodbyes will be displayed instead.
         drop    = <integer>; // mobj for the object to drop if the actor is 
                              // killed.
         link    = <integer>; // Page to jump to if all ifitem conditions are

--- a/specs/usdf_zdoom.txt
+++ b/specs/usdf_zdoom.txt
@@ -76,8 +76,8 @@ namespace = "ZDoom";
 III.A : Conversations
 ---------------------
 
-This block only lists the newly added fields. Currently ZDoom only adds one
-field to the specification:
+This block only lists the newly added fields. Currently ZDoom only adds a few
+fields to the specification:
 
 conversation // Starts a dialog.
 {
@@ -86,6 +86,12 @@ conversation // Starts a dialog.
 				// the standard conversation ID ('actor' property) is used instead
 				// for this purpose but since 'ZDoom' namespace requires the actor
 				// to be a class name it needs a separate field for this.
+
+    page
+    {
+        goodbye = <string>; // Custom goodbye message. If omitted then the
+                            // generic goodbyes will be displayed instead.
+    }
 }
 
 ===============================================================================

--- a/src/p_usdf.cpp
+++ b/src/p_usdf.cpp
@@ -333,7 +333,11 @@ class USDFParser : public UDMFParserBase
 					break;
 
 				case NAME_Goodbye:
-					Goodbye = CheckString(key);
+					// Custom goodbyes are exclusive to namespace ZDoom. [FishyClockwork]
+					if (namespace_bits == Zd)
+					{
+						Goodbye = CheckString(key);
+					}
 					break;
 				}
 			}


### PR DESCRIPTION
Undo the illegal extension of base USDF by making custom goodbyes exclusive to the ZDoom namespace (ZSDF).