### PR TITLE
Velocity Check

### DIFF
--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -3373,11 +3373,14 @@ void AActor::Tick ()
 			}
 		}
 
-		UnlinkFromWorld ();
-		flags |= MF_NOBLOCKMAP;
-		SetXYZ(Vec3Offset(Vel));
-		CheckPortalTransition(false);
-		LinkToWorld ();
+		if (!Vel.isZero() || !(flags & MF_NOBLOCKMAP))
+		{
+			UnlinkFromWorld();
+			flags |= MF_NOBLOCKMAP;
+			SetXYZ(Vec3Offset(Vel));
+			CheckPortalTransition(false);
+			LinkToWorld();
+		}
 	}
 	else
 	{


### PR DESCRIPTION
- Fixed: Actors with NOINTERACTION shouldn't waste time continuously applying NOBLOCKMAP if it has it already and not moving.