### PR TITLE
- Backported A_FireRailgun 'puffType' parameter from Zandronum.

### DIFF
--- a/wadsrc/static/zscript/doom/doomweapons.txt
+++ b/wadsrc/static/zscript/doom/doomweapons.txt
@@ -19,8 +19,9 @@ extend class StateProvider
 
 	//
 	// [RH] A_FireRailgun
+	// [TP] This now takes a puff type to retain Skulltag's railgun's ability to pierce armor.
 	//
-	action void A_FireRailgun(int offset_xy = 0)
+	action void A_FireRailgun(class<Actor> puffType = "BulletPuff", int offset_xy = 0)
 	{
 		if (player == null)
 		{
@@ -42,17 +43,17 @@ extend class StateProvider
 		}
 
 		int damage = deathmatch ? 100 : 150;
-		A_RailAttack(damage, offset_xy, false);	// note that this function handles ammo depletion itself for Dehacked compatibility purposes.
+		A_RailAttack(damage, offset_xy, false, pufftype: puffType);	// note that this function handles ammo depletion itself for Dehacked compatibility purposes.
 	}
 
 	action void A_FireRailgunLeft()
 	{
-		A_FireRailgun(-10);
+		A_FireRailgun(offset_xy: -10);
 	}
 
 	action void A_FireRailgunRight()
 	{
-		A_FireRailgun(10);
+		A_FireRailgun(offset_xy: 10);
 	}
 
 	action void A_RailWait() 


### PR DESCRIPTION
Zandronum added this so that it could restore the original Skulltag piercing armor capability with a specific puff, like it's done with the other zdoom railgun action functions.