### PR TITLE
add missing include

### DIFF
--- a/src/sound/oalsound.cpp
+++ b/src/sound/oalsound.cpp
@@ -40,6 +40,7 @@
 #include <dlfcn.h>
 #endif
 
+#include <functional>
 #include <memory>
 #include <chrono>
 


### PR DESCRIPTION
`oalsound.cpp` uses `std::mem_fn` but lacks the `<functional>` include.  With gcc 8, this no longer compiles because `functional` is no longer included by other standard includes.