### PR TITLE
Made 'Alternative' pointer read-only.

### DIFF
--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -260,7 +260,7 @@ void AActor::InitNativeFields()
 	meta->AddNativeField("RipLevelMin",			TypeSInt32,		myoffsetof(AActor, RipLevelMin));
 	meta->AddNativeField("RipLevelMax",			TypeSInt32,		myoffsetof(AActor, RipLevelMax));
 	meta->AddNativeField("Species",				TypeName,		myoffsetof(AActor, Species));
-	meta->AddNativeField("Alternative",			TypeActor,		myoffsetof(AActor, alternative));
+	meta->AddNativeField("Alternative",			TypeActor,		myoffsetof(AActor, alternative), VARF_ReadOnly); // Messing with this can screw up morphs.
 	meta->AddNativeField("goal",				TypeActor,		myoffsetof(AActor, goal));
 	meta->AddNativeField("MinMissileChance",	TypeUInt8,		myoffsetof(AActor, MinMissileChance));
 	meta->AddNativeField("LastLookPlayerNumber",TypeSInt8,		myoffsetof(AActor, LastLookPlayerNumber));


### PR DESCRIPTION
- Mods can abuse this pointer and make it so entities cannot unmorph at all, especially players.