### PR TITLE
Adicional include

### DIFF
--- a/src/sound/oalsound.cpp
+++ b/src/sound/oalsound.cpp
@@ -61,6 +61,9 @@
 #include "tempfiles.h"
 #include "cmdlib.h"
 
+#include <iostream>
+#include <functional>
+
 FModule OpenALModule{"OpenAL"};
 
 #include "oalload.h"


### PR DESCRIPTION
With new gcc compilers these 'includes' are required to compile.