### PR TITLE
Add missing GCCPRINTF attribute to some printf-like functions

### DIFF
--- a/src/files.h
+++ b/src/files.h
@@ -374,7 +374,7 @@ public:
 	static FileWriter *Open(const char *filename);
 
 	virtual size_t Write(const void *buffer, size_t len);
-	size_t Printf(const char *fmt, ...);
+	size_t Printf(const char *fmt, ...) GCCPRINTF(2,3);
 
 protected:
 

--- a/src/fragglescript/t_script.h
+++ b/src/fragglescript/t_script.h
@@ -718,7 +718,7 @@ public:
 
 #include "t_fs.h"
 
-void script_error(const char *s, ...);
+void script_error(const char *s, ...) GCCPRINTF(1,2);
 void FS_EmulateCmd(char * string);
 
 extern AActor *trigger_obj;

--- a/src/r_data/voxels.cpp
+++ b/src/r_data/voxels.cpp
@@ -456,7 +456,7 @@ static bool VOX_ReadSpriteNames(FScanner &sc, TArray<DWORD> &vsprites)
 		}
 		else if (sc.StringLen == 5 && (sc.String[4] = toupper(sc.String[4]), sc.String[4] < 'A' || sc.String[4] >= 'A' + MAX_SPRITE_FRAMES))
 		{
-			sc.ScriptMessage("Sprite frame %s is invalid.\n", sc.String[4]);
+			sc.ScriptMessage("Sprite frame %c is invalid.\n", sc.String[4]);
 		}
 		else
 		{

--- a/src/sc_man.h
+++ b/src/sc_man.h
@@ -61,8 +61,8 @@ public:
 	int MustMatchString(const char * const *strings, size_t stride = sizeof(char*));
 	int GetMessageLine();
 
-	void ScriptError(const char *message, ...);
-	void ScriptMessage(const char *message, ...);
+	void ScriptError(const char *message, ...) GCCPRINTF(2,3);
+	void ScriptMessage(const char *message, ...) GCCPRINTF(2,3);
 
 	bool isText();
 
@@ -155,7 +155,7 @@ struct FScriptPosition
 	FScriptPosition(FString fname, int line);
 	FScriptPosition(FScanner &sc);
 	FScriptPosition &operator=(const FScriptPosition &other);
-	void Message(int severity, const char *message,...) const;
+	void Message(int severity, const char *message,...) const GCCPRINTF(3,4);
 	static void ResetErrorCounter()
 	{
 		WarnCounter = 0;

--- a/src/scripting/zscript/zcc_compile.h
+++ b/src/scripting/zscript/zcc_compile.h
@@ -135,8 +135,8 @@ private:
 	ZCC_ExprTypeRef *NodeFromSymbolType(PSymbolType *sym, ZCC_Expression *idnode);
 
 
-	void Warn(ZCC_TreeNode *node, const char *msg, ...);
-	void Error(ZCC_TreeNode *node, const char *msg, ...);
+	void Warn(ZCC_TreeNode *node, const char *msg, ...) GCCPRINTF(3,4);
+	void Error(ZCC_TreeNode *node, const char *msg, ...) GCCPRINTF(3,4);
 	void MessageV(ZCC_TreeNode *node, const char *txtcolor, const char *msg, va_list argptr);
 
 	FxExpression *ConvertAST(PStruct *cclass, ZCC_TreeNode *ast);

--- a/src/timidity/timidity.h
+++ b/src/timidity/timidity.h
@@ -190,7 +190,7 @@ enum
 	VERB_DEBUG
 };
 
-void cmsg(int type, int verbosity_level, const char *fmt, ...);
+void cmsg(int type, int verbosity_level, const char *fmt, ...) GCCPRINTF(3,4);
 
 
 /*


### PR DESCRIPTION
The commit a7c80ae858eb85b58908f9893bec1475fa92a3ee made me realize that we missed the proper format checks to FScanner and others. The changes will help uncover the problems for gcc-like compilers (I'll make a new bug report for these). I fixed also the voxeldef error because it was easy enough.

Note: I split the changes because this way fork projects can cherry-pick some of these commits (for example zandronum contains the same error in voxeldef code).