### PR TITLE
Fixed: A StateProvider actor could no longer use its own user variables

### DIFF
--- a/src/scripting/codegeneration/codegen.h
+++ b/src/scripting/codegeneration/codegen.h
@@ -347,12 +347,13 @@ public:
 
 	FxIdentifier(FName i, const FScriptPosition &p);
 	FxExpression *Resolve(FCompileContext&);
+	FxExpression *ResolveMember(FCompileContext&, PClass*, FxExpression*&, PStruct*);
 };
 
 
 //==========================================================================
 //
-//	FxIdentifier
+//	FxMemberIdentifier
 //
 //==========================================================================
 
@@ -1240,8 +1241,10 @@ public:
 
 class FxSelf : public FxExpression
 {
+	bool check;
+
 public:
-	FxSelf(const FScriptPosition&);
+	FxSelf(const FScriptPosition&, bool deccheck = false);
 	FxExpression *Resolve(FCompileContext&);
 	ExpEmit Emit(VMFunctionBuilder *build);
 };


### PR DESCRIPTION
Refactored the FxIdentifier code a bit to avoid code duplication