### PR TITLE
Update Game-Music-Emu to version 0.6.1

### DIFF
--- a/game-music-emu/CMakeLists.txt
+++ b/game-music-emu/CMakeLists.txt
@@ -104,10 +104,10 @@ if (CMAKE_COMPILER_IS_GNUCXX)
          endif()
       endif()
    endif() # test visibility
-endif()
 
-# Cache this result
-set( LIBGME_HAVE_GCC_VISIBILITY ${ENABLE_VISIBILITY} CACHE BOOL "GCC support for hidden visibility")
+    # Cache this result
+    set( LIBGME_HAVE_GCC_VISIBILITY ${ENABLE_VISIBILITY} CACHE BOOL "GCC support for hidden visibility")
+endif()
 
 # Shared library defined here
 add_subdirectory(gme)

--- a/game-music-emu/CMakeLists.txt
+++ b/game-music-emu/CMakeLists.txt
@@ -4,7 +4,7 @@ project(libgme)
 include (CheckCXXCompilerFlag)
 
 # When version is changed, also change the one in gme/gme.h to match
-set(GME_VERSION 0.6.0 CACHE INTERNAL "libgme Version")
+set(GME_VERSION 0.6.1 CACHE INTERNAL "libgme Version")
 
 # 2.6+ always assumes FATAL_ERROR, but 2.4 and below don't.
 # Of course, 2.4 might work, in which case you're welcome to drop

--- a/game-music-emu/CMakeLists.txt
+++ b/game-music-emu/CMakeLists.txt
@@ -108,3 +108,10 @@ set( LIBGME_HAVE_GCC_VISIBILITY ${ENABLE_VISIBILITY} CACHE BOOL "GCC support for
 
 # Shared library defined here
 add_subdirectory(gme)
+
+# EXCLUDE_FROM_ALL adds build rules but keeps it out of default build
+# [ZDoom] Not needed.
+if( FALSE )
+add_subdirectory(player EXCLUDE_FROM_ALL)
+add_subdirectory(demo EXCLUDE_FROM_ALL)
+endif()

--- a/game-music-emu/CMakeLists.txt
+++ b/game-music-emu/CMakeLists.txt
@@ -79,6 +79,9 @@ set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ZD_FASTMATH_FLAG}" )
     SET(USE_GME_NSF 1 BOOL "Enable NES NSF music emulation")
 #endif()
 
+# [ZDoom] Set always to OFF.
+set(BUILD_SHARED_LIBS 0 BOOL "Build shared library (set to OFF for static library)")
+
 # Check for GCC "visibility" support.
 if (CMAKE_COMPILER_IS_GNUCXX)
    check_cxx_compiler_flag (-fvisibility=hidden __LIBGME_TEST_VISIBILITY)

--- a/game-music-emu/changes.txt
+++ b/game-music-emu/changes.txt
@@ -1,6 +1,12 @@
 Game_Music_Emu Change Log
 -------------------------
 
+Game_Music_Emu 0.6.1
+--------------------
+
+- Packaging improvements:
+    - Honor $LIB_SUFFIX for installed pkg-config metadata.
+
 Game_Music_Emu 0.6.0
 --------------------
 

--- a/game-music-emu/changes.txt
+++ b/game-music-emu/changes.txt
@@ -4,8 +4,14 @@ Game_Music_Emu Change Log
 Game_Music_Emu 0.6.1
 --------------------
 
+- Moved repository to Bitbucket since Google Code announced they would
+  shutdown this year.
+
 - Packaging improvements:
     - Honor $LIB_SUFFIX for installed pkg-config metadata.
+    - Support setting BUILD_SHARED_LIBS to OFF to build libgme as a static
+      library. (Pass -DBUILD_SHARED_LIBS=OFF when running cmake).
+      Thanks to lachs0r.
 
 Game_Music_Emu 0.6.0
 --------------------

--- a/game-music-emu/gme.txt
+++ b/game-music-emu/gme.txt
@@ -1,10 +1,11 @@
-Game_Music_Emu 0.6.0
+Game_Music_Emu 0.6.1
 --------------------
-Author : Shay Green <gblargg@gmail.com>
-Website: http://www.slack.net/~ant/libs/
-Forum  : http://groups.google.com/group/blargg-sound-libs
-Source : https://code.google.com/p/game-music-emu/
-License: GNU Lesser General Public License (LGPL)
+Author     : Shay Green <gblargg@gmail.com>
+Maintainer : Michael Pyne <mpyne@purinchu.net>
+Website    : http://www.slack.net/~ant/libs/
+Forum      : http://groups.google.com/group/blargg-sound-libs
+Source     : https://bitbucket.org/mpyne/game-music-emu/
+License    : GNU Lesser General Public License (LGPL), see LICENSE.txt
 
 Contents
 --------

--- a/game-music-emu/gme/CMakeLists.txt
+++ b/game-music-emu/gme/CMakeLists.txt
@@ -131,6 +131,12 @@ set (EXPORTED_HEADERS gme.h)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/gme_types.h.in
     ${CMAKE_CURRENT_BINARY_DIR}/gme_types.h)
 
+# [ZDoom] Not needed.
+if( FALSE )
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libgme.pc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/libgme.pc @ONLY)
+endif()
+
 # On some platforms we may need to change headers or whatnot based on whether
 # we're building the library or merely using the library. The following is
 # only defined when building the library to allow us to tell which is which.
@@ -147,7 +153,18 @@ add_library(gme ${libgme_SRCS})
 # to the API), the SOVERSION should be the same even when bumping up VERSION.
 # The way gme.h is designed, SOVERSION should very rarely be bumped, if ever.
 # Hopefully the API can stay compatible with old versions.
-#set_target_properties(gme
-#    PROPERTIES VERSION ${GME_VERSION}
-#               SOVERSION 0)
+# [ZDoom] Not needed.
+if( FALSE )
+set_target_properties(gme
+    PROPERTIES VERSION ${GME_VERSION}
+               SOVERSION 0)
+
+install(TARGETS gme LIBRARY DESTINATION lib${LIB_SUFFIX}
+                    RUNTIME DESTINATION bin  # DLL platforms
+                    ARCHIVE DESTINATION lib) # DLL platforms
+
+install(FILES ${EXPORTED_HEADERS} DESTINATION include/gme)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libgme.pc DESTINATION lib/pkgconfig)
+endif()
+
 target_link_libraries(gme)

--- a/game-music-emu/gme/CMakeLists.txt
+++ b/game-music-emu/gme/CMakeLists.txt
@@ -164,7 +164,7 @@ install(TARGETS gme LIBRARY DESTINATION lib${LIB_SUFFIX}
                     ARCHIVE DESTINATION lib) # DLL platforms
 
 install(FILES ${EXPORTED_HEADERS} DESTINATION include/gme)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libgme.pc DESTINATION lib/pkgconfig)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libgme.pc DESTINATION lib${LIB_SUFFIX}/pkgconfig)
 endif()
 
 target_link_libraries(gme)

--- a/game-music-emu/gme/Data_Reader.h
+++ b/game-music-emu/gme/Data_Reader.h
@@ -129,6 +129,8 @@ private:
 };
 
 #ifdef HAVE_ZLIB_H
+#include <zlib.h>
+
 // Gzip compressed file reader
 class Gzip_File_Reader : public File_Reader {
 public:
@@ -143,7 +145,7 @@ public:
 	long tell() const;
 	blargg_err_t seek( long );
 private:
-	void* file_;
+	gzFile file_;
 	long size_;
 };
 #endif

--- a/game-music-emu/gme/Music_Emu.cpp
+++ b/game-music-emu/gme/Music_Emu.cpp
@@ -178,6 +178,11 @@ blargg_long Music_Emu::msec_to_samples( blargg_long msec ) const
 	return (sec * sample_rate() + msec * sample_rate() / 1000) * stereo;
 }
 
+long Music_Emu::tell_samples() const
+{
+	return out_time;
+}
+
 long Music_Emu::tell() const
 {
 	blargg_long rate = sample_rate() * stereo;
@@ -185,12 +190,16 @@ long Music_Emu::tell() const
 	return sec * 1000 + (out_time - sec * rate) * 1000 / rate;
 }
 
-blargg_err_t Music_Emu::seek( long msec )
+blargg_err_t Music_Emu::seek_samples( long time )
 {
-	blargg_long time = msec_to_samples( msec );
 	if ( time < out_time )
 		RETURN_ERR( start_track( current_track_ ) );
 	return skip( time - out_time );
+}
+
+blargg_err_t Music_Emu::seek( long msec )
+{
+	return seek_samples( msec_to_samples( msec ) );
 }
 
 blargg_err_t Music_Emu::skip( long count )

--- a/game-music-emu/gme/Music_Emu.h
+++ b/game-music-emu/gme/Music_Emu.h
@@ -41,8 +41,14 @@ public:
 	// Number of milliseconds (1000 msec = 1 second) played since beginning of track
 	long tell() const;
 	
+	// Number of samples generated since beginning of track
+	long tell_samples() const;
+
 	// Seek to new time in track. Seeking backwards or far forward can take a while.
 	blargg_err_t seek( long msec );
+	
+	// Equivalent to restarting track then skipping n samples
+	blargg_err_t seek_samples( long n );
 	
 	// Skip n samples
 	blargg_err_t skip( long n );

--- a/game-music-emu/gme/Spc_Cpu.cpp
+++ b/game-music-emu/gme/Spc_Cpu.cpp
@@ -433,9 +433,7 @@ void Snes_Spc::cpu_write( int data, int addr, rel_time_t time )
 			#endif
 			
 			// Registers other than $F2 and $F4-$F7
-			//if ( reg != 2 && reg != 4 && reg != 5 && reg != 6 && reg != 7 )
-			// TODO: this is a bit on the fragile side
-			if ( ((~0x2F00 << (bits_in_int - 16)) << reg) < 0 ) // 36%
+			if ( reg != 2 && (reg < 4 || reg > 7) ) // 36%
 				cpu_write_smp_reg( data, time, reg );
 		}
 		// High mem/address wrap-around

--- a/game-music-emu/gme/Spc_Cpu.h
+++ b/game-music-emu/gme/Spc_Cpu.h
@@ -77,7 +77,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA */
 #define SPC_NO_SP_WRAPAROUND 0
 
 #define SET_SP( v )     (sp = ram + 0x101 + ((uint8_t) v))
-#define GET_SP()        (uint8_t) (sp - 0x101 - ram)
+#define GET_SP()        (uint8_t (sp - 0x101 - ram))
 
 #if SPC_NO_SP_WRAPAROUND
 #define PUSH16( v )     (sp -= 2, SET_LE16( sp, v ))

--- a/game-music-emu/gme/gme.cpp
+++ b/game-music-emu/gme/gme.cpp
@@ -337,7 +337,9 @@ BLARGG_EXPORT gme_err_t gme_play           ( Music_Emu* me, int n, short* p )   
 BLARGG_EXPORT void      gme_set_fade       ( Music_Emu* me, int start_msec )      { me->set_fade( start_msec ); }
 BLARGG_EXPORT int       gme_track_ended    ( Music_Emu const* me )                { return me->track_ended(); }
 BLARGG_EXPORT int       gme_tell           ( Music_Emu const* me )                { return me->tell(); }
+BLARGG_EXPORT int       gme_tell_samples   ( Music_Emu const* me )                { return me->tell_samples(); }
 BLARGG_EXPORT gme_err_t gme_seek           ( Music_Emu* me, int msec )            { return me->seek( msec ); }
+BLARGG_EXPORT gme_err_t gme_seek_samples   ( Music_Emu* me, int n )               { return me->seek_samples( n ); }
 BLARGG_EXPORT int       gme_voice_count    ( Music_Emu const* me )                { return me->voice_count(); }
 BLARGG_EXPORT void      gme_ignore_silence ( Music_Emu* me, int disable )         { me->ignore_silence( disable != 0 ); }
 BLARGG_EXPORT void      gme_set_tempo      ( Music_Emu* me, double t )            { me->set_tempo( t ); }

--- a/game-music-emu/gme/gme.h
+++ b/game-music-emu/gme/gme.h
@@ -1,6 +1,6 @@
 /* Game music emulator library C interface (also usable from C++) */
 
-/* Game_Music_Emu 0.6.0 */
+/* Game_Music_Emu 0.6.1 */
 #ifndef GME_H
 #define GME_H
 
@@ -8,7 +8,7 @@
 	extern "C" {
 #endif
 
-#define GME_VERSION 0x000600 /* 1 byte major, 1 byte minor, 1 byte patch-level */
+#define GME_VERSION 0x000601 /* 1 byte major, 1 byte minor, 1 byte patch-level */
 
 /* Error string returned by library functions, or NULL if no error (success) */
 typedef const char* gme_err_t;

--- a/game-music-emu/gme/gme.h
+++ b/game-music-emu/gme/gme.h
@@ -47,8 +47,14 @@ int gme_track_ended( Music_Emu const* );
 /* Number of milliseconds (1000 = one second) played since beginning of track */
 int gme_tell( Music_Emu const* );
 
+/* Number of samples generated since beginning of track */
+int gme_tell_samples( Music_Emu const* );
+
 /* Seek to new time in track. Seeking backwards or far forward can take a while. */
 gme_err_t gme_seek( Music_Emu*, int msec );
+
+/* Equivalent to restarting track then skipping n samples */
+gme_err_t gme_seek_samples( Music_Emu*, int n );
 
 
 /******** Informational ********/

--- a/game-music-emu/readme.txt
+++ b/game-music-emu/readme.txt
@@ -1,4 +1,4 @@
-Game_Music_Emu 0.6.0: Game Music Emulators
+Game_Music_Emu 0.6.1: Game Music Emulators
 ------------------------------------------
 Game_Music_Emu is a collection of video game music file emulators that
 support the following formats and systems:
@@ -38,25 +38,41 @@ Website: http://www.slack.net/~ant/
 Forum  : http://groups.google.com/group/blargg-sound-libs
 License: GNU Lesser General Public License (LGPL)
 
+Current Maintainer: Michael Pyne <mpyne@purinchu.net>
 
 Getting Started
 ---------------
 Build a program consisting of demo/basics.c, demo/Wave_Writer.cpp, and
-all source files in gme/. If you have CMake 2.6 or later, execute
+all source files in gme/.
 
-	run cmake
-	cd demo
-	run make
+Or, if you have CMake 2.6 or later, execute at a command prompt (from the
+extracted source directory):
 
-Be sure "test.nsf" is in the same directory as the program. Running it
+    mkdir build
+    cd build
+    cmake ../         # <-- Pass any needed CMake flags here
+    make              # To build the library
+    cd demo
+    make              # To build the demo itself
+
+Be sure "test.nsf" is in the same directory as the demo program. Running it
 should generate the recording "out.wav".
+
+You can use "make install" to install the library. To choose where to install
+the library to, use the CMake argument "-DCMAKE_INSTALL_PREFIX=/usr/local"
+(and replace /usr/local with the base path you wish to use). Alternately, you
+can specify the base path to install to when you run "make install" by passing
+'DESTDIR=/usr/local' on the make install command line (again, replace
+/usr/local as appropriate).
+
+To build a static library instead of shared (the default), pass
+-DBUILD_SHARED_LIBS=OFF to the cmake command when running cmake.
 
 A slightly more extensive demo application is available in the player/
 directory.  It requires SDL to build.
 
 Read gme.txt for more information. Post to the discussion forum for
 assistance.
-
 
 Files
 -----


### PR DESCRIPTION
Probably an additional 'warning-silencing' commit for commit f977f24 is required, but I don't have the system to test it.

Of course, the referred commits in the messages are referred to the [original gme source](https://bitbucket.org/mpyne/game-music-emu).