### PR TITLE
A few fixes for macOS

### DIFF
--- a/src/posix/cocoa/i_input.mm
+++ b/src/posix/cocoa/i_input.mm
@@ -526,7 +526,7 @@ void ProcessMouseMoveInGame(NSEvent* theEvent)
 	lastX = x;
 	lastY = y;
 
-	if (0 != event.x | 0 != event.y)
+	if (0 != event.x || 0 != event.y)
 	{
 		event.type = EV_Mouse;
 		

--- a/src/posix/cocoa/i_joystick.cpp
+++ b/src/posix/cocoa/i_joystick.cpp
@@ -1018,7 +1018,7 @@ IOKitJoystickManager::~IOKitJoystickManager()
 		if (0 != notification)
 		{
 			IOObjectRelease(notification);
-			notification = NULL;
+			notification = 0;
 		}
 	}
 }

--- a/src/posix/cocoa/i_main.mm
+++ b/src/posix/cocoa/i_main.mm
@@ -156,7 +156,7 @@ static void I_DetectOS()
 		case 12: name = "macOS Sierra";          break;
 	}
 
-	char release[16] = {};
+	char release[16] = "unknown";
 	size_t size = sizeof release - 1;
 	sysctlbyname("kern.osversion", release, &size, nullptr, 0);
 	

--- a/src/resourcefiles/file_zip.cpp
+++ b/src/resourcefiles/file_zip.cpp
@@ -577,7 +577,7 @@ bool WriteZip(const char *filename, TArray<FString> &filenames, TArray<FCompress
 		dirend.DiskNumber = 0;
 		dirend.FirstDisk = 0;
 		dirend.NumEntriesOnAllDisks = dirend.NumEntries = LittleShort(filenames.Size());
-		dirend.DirectoryOffset = dirofs;
+		dirend.DirectoryOffset = LittleLong(dirofs);
 		dirend.DirectorySize = LittleLong(ftell(f) - dirofs);
 		dirend.ZipCommentLength = 0;
 		if (fwrite(&dirend, sizeof(dirend), 1, f) != 1)


### PR DESCRIPTION
Fixed endianness issue with saved games
Fixed compilation warnings in Cocoa backend
Print unknown if release information is unavailable on macOS