### PR TITLE
Change DPI Awareness to per-monitor on Windows8.1+

### DIFF
--- a/src/win32/zdoom.exe.manifest
+++ b/src/win32/zdoom.exe.manifest
@@ -14,7 +14,7 @@
   </trustInfo>
   <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
     <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
-      <dpiAware>true</dpiAware>
+      <dpiAware>true/pm</dpiAware>
     </asmv3:windowsSettings>
   </asmv3:application>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">


### PR DESCRIPTION
Just a simple change of the dpiaware from true to true/pm to enable Windows 8.1 Per-Monitor DPI awareness while retaining compatibility with Windows 8.0, 7, and Vista DPI scaling.