### PR TITLE
Custom goodbye restriction (take 2)

### DIFF
--- a/specs/usdf.txt
+++ b/specs/usdf.txt
@@ -87,16 +87,14 @@ conversation // Starts a dialog.
 
     page // Starts a new page.  Pages are automatically numbered starting at 1.
     {
-        name    = <string>;  // Name that goes in the upper left hand corner
-        panel   = <string>;  // Name of lump to render as the background.
-        voice   = <string>;  // Narration sound lump.
-        dialog  = <string>;  // Dialog of the page.
-	goodbye = <string>;  // Custom goodbye message. If omitted then the
-                             // generic goodbyes will be displayed instead.
-        drop    = <integer>; // mobj for the object to drop if the actor is 
-                             // killed.
-        link    = <integer>; // Page to jump to if all ifitem conditions are
-                             // satisified.
+        name   = <string>;  // Name that goes in the upper left hand corner
+        panel  = <string>;  // Name of lump to render as the background.
+        voice  = <string>;  // Narration sound lump.
+        dialog = <string>;  // Dialog of the page.
+        drop   = <integer>; // mobj for the object to drop if the actor is 
+                            // killed.
+        link   = <integer>; // Page to jump to if all ifitem conditions are
+                            // satisified.
 
         // jumps to the specified page if the player has the specified amount 
         // or more of item in their inventory.  This can be repeated as many

--- a/specs/usdf_zdoom.txt
+++ b/specs/usdf_zdoom.txt
@@ -89,6 +89,9 @@ conversation // Starts a dialog.
 
     page
     {
+        goodbye = <string>; // Custom goodbye message. If omitted then the
+                            // generic goodbyes will be displayed instead.
+
         choice
         {
             // The amount of an item needed for this option to become available.

--- a/src/p_usdf.cpp
+++ b/src/p_usdf.cpp
@@ -345,7 +345,11 @@ class USDFParser : public UDMFParserBase
 					break;
 
 				case NAME_Goodbye:
-					Goodbye = CheckString(key);
+					// Custom goodbyes are exclusive to namespace ZDoom. [FishyClockwork]
+					if (namespace_bits == Zd)
+					{
+						Goodbye = CheckString(key);
+					}
 					break;
 				}
 			}


### PR DESCRIPTION
Undo the illegal extension of base USDF regarding custom goodbyes and restrict them to ZSDF.