### PR TITLE
Fixed bugs with Line_PortalSetTarget and added more portal geometry warnings

### DIFF
--- a/src/portal.cpp
+++ b/src/portal.cpp
@@ -296,10 +296,7 @@ void P_SpawnLinePortal(line_t* line)
 				port->mType = PORTT_TELEPORT;
 			}
 		}
-		if (port->mDestination != NULL)
-		{
-			port->mDefFlags = port->mType == PORTT_VISUAL ? PORTF_VISIBLE : port->mType == PORTT_TELEPORT ? PORTF_TYPETELEPORT : PORTF_TYPEINTERACTIVE;
-		}
+		port->mDefFlags = port->mType == PORTT_VISUAL ? PORTF_VISIBLE : port->mType == PORTT_TELEPORT ? PORTF_TYPETELEPORT : PORTF_TYPEINTERACTIVE;
 	}
 	else if (line->args[2] == PORTT_LINKEDEE && line->args[0] == 0)
 	{
@@ -349,6 +346,13 @@ void P_SpawnLinePortal(line_t* line)
 
 void P_UpdatePortal(FLinePortal *port)
 {
+	if (port->mType != PORTT_VISUAL && port->mOrigin->backsector == nullptr && !(port->mOrigin->sidedef[0]->Flags & WALLF_POLYOBJ))
+	{
+		Printf(TEXTCOLOR_RED "Warning: Traversable portals must have a back-sector and empty space behind them (or be on a polyobject)! Changing line %d to visual-portal!\n", port->mOrigin->Index());
+		port->mType = PORTT_VISUAL;
+		port->mDefFlags &= ~(PORTF_PASSABLE | PORTF_SOUNDTRAVERSE);
+	}
+	
 	if (port->mDestination == NULL)
 	{
 		// Portal has no destination: switch it off
@@ -363,6 +367,7 @@ void P_UpdatePortal(FLinePortal *port)
 			// this is illegal. Demote the type to TELEPORT
 			port->mType = PORTT_TELEPORT;
 			port->mDefFlags &= ~PORTF_INTERACTIVE;
+			Printf(TEXTCOLOR_RED "Warning: linked portal did not have matching reverse portal. Changing line %d to teleport-portal!\n", port->mOrigin->Index());
 		}
 	}
 	else
@@ -454,6 +459,10 @@ static bool ChangePortalLine(line_t *line, int destid)
 			port->mFlags = port->mDefFlags;
 		}
 		SetRotation(portd);
+	}
+	else
+	{
+		port->mFlags = port->mDefFlags;
 	}
 	SetRotation(port);
 	return true;


### PR DESCRIPTION
- A bug exists where portals that have been deactivated with Line_PortalSetTarget cannot be reactivated, even if given a valid target. -
- Another bug exists where portals that were created in an inactive state (using a target line tag of 0) could never be activated. (Even with the above bugfix.)
- Linked portals that have been demoted to teleport portals because they do not have a return portal now emit a warning.
- Portals that are supposed to be traversable, but do not have back-sector now demote to visual portals and emit a warning, because nothing could ever possibly traverse them anyway.