### PR TITLE
- Fixed GCC compilation error.

### DIFF
--- a/src/scripting/codegeneration/codegen.cpp
+++ b/src/scripting/codegeneration/codegen.cpp
@@ -5590,8 +5590,7 @@ FxExpression *FxIdentifier::Resolve(FCompileContext& ctx)
 		goto foundit;
 	}
 
-	auto cvar = FindCVar(Identifier.GetChars(), nullptr);
-	if (cvar != nullptr)
+	if (auto *cvar = FindCVar(Identifier.GetChars(), nullptr))
 	{
 		if (cvar->GetFlags() & CVAR_USERINFO)
 		{


### PR DESCRIPTION
It didn't like 'cvar' being declared between 'goto foundit' and the 'foundit' label.