### PR TITLE
- Preventive fix for future include conflicts.

### DIFF
--- a/src/posix/cocoa/i_timer.cpp
+++ b/src/posix/cocoa/i_timer.cpp
@@ -37,8 +37,6 @@
 #include <pthread.h>
 #include <libkern/OSAtomic.h>
 
-#include "basictypes.h"
-#include "basicinlines.h"
 #include "doomdef.h"
 #include "i_system.h"
 #include "templates.h"

--- a/src/posix/sdl/i_timer.cpp
+++ b/src/posix/sdl/i_timer.cpp
@@ -7,8 +7,7 @@
 
 #include <SDL.h>
 
-#include "basictypes.h"
-#include "basicinlines.h"
+#include "m_fixed.h"
 #include "hardware.h"
 #include "i_system.h"
 #include "templates.h"


### PR DESCRIPTION
```basicinlines.h``` is only included in ```m_fixed.h```, while ```basictypes.h``` is included only in headers, so it's better to respect this convention.

This fixes a problem with zscript and zandronum-zdoom-sync not compiling ```i_timer.cpp``` because of duplicate function names.

CCing @alexey-lysiuk to know if the patch works in OSX backend.