### PR TITLE
Fix compile issues on Arch Linux

### DIFF
--- a/src/sound/oalsound.cpp
+++ b/src/sound/oalsound.cpp
@@ -42,6 +42,7 @@
 
 #include <memory>
 #include <chrono>
+#include <functional>
 
 #include "except.h"
 #include "doomstat.h"

--- a/wadsrc/static/compatibility.txt
+++ b/wadsrc/static/compatibility.txt
@@ -491,7 +491,6 @@ F6EE16F770AD309D608EA0B1F1E249FC // Ultimate Doom, e4m3
 110F84DE041052B59307FAF0293E6BC0 // Doom II, map27
 {
 	setsectorspecial 93 0
-	setwalltexture 582 back top ZIMMER3
 }
  
 ABC4EB5A1535ECCD0061AD14F3547908 // Plutonia Experiment, map26


### PR DESCRIPTION
1. Add #include functional

`
error: ‘mem_fn’ is not a member of ‘std’
         StreamThread = std::thread(std::mem_fn(&OpenALSoundRenderer::BackgroundProc), this);
`

2. Remove setwalltexture 582 back top ZIMMER3

`
Script error, "zdoom.pk3:compatibility.txt" line 494:
Expected '}', got 'setwalltexture'.
`