### PR TITLE
- Implemented sv_overridegetcvar: This will override the return value…

### DIFF
--- a/src/c_cvars.cpp
+++ b/src/c_cvars.cpp
@@ -52,6 +52,13 @@
 #include "v_video.h"
 #include "colormatcher.h"
 
+// [SP] This is a dummy CVAR that needs to be removed in child ports that implement the real version.
+CVAR(Int, vid_renderer, 1, CVAR_GLOBALCONFIG | CVAR_OVERRIDEGET | CVAR_ARCHIVE)
+
+// [SP] Lets the player (arbitrator) choose whether to override GetCVar checks.
+//   Danger of desync? Can we just make it a client var? This probably *fixes* desyncs, actually...
+CVAR(Bool, sv_overridegetcvar, true, CVAR_SERVERINFO | CVAR_GLOBALCONFIG | CVAR_ARCHIVE)
+
 struct FLatchedValue
 {
 	FBaseCVar *Variable;

--- a/src/c_cvars.h
+++ b/src/c_cvars.h
@@ -63,6 +63,7 @@ enum
 	CVAR_NOSAVE			= 4096, // when used with CVAR_SERVERINFO, do not save var to savegame
 	CVAR_MOD			= 8192,	// cvar was defined by a mod
 	CVAR_IGNORE			= 16384,// do not send cvar across the network/inaccesible from ACS (dummy mod cvar)
+	CVAR_OVERRIDEGET	= 32768,// this cvar disguises its return value for GetCVAR
 };
 
 union UCVarValue

--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -4549,6 +4549,8 @@ static void DoSetCVar(FBaseCVar *cvar, int value, bool is_string, bool force=fal
 	}
 }
 
+EXTERN_CVAR(Bool, sv_overridegetcvar)
+
 // Converts floating- to fixed-point as required.
 static int DoGetCVar(FBaseCVar *cvar, bool is_string)
 {
@@ -4557,6 +4559,24 @@ static int DoGetCVar(FBaseCVar *cvar, bool is_string)
 	if (cvar == nullptr)
 	{
 		return 0;
+	}
+	else if (sv_overridegetcvar && (cvar->GetFlags() & CVAR_OVERRIDEGET))
+	{
+		if (is_string)
+		{
+			val = cvar->GetGenericRepDefault(CVAR_String);
+			return GlobalACSStrings.AddString(val.String);
+		}
+		else if (cvar->GetRealType() == CVAR_Float)
+		{
+			val = cvar->GetGenericRepDefault(CVAR_Float);
+			return DoubleToACS(val.Float);
+		}
+		else
+		{
+			val = cvar->GetGenericRepDefault(CVAR_Int);
+			return val.Int;
+		}
 	}
 	else if (is_string)
 	{

--- a/src/p_actionfunctions.cpp
+++ b/src/p_actionfunctions.cpp
@@ -621,6 +621,8 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, GetCrouchFactor)
 //
 //==========================================================================
 
+EXTERN_CVAR(Bool, sv_overridegetcvar)
+
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, GetCVar)
 {
 	if (numret > 0)
@@ -633,6 +635,10 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, GetCVar)
 		if (cvar == nullptr)
 		{
 			ret->SetFloat(0);
+		}
+		else if (sv_overridegetcvar && (cvar->GetFlags() & CVAR_OVERRIDEGET))
+		{
+			ret->SetFloat(cvar->GetGenericRepDefault(CVAR_Float).Float);
 		}
 		else
 		{


### PR DESCRIPTION
… for GetCVar checks for certain CVars marked with the CVAR_OVERRIDEGET flag. Instead of returning their true value, they only return defaults instead.

- Implemented dummy CVar vid_renderer with a default value of 1. This allows mods not designed for the software renderer to run if sv_overridegetcvar is turned on.