### PR TITLE
Backported A_FireRailgun 'puffType' parameter from Zandronum.

### DIFF
--- a/src/g_doom/a_doomweaps.cpp
+++ b/src/g_doom/a_doomweaps.cpp
@@ -540,7 +540,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_FirePlasma)
 // [RH] A_FireRailgun
 // [TP] Now takes a puff class
 //
-static void FireRailgun(AActor *self, int offset_xy, bool fromweapon, PClassActor* puffType = NULL )
+static void FireRailgun(AActor *self, int offset_xy, bool fromweapon, PClassActor* puffType = NULL)
 {
 	int damage;
 	player_t *player;
@@ -578,8 +578,8 @@ static void FireRailgun(AActor *self, int offset_xy, bool fromweapon, PClassActo
 DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FireRailgun)
 {
 	PARAM_ACTION_PROLOGUE;
-	PARAM_CLASS_OPT	(pufftype, AActor) { pufftype = PClass::FindActor(NAME_BulletPuff); }
-	FireRailgun(self, 0, ACTION_CALL_FROM_PSPRITE(), pufftype );
+	PARAM_CLASS_OPT	(pufftype, AActor)	{ pufftype = PClass::FindActor(NAME_BulletPuff); }
+	FireRailgun(self, 0, ACTION_CALL_FROM_PSPRITE(), pufftype);
 	return 0;
 }
 

--- a/src/g_doom/a_doomweaps.cpp
+++ b/src/g_doom/a_doomweaps.cpp
@@ -538,8 +538,9 @@ DEFINE_ACTION_FUNCTION(AActor, A_FirePlasma)
 
 //
 // [RH] A_FireRailgun
+// [TP] Now takes a puff class
 //
-static void FireRailgun(AActor *self, int offset_xy, bool fromweapon)
+static void FireRailgun(AActor *self, int offset_xy, bool fromweapon, PClassActor* puffType = NULL )
 {
 	int damage;
 	player_t *player;
@@ -568,14 +569,17 @@ static void FireRailgun(AActor *self, int offset_xy, bool fromweapon)
 	p.source = self;
 	p.damage = damage;
 	p.offset_xy = offset_xy;
+	// [TP] Now takes a puff too.
+	p.puff = puffType;
 	P_RailAttack (&p);
 }
 
-
-DEFINE_ACTION_FUNCTION(AActor, A_FireRailgun)
+// [TP] This now takes a puff type to retain Skulltag's railgun's ability to pierce armor.
+DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_FireRailgun)
 {
 	PARAM_ACTION_PROLOGUE;
-	FireRailgun(self, 0, ACTION_CALL_FROM_PSPRITE());
+	PARAM_CLASS_OPT	(pufftype, AActor) { pufftype = PClass::FindActor(NAME_BulletPuff); }
+	FireRailgun(self, 0, ACTION_CALL_FROM_PSPRITE(), pufftype );
 	return 0;
 }
 

--- a/wadsrc/static/actors/shared/inventory.txt
+++ b/wadsrc/static/actors/shared/inventory.txt
@@ -30,7 +30,7 @@ ACTOR Inventory native
 	action native A_FireSTGrenade(class<Actor> grenadetype = "Grenade");
 	action native A_FireMissile();
 	action native A_FirePlasma();
-	action native A_FireRailgun();
+	action native A_FireRailgun( class<Actor> puffType = "None" ); // [TP] Now takes a puff parameter
 	action native A_FireRailgunLeft();
 	action native A_FireRailgunRight();
 	action native A_RailWait();

--- a/wadsrc/static/actors/shared/inventory.txt
+++ b/wadsrc/static/actors/shared/inventory.txt
@@ -30,7 +30,7 @@ ACTOR Inventory native
 	action native A_FireSTGrenade(class<Actor> grenadetype = "Grenade");
 	action native A_FireMissile();
 	action native A_FirePlasma();
-	action native A_FireRailgun( class<Actor> puffType = "None" ); // [TP] Now takes a puff parameter
+	action native A_FireRailgun(class<Actor> puffType = "None"); // [TP] Now takes a puff parameter
 	action native A_FireRailgunLeft();
 	action native A_FireRailgunRight();
 	action native A_RailWait();


### PR DESCRIPTION
Zandronum added this so that it could restore the original Skulltag piercing armor capability with a specific puff, like it's done with the other railgun action functions.