### PR TITLE
CMF_AIMDIRECTION Fix

### DIFF
--- a/src/p_actionfunctions.cpp
+++ b/src/p_actionfunctions.cpp
@@ -1524,7 +1524,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_CustomMissile)
 						Pitch += missile->Vel.Pitch();
 					}
 					missilespeed = fabs(Pitch.Cos() * missile->Speed);
-					missile->Vel.Z = Pitch.Sin() * missile->Speed;
+					missile->Vel.Z = -Pitch.Sin() * missile->Speed;
 				}
 				else
 				{


### PR DESCRIPTION
Fixed: A_CustomMissile's CMF_AIMDIRECTION's pitch calculations were also backwards.